### PR TITLE
0084 VarInt 補助型を導入し RFC 9000 Section 16 の値域を型で表現する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,23 @@
 
 ## develop
 
+- [ADD] `VarInt` / `VarIntError` を新設し、RFC 9000 Section 16 の値域 (`0..=2^62 - 1`) を型で表現する
+  - @voluntas
+- [ADD] `VarInt::from_static` を `const fn` で提供し、`2^62` 以上のリテラル定数を `const` / `static` 宣言時にコンパイル時 panic として検出可能にする
+  - @voluntas
+- [ADD] `webtransport::DatagramError::SessionIdOutOfRange` を追加し、`Datagram::new` に session_id の VarInt 範囲検査を導入する
+  - @voluntas
+- [ADD] `webtransport::stream::StreamHeaderDecodeError::SessionIdOutOfRange` を追加し、`StreamHeader::new` に session_id の VarInt 範囲検査を導入する
+  - @voluntas
+- [ADD] `varint::DecodeError` / `varint::EncodeError` / `webtransport::DatagramError` / `webtransport::stream::StreamHeaderDecodeError` に `#[non_exhaustive]` を付与し、将来のバリアント追加を後方互換にする
+  - @voluntas
+- [CHANGE] `varint::encode` / `varint::encode_into_vec` / `varint::decode` のシグネチャを `VarInt` を扱う形に変更する
+  - @voluntas
+- [CHANGE] `varint::MAX_VALUE` / `varint::encoded_len(u64)` / `varint::try_encoded_len` / `varint::try_encode_into_vec` / `varint::EncodeError::ValueTooLarge` を削除する (`VarInt` 型が値域を保証するため)
+  - @voluntas
+- [CHANGE] `frame::encoded_frame_len` の戻り値型を `usize` から `Option<usize>` に変更し、`Frame::Unknown` 等の `u64` フィールドが VarInt 範囲外の場合に `None` を返すようにする
+  - @voluntas
+
 ### misc
 
 - [UPDATE] 仕様引用の節番号を一次資料 (`refs/`) に合わせてコメントを修正する

--- a/examples/wt_server/src/main.rs
+++ b/examples/wt_server/src/main.rs
@@ -201,11 +201,12 @@ async fn handle_connection(
 
             // H3 DATA フレーム: type=0x00, length=varint, payload
             buf.push(0x00);
-            let len_size = shiguredo_http3::varint::encoded_len(capsule_bytes.len() as u64);
+            let payload_len = shiguredo_http3::VarInt::new(capsule_bytes.len() as u64)
+                .expect("capsule payload length fits in VarInt");
+            let len_size = payload_len.encoded_len();
             let len_start = buf.len();
             buf.resize(len_start + len_size, 0);
-            shiguredo_http3::varint::encode(&mut buf[len_start..], capsule_bytes.len() as u64)
-                .unwrap();
+            shiguredo_http3::varint::encode(&mut buf[len_start..], payload_len).unwrap();
             buf.extend_from_slice(&capsule_bytes);
         }
 

--- a/examples/wt_server/src/webtransport.rs
+++ b/examples/wt_server/src/webtransport.rs
@@ -183,6 +183,7 @@ impl WtSessionRequest {
                 // ストリームタイプを判定する
                 let (stream_type, _) = shiguredo_http3::varint::decode(&buf)
                     .map_err(|_| Error::InvalidState("stream type decode error".into()))?;
+                let stream_type = stream_type.get();
 
                 tracing::info!("WebTransport: uni stream {} type: 0x{:x}", sid, stream_type);
 
@@ -942,6 +943,7 @@ fn parse_settings_from_control(buf: &[u8]) -> std::result::Result<H3Settings, Se
     // ストリームタイプバイト (0x00) をスキップする
     let (stream_type, type_len) =
         shiguredo_http3::varint::decode(buf).map_err(|_| SettingsParseState::NeedMoreData)?;
+    let stream_type = stream_type.get();
     if stream_type != 0x00 {
         return Err(SettingsParseState::Error(format!(
             "expected control stream type 0x00, got {stream_type:#x}"
@@ -952,6 +954,7 @@ fn parse_settings_from_control(buf: &[u8]) -> std::result::Result<H3Settings, Se
     // フレームタイプを読む
     let (frame_type, ft_len) =
         shiguredo_http3::varint::decode(rest).map_err(|_| SettingsParseState::NeedMoreData)?;
+    let frame_type = frame_type.get();
     if frame_type != 0x04 {
         return Err(SettingsParseState::Error(format!(
             "expected SETTINGS frame type 0x04, got {frame_type:#x}"
@@ -961,6 +964,7 @@ fn parse_settings_from_control(buf: &[u8]) -> std::result::Result<H3Settings, Se
     // フレーム長を読む
     let (payload_len, pl_len) = shiguredo_http3::varint::decode(&rest[ft_len..])
         .map_err(|_| SettingsParseState::NeedMoreData)?;
+    let payload_len = payload_len.get();
     let payload_start = ft_len + pl_len;
     let payload_end = payload_start + payload_len as usize;
     if rest.len() < payload_end {
@@ -983,6 +987,8 @@ fn parse_settings_from_control(buf: &[u8]) -> std::result::Result<H3Settings, Se
         let (value, value_len) = shiguredo_http3::varint::decode(&payload_buf[pos..])
             .map_err(|_| SettingsParseState::Error("settings value decode error".into()))?;
         pos += value_len;
+        let id = id.get();
+        let value = value.get();
         tracing::info!("WebTransport: client SETTINGS entry: id=0x{id:x}, value={value}");
         payload.add(id, value);
     }

--- a/interop/wt/src/lib.rs
+++ b/interop/wt/src/lib.rs
@@ -62,15 +62,20 @@ pub fn cleanup_certificate_files(cert_path: &PathBuf, key_path: &PathBuf) {
 }
 
 /// QUIC 可変長整数をエンコードする (RFC 9000 Section 16)
+///
+/// `value` が VarInt 範囲 (`0..=2^62 - 1`) を超える場合は panic する。
 pub fn encode_varint(value: u64) -> Vec<u8> {
     let mut buf = Vec::new();
-    shiguredo_http3::varint::encode_into_vec(&mut buf, value);
+    let v = shiguredo_http3::VarInt::new(value).expect("interop varint value fits in VarInt");
+    shiguredo_http3::varint::encode_into_vec(&mut buf, v);
     buf
 }
 
 /// QUIC 可変長整数をデコードする (RFC 9000 Section 16)
 pub fn decode_varint(data: &[u8]) -> Option<(u64, usize)> {
-    shiguredo_http3::varint::decode(data).ok()
+    shiguredo_http3::varint::decode(data)
+        .ok()
+        .map(|(v, n)| (v.get(), n))
 }
 
 /// WebTransport 双方向ストリームヘッダーをエンコードする

--- a/issues/closed/0084-add-varint-constructor-type.md
+++ b/issues/closed/0084-add-varint-constructor-type.md
@@ -1,6 +1,8 @@
 # 0084: VarInt 補助型を導入し RFC 9000 §16 の値域を型で表現する
 
 Created: 2026-05-23
+Completed: 2026-05-23
+Branch: feature/add-varint-type
 Model: Opus 4.7
 
 ## 概要
@@ -395,3 +397,42 @@ pub enum DecodeError {
 - [[0086-change-settings-construct-time-validation]] (Settings 値型に VarInt を適用)
 - [[0087-change-frame-construct-time-validation]] (Frame ペイロードに VarInt を適用)
 - [[0088-add-trybuild-and-pbt-construct-time-validation]] (`from_static` の compile_fail テスト)
+
+## 解決方法
+
+`src/varint.rs` を新 API に書き換え、`VarInt` 構造体 / `VarIntError` を導入。`src/lib.rs` から `pub use varint::{VarInt, VarIntError}` を公開。
+
+### 主な変更点
+
+- `VarInt` 構造体: 値域 `0..=2^62 - 1` を型で表現。
+- `VarInt::new` (`const fn`) / `VarInt::from_static` (`const fn` + `#[track_caller]`)。
+- `VarInt::encoded_len` / `VarInt::MAX` / `VarInt::ZERO` / `Display` / `From<u8/u16/u32>` / `TryFrom<u64/usize>`。
+- `pub(crate) const fn from_validated_parts`: `decode` 経路のみで使用。
+- `varint::encode` / `encode_into_vec` / `decode` のシグネチャを `VarInt` 受け取り / 返却に変更。
+- `varint::MAX_VALUE` / `encoded_len(u64)` / `try_encoded_len` / `try_encode_into_vec` / `EncodeError::ValueTooLarge` を削除。
+- `varint::DecodeError` / `EncodeError` に `#[non_exhaustive]` を付与。
+- `frame::encoded_frame_len` の戻り値を `usize` から `Option<usize>` に変更し、嘘の長さを返さないように修正。`encoded_varint_len` の沈黙フォールバックを廃止。`goaway_id_encoded_len` ヘルパーは削除。
+- `Frame::Unknown` 等で frame_type が VarInt 範囲外なら `encode_frame_header` / `encode_frame` / `encoded_frame_len` 全てが `None` を返すよう統一。
+- `frame::FrameHeader` / `Frame::Goaway.id` / `Frame::MaxPushId` 等の `u64` フィールドは本 issue では維持し、後続 issue 0087 で `VarInt` 化する方針を確認。
+- WebTransport stream の `UNIDIRECTIONAL_STREAM_TYPE` / `BIDIRECTIONAL_SIGNAL_VALUE` を `const VarInt`（`from_static`）でラップ。
+- `Datagram::new` に session_id の VarInt 範囲検査を追加し、`DatagramError::SessionIdOutOfRange` を追加 (`#[non_exhaustive]` 付与)。
+- `StreamHeader::new` にも同様の検査と `StreamHeaderDecodeError::SessionIdOutOfRange` を追加 (`#[non_exhaustive]` 付与)。
+- `stream::control::send_goaway` で id の VarInt 範囲検査を追加し、範囲外時は `ErrorCode::InternalError` で返す。
+- `send_settings` / `send_encoded_headers` / `send_body` / `send_goaway` で `encode_frame` の戻り値を `expect` で受け、`debug_assert_eq!` で長さ整合を保証。
+- `webtransport::capsule` モジュールヘッダーに `# Panics` 節を追加し、後続 issue で構造的に解消する旨を明記。
+
+### テスト
+
+- `src/varint.rs` の `#[cfg(test)] mod tests` には PBT で代替できない単体テスト (const 文脈の正常系・`from_validated_parts` 境界・エラー文面の RFC 引用検査・64bit ガード付き `TryFrom<usize>` 拒否) のみ残し、ラウンドトリップ・境界値・`From` のパターンは `pbt/tests/prop_varint.rs` に統合。
+- PBT に `prop_encode_succeeds_for_any_varint` / `prop_short_buffer_returns_buffer_too_short` / `prop_display_matches_u64` / `prop_from_u8_roundtrip` / `prop_from_u16_roundtrip` / `prop_from_u32_roundtrip` / `prop_try_from_u64_value_domain` を追加。
+- `src/frame/encoder.rs` に `Frame::Unknown` 範囲外時の `encoded_frame_len` / `encode_frame` が `None` を返すユニットテストを追加。
+- `src/webtransport/datagram.rs` / `src/webtransport/stream.rs` に `SessionIdOutOfRange` の単体テストを追加。
+
+### 影響範囲追従
+
+- `src/connection/mod.rs` / `src/frame/{decoder,encoder}.rs` / `src/webtransport/{datagram,capsule,stream}.rs` / `src/stream/{control,request}.rs` / `pbt/tests/prop_{varint,frame,datagram,webtransport}.rs` / `examples/wt_server/src/{main,webtransport}.rs` / `interop/wt/src/lib.rs` / `tests/test_webtransport_draft_connect.rs` を新 API に追従。
+- `fuzz/fuzz_targets/fuzz_varint.rs` は戻り値を `_` で破棄しているため変更不要。
+
+### CHANGES.md
+
+`## develop` セクションに ADD x4 / CHANGE x3 のエントリを追加。

--- a/pbt/tests/prop_datagram.rs
+++ b/pbt/tests/prop_datagram.rs
@@ -2,10 +2,8 @@
 //! (RFC 9297, draft-ietf-webtrans-http3-15 Section 4.5)
 
 use proptest::prelude::*;
+use shiguredo_http3::VarInt;
 use shiguredo_http3::webtransport::Datagram;
-
-/// 可変長整数の最大値
-const MAX_VARINT: u64 = (1 << 62) - 1;
 
 // =============================================================================
 // Strategy ヘルパー
@@ -116,12 +114,15 @@ proptest! {
     ///           decode の結果の session_id は 4 の倍数
     #[test]
     fn prop_arbitrary_qsi_decodes_to_multiple_of_4(
-        qsi in 0u64..=(MAX_VARINT / 4),
+        qsi in 0u64..=(VarInt::MAX.get() / 4),
         payload in valid_payload(),
     ) {
         // Quarter Stream ID を直接エンコードする
         let mut buf = Vec::new();
-        shiguredo_http3::varint::encode_into_vec(&mut buf, qsi);
+        shiguredo_http3::varint::encode_into_vec(
+            &mut buf,
+            shiguredo_http3::VarInt::new(qsi).unwrap(),
+        );
         buf.extend_from_slice(&payload);
 
         let (decoded, consumed) = Datagram::decode(&buf)

--- a/pbt/tests/prop_frame.rs
+++ b/pbt/tests/prop_frame.rs
@@ -123,7 +123,7 @@ proptest! {
             data: payload.clone(),
         });
 
-        let mut buf = vec![0u8; encoded_frame_len(&frame)];
+        let mut buf = vec![0u8; encoded_frame_len(&frame).unwrap()];
         let encoded_len = encode_frame(&mut buf, &frame).unwrap();
 
         let (decoded, decoded_len) = decode_frame(&buf[..encoded_len]).unwrap();
@@ -147,11 +147,18 @@ proptest! {
             data: payload.clone(),
         });
 
-        let expected_len = shiguredo_http3::varint::encoded_len(FrameType::Data as u64)
-            + shiguredo_http3::varint::encoded_len(payload.len() as u64)
+        // FrameType::Data は 0x00 (1 バイト VarInt) で構築不能ではないため、
+        // ランタイム値の `VarInt::new` を使って整合性を取る (const 文脈ではないので
+        // `from_static` は使わない)。
+        let expected_len = shiguredo_http3::VarInt::new(FrameType::Data as u64)
+            .unwrap()
+            .encoded_len()
+            + shiguredo_http3::VarInt::new(payload.len() as u64)
+                .unwrap()
+                .encoded_len()
             + payload.len();
 
-        let actual_len = encoded_frame_len(&frame);
+        let actual_len = encoded_frame_len(&frame).unwrap();
 
         prop_assert_eq!(
             actual_len, expected_len,
@@ -172,7 +179,7 @@ proptest! {
             encoded_field_section: encoded_block.clone(),
         });
 
-        let mut buf = vec![0u8; encoded_frame_len(&frame)];
+        let mut buf = vec![0u8; encoded_frame_len(&frame).unwrap()];
         let encoded_len = encode_frame(&mut buf, &frame).unwrap();
 
         let (decoded, decoded_len) = decode_frame(&buf[..encoded_len]).unwrap();
@@ -204,7 +211,7 @@ proptest! {
         }
         let frame = Frame::Settings(payload);
 
-        let mut buf = vec![0u8; encoded_frame_len(&frame)];
+        let mut buf = vec![0u8; encoded_frame_len(&frame).unwrap()];
         let encoded_len = encode_frame(&mut buf, &frame).unwrap();
 
         let (decoded, decoded_len) = decode_frame(&buf[..encoded_len]).unwrap();
@@ -229,7 +236,7 @@ proptest! {
     fn prop_empty_settings_frame_valid(_dummy in Just(())) {
         let frame = Frame::Settings(SettingsPayload::new());
 
-        let mut buf = vec![0u8; encoded_frame_len(&frame)];
+        let mut buf = vec![0u8; encoded_frame_len(&frame).unwrap()];
         let encoded_len = encode_frame(&mut buf, &frame).unwrap();
 
         let (decoded, decoded_len) = decode_frame(&buf[..encoded_len]).unwrap();
@@ -254,7 +261,7 @@ proptest! {
     fn prop_goaway_frame_roundtrip(id in valid_goaway_id()) {
         let frame = Frame::Goaway(GoawayPayload { id });
 
-        let mut buf = vec![0u8; encoded_frame_len(&frame)];
+        let mut buf = vec![0u8; encoded_frame_len(&frame).unwrap()];
         let encoded_len = encode_frame(&mut buf, &frame).unwrap();
 
         let (decoded, decoded_len) = decode_frame(&buf[..encoded_len]).unwrap();
@@ -288,7 +295,7 @@ proptest! {
             payload: payload.clone(),
         };
 
-        let mut buf = vec![0u8; encoded_frame_len(&frame)];
+        let mut buf = vec![0u8; encoded_frame_len(&frame).unwrap()];
         let encoded_len = encode_frame(&mut buf, &frame).unwrap();
 
         let (decoded, decoded_len) = decode_frame(&buf[..encoded_len]).unwrap();
@@ -314,7 +321,7 @@ proptest! {
     fn prop_encoded_frame_len_accurate(payload in valid_payload()) {
         let frame = Frame::Data(DataPayload { data: payload });
 
-        let predicted_len = encoded_frame_len(&frame);
+        let predicted_len = encoded_frame_len(&frame).unwrap();
         let mut buf = vec![0u8; predicted_len + 100]; // 余裕を持たせる
         let actual_len = encode_frame(&mut buf, &frame).unwrap();
 

--- a/pbt/tests/prop_varint.rs
+++ b/pbt/tests/prop_varint.rs
@@ -1,43 +1,41 @@
 //! Property-Based Testing for QUIC Variable-Length Integer (RFC 9000 Section 16)
 
 use proptest::prelude::*;
+use shiguredo_http3::VarInt;
 use shiguredo_http3::varint;
 
-/// 可変長整数の最大値
-const MAX_VARINT: u64 = (1 << 62) - 1;
-
 prop_compose! {
-    /// 有効な可変長整数値を生成
-    fn valid_varint()(value in 0u64..=MAX_VARINT) -> u64 {
-        value
+    /// 有効な VarInt を生成
+    fn valid_varint()(value in 0u64..=VarInt::MAX.get()) -> VarInt {
+        VarInt::new(value).unwrap()
     }
 }
 
 prop_compose! {
     /// 1 バイトエンコード範囲の値を生成 (0-63)
-    fn one_byte_value()(value in 0u64..64) -> u64 {
-        value
+    fn one_byte_value()(value in 0u64..64) -> VarInt {
+        VarInt::new(value).unwrap()
     }
 }
 
 prop_compose! {
     /// 2 バイトエンコード範囲の値を生成 (64-16383)
-    fn two_byte_value()(value in 64u64..16384) -> u64 {
-        value
+    fn two_byte_value()(value in 64u64..16384) -> VarInt {
+        VarInt::new(value).unwrap()
     }
 }
 
 prop_compose! {
     /// 4 バイトエンコード範囲の値を生成 (16384-1073741823)
-    fn four_byte_value()(value in 16384u64..1073741824) -> u64 {
-        value
+    fn four_byte_value()(value in 16384u64..1073741824) -> VarInt {
+        VarInt::new(value).unwrap()
     }
 }
 
 prop_compose! {
     /// 8 バイトエンコード範囲の値を生成 (1073741824-MAX)
-    fn eight_byte_value()(value in 1073741824u64..=MAX_VARINT) -> u64 {
-        value
+    fn eight_byte_value()(value in 1073741824u64..=VarInt::MAX.get()) -> VarInt {
+        VarInt::new(value).unwrap()
     }
 }
 
@@ -53,20 +51,43 @@ proptest! {
         prop_assert_eq!(encoded_len, decoded_len, "Length mismatch for value {}", value);
     }
 
-    /// Property: encoded_len() が実際のエンコード長と一致する
+    /// Property: VarInt::encoded_len() が実際のエンコード長と一致する
     #[test]
     fn prop_encoded_len_matches_actual(value in valid_varint()) {
-        let expected_len = varint::encoded_len(value);
+        let expected_len = value.encoded_len();
         let mut buf = [0u8; 8];
         let actual_len = varint::encode(&mut buf, value).unwrap();
 
         prop_assert_eq!(expected_len, actual_len, "encoded_len mismatch for {}", value);
     }
 
+    /// Property: 任意 VarInt は `encoded_len()` 分のバッファで必ずエンコードできる
+    /// (`EncodeError::ValueTooLarge` を削除した正当性: 値域は型レベルで保証される)
+    #[test]
+    fn prop_encode_succeeds_for_any_varint(value in valid_varint()) {
+        let mut buf = vec![0u8; value.encoded_len()];
+        let result = varint::encode(&mut buf, value);
+        prop_assert!(result.is_ok(), "encode should succeed for any VarInt");
+    }
+
+    /// Property: バッファ長が `encoded_len()` 未満なら必ず `BufferTooShort` を返す
+    #[test]
+    fn prop_short_buffer_returns_buffer_too_short(
+        value in valid_varint(),
+        shortfall in 1usize..=8,
+    ) {
+        let need = value.encoded_len();
+        // shortfall 分だけ短いバッファ (need == 1 の場合は 0 バイトバッファ)
+        let len = need.saturating_sub(shortfall);
+        let mut buf = vec![0u8; len];
+        let result = varint::encode(&mut buf, value);
+        prop_assert_eq!(result, Err(varint::EncodeError::BufferTooShort));
+    }
+
     /// Property: 1 バイト値は 1 バイトでエンコードされる
     #[test]
     fn prop_one_byte_encoding(value in one_byte_value()) {
-        let len = varint::encoded_len(value);
+        let len = value.encoded_len();
         prop_assert_eq!(len, 1, "Value {} should encode to 1 byte", value);
 
         let mut buf = [0u8; 8];
@@ -78,7 +99,7 @@ proptest! {
     /// Property: 2 バイト値は 2 バイトでエンコードされる
     #[test]
     fn prop_two_byte_encoding(value in two_byte_value()) {
-        let len = varint::encoded_len(value);
+        let len = value.encoded_len();
         prop_assert_eq!(len, 2, "Value {} should encode to 2 bytes", value);
 
         let mut buf = [0u8; 8];
@@ -90,7 +111,7 @@ proptest! {
     /// Property: 4 バイト値は 4 バイトでエンコードされる
     #[test]
     fn prop_four_byte_encoding(value in four_byte_value()) {
-        let len = varint::encoded_len(value);
+        let len = value.encoded_len();
         prop_assert_eq!(len, 4, "Value {} should encode to 4 bytes", value);
 
         let mut buf = [0u8; 8];
@@ -102,7 +123,7 @@ proptest! {
     /// Property: 8 バイト値は 8 バイトでエンコードされる
     #[test]
     fn prop_eight_byte_encoding(value in eight_byte_value()) {
-        let len = varint::encoded_len(value);
+        let len = value.encoded_len();
         prop_assert_eq!(len, 8, "Value {} should encode to 8 bytes", value);
 
         let mut buf = [0u8; 8];
@@ -121,14 +142,6 @@ proptest! {
         prop_assert_eq!(encoded_len, peeked_len, "peek_len mismatch for {}", value);
     }
 
-    /// Property: バッファサイズが不足している場合はエラー
-    #[test]
-    fn prop_insufficient_buffer_returns_error(value in two_byte_value()) {
-        let mut buf = [0u8; 1]; // 2 バイト値には不十分
-        let result = varint::encode(&mut buf, value);
-        prop_assert!(result.is_err(), "Should fail for insufficient buffer");
-    }
-
     /// Property: エンコード結果はビッグエンディアン順
     #[test]
     fn prop_encoding_is_big_endian(value in two_byte_value()) {
@@ -136,25 +149,50 @@ proptest! {
         varint::encode(&mut buf, value).unwrap();
 
         // 2 バイトエンコードの場合、値は 0x4000 | value として格納
-        let expected_high = (0x40 | ((value >> 8) & 0x3f)) as u8;
-        let expected_low = (value & 0xff) as u8;
+        let raw = value.get();
+        let expected_high = (0x40 | ((raw >> 8) & 0x3f)) as u8;
+        let expected_low = (raw & 0xff) as u8;
 
         prop_assert_eq!(buf[0], expected_high, "High byte mismatch");
         prop_assert_eq!(buf[1], expected_low, "Low byte mismatch");
     }
-}
 
-/// Property: MAX_VALUE を超える値はエンコードできない
-#[test]
-fn prop_value_exceeding_max_fails() {
-    let mut buf = [0u8; 8];
-    let result = varint::encode(&mut buf, MAX_VARINT + 1);
-    assert!(result.is_err());
-}
+    /// Property: `From<u8>` は任意 u8 で値が一致する
+    #[test]
+    fn prop_from_u8_roundtrip(value in any::<u8>()) {
+        let v = VarInt::from(value);
+        prop_assert_eq!(v.get(), u64::from(value));
+    }
 
-/// Property: 空バッファのデコードはエラー
-#[test]
-fn prop_empty_buffer_decode_fails() {
-    let result = varint::decode(&[]);
-    assert!(result.is_err());
+    /// Property: `From<u16>` は任意 u16 で値が一致する
+    #[test]
+    fn prop_from_u16_roundtrip(value in any::<u16>()) {
+        let v = VarInt::from(value);
+        prop_assert_eq!(v.get(), u64::from(value));
+    }
+
+    /// Property: `From<u32>` は任意 u32 で値が一致する
+    #[test]
+    fn prop_from_u32_roundtrip(value in any::<u32>()) {
+        let v = VarInt::from(value);
+        prop_assert_eq!(v.get(), u64::from(value));
+    }
+
+    /// Property: `TryFrom<u64>` は値域内で必ず Ok、値域外で必ず Err
+    #[test]
+    fn prop_try_from_u64_value_domain(value in any::<u64>()) {
+        let result = VarInt::try_from(value);
+        if value <= VarInt::MAX.get() {
+            prop_assert!(result.is_ok());
+            prop_assert_eq!(result.unwrap().get(), value);
+        } else {
+            prop_assert!(result.is_err());
+        }
+    }
+
+    /// Property: `VarInt::Display` 出力は内部値の 10 進表現と一致する
+    #[test]
+    fn prop_display_matches_u64(value in valid_varint()) {
+        prop_assert_eq!(format!("{value}"), format!("{}", value.get()));
+    }
 }

--- a/pbt/tests/prop_webtransport.rs
+++ b/pbt/tests/prop_webtransport.rs
@@ -768,7 +768,10 @@ prop_compose! {
 
 /// 可変長整数をエンコード
 fn encode_varint_for_test(buf: &mut Vec<u8>, value: u64) {
-    shiguredo_http3::varint::encode_into_vec(buf, value);
+    shiguredo_http3::varint::encode_into_vec(
+        buf,
+        shiguredo_http3::VarInt::new(value).expect("value fits in VarInt"),
+    );
 }
 
 proptest! {

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -1302,7 +1302,7 @@ impl Connection {
 
         let remaining = &type_data[type_len..];
 
-        match stream_type {
+        match stream_type.get() {
             0x00 => {
                 // Control Stream
                 if self.control_recv.stream_id().is_some() {
@@ -1432,6 +1432,7 @@ impl Connection {
 
         match crate::varint::decode(&buf) {
             Ok((session_id, id_len)) => {
+                let session_id = session_id.get();
                 // session_id は client-initiated bidirectional stream ID でなければならない
                 // (draft-ietf-webtrans-http3-15 Section 4.2)
                 // RFC 9000 Section 2.1: client-initiated bidi は stream_id % 4 == 0
@@ -1586,7 +1587,7 @@ impl Connection {
         match crate::varint::decode(&buf) {
             Ok((value, _)) => {
                 self.pending_bidi_dispatch.remove(&stream_id);
-                if value == crate::webtransport::stream::BIDIRECTIONAL_SIGNAL_VALUE {
+                if value.get() == crate::webtransport::stream::BIDIRECTIONAL_SIGNAL_VALUE {
                     // WT_STREAM (0x41): WT bidi ストリームとして処理
                     self.handle_wt_bidi_stream(stream_id, &buf, fin)?;
                 } else {
@@ -2049,15 +2050,20 @@ impl Connection {
     /// 0 を返す (CONNECT stream や非 WT ストリーム)。将来のドラフトで stream
     /// header フォーマットが変更される可能性がある。
     pub fn wt_stream_header_len(&self, stream_id: u64) -> u64 {
-        use crate::varint;
+        use crate::varint::VarInt;
         use crate::webtransport::stream::{BIDIRECTIONAL_SIGNAL_VALUE, UNIDIRECTIONAL_STREAM_TYPE};
+        // signal value / stream type は WebTransport プロトコルの定数なので const 文脈で
+        // VarInt 構築できる (`from_static` でコンパイル時検査)。
+        const BIDI_SIGNAL: VarInt = VarInt::from_static(BIDIRECTIONAL_SIGNAL_VALUE);
+        const UNI_TYPE: VarInt = VarInt::from_static(UNIDIRECTIONAL_STREAM_TYPE);
         if let Some(&session_id) = self.wt_bidi_streams.get(&stream_id) {
-            return (varint::encoded_len(BIDIRECTIONAL_SIGNAL_VALUE)
-                + varint::encoded_len(session_id)) as u64;
+            // session_id は QUIC ストリーム ID 空間 (`<= 2^62 - 1`) で構造的に保証される。
+            let session_id = VarInt::new(session_id).expect("session_id fits in VarInt");
+            return (BIDI_SIGNAL.encoded_len() + session_id.encoded_len()) as u64;
         }
         if let Some(&session_id) = self.wt_uni_streams.get(&stream_id) {
-            return (varint::encoded_len(UNIDIRECTIONAL_STREAM_TYPE)
-                + varint::encoded_len(session_id)) as u64;
+            let session_id = VarInt::new(session_id).expect("session_id fits in VarInt");
+            return (UNI_TYPE.encoded_len() + session_id.encoded_len()) as u64;
         }
         0
     }
@@ -2212,7 +2218,7 @@ impl Connection {
 
         // signal value は 0x41 (WT_STREAM) でなければならない
         // (draft-ietf-webtrans-http3-15 Section 4.3)
-        if signal_value != 0x41 {
+        if signal_value.get() != 0x41 {
             // 0x41 以外の signal value はリクエストストリームの先頭以外での WT_STREAM 受信、
             // または不正な signal value。H3_FRAME_ERROR として接続エラー。
             return Err(Error::ConnectionError(ErrorCode::FrameError));
@@ -2222,6 +2228,7 @@ impl Connection {
         let remaining = &buf[signal_len..];
         match crate::varint::decode(remaining) {
             Ok((session_id, id_len)) => {
+                let session_id = session_id.get();
                 // session_id は client-initiated bidirectional stream ID でなければならない
                 // (draft-ietf-webtrans-http3-15 Section 4.2)
                 if session_id & 0x03 != 0x00 {
@@ -4872,8 +4879,11 @@ mod tests {
 
         // HEADERS フレーム: type=0x01, length=varint, payload=QPACK エンコード済み
         let mut frame = Vec::new();
-        crate::varint::encode_into_vec(&mut frame, 0x01); // HEADERS frame type
-        crate::varint::encode_into_vec(&mut frame, qpack_len as u64);
+        crate::varint::encode_into_vec(&mut frame, crate::VarInt::from_static(0x01)); // HEADERS frame type
+        crate::varint::encode_into_vec(
+            &mut frame,
+            crate::VarInt::new(qpack_len as u64).expect("qpack_len fits in VarInt"),
+        );
         frame.extend_from_slice(&qpack_buf);
         frame
     }
@@ -5396,7 +5406,10 @@ mod tests {
             let stream_id = 10 + (i as u64) * 4;
             // ストリームタイプ 0x54 + session_id varint
             let mut buf = vec![0x40, 0x54];
-            crate::varint::encode_into_vec(&mut buf, session_id);
+            crate::varint::encode_into_vec(
+                &mut buf,
+                crate::VarInt::new(session_id).expect("session_id fits in VarInt"),
+            );
             server.feed_stream(stream_id, &buf, false).unwrap();
         }
         assert_eq!(server.count_pending_wt_sessions(), WT_MAX_PENDING_SESSIONS);
@@ -5405,7 +5418,10 @@ mod tests {
         let overflow_session_id = ((WT_MAX_PENDING_SESSIONS + 1) * 4) as u64;
         let overflow_stream_id = 10 + (WT_MAX_PENDING_SESSIONS as u64) * 4;
         let mut buf = vec![0x40, 0x54];
-        crate::varint::encode_into_vec(&mut buf, overflow_session_id);
+        crate::varint::encode_into_vec(
+            &mut buf,
+            crate::VarInt::new(overflow_session_id).expect("overflow_session_id fits in VarInt"),
+        );
         server.feed_stream(overflow_stream_id, &buf, false).unwrap();
 
         // 最終イベントが BufferedStreamRejected であること
@@ -5432,7 +5448,10 @@ mod tests {
             let session_id = ((i + 1) * 4) as u64;
             let qsi = session_id / 4;
             let mut buf = Vec::new();
-            crate::varint::encode_into_vec(&mut buf, qsi);
+            crate::varint::encode_into_vec(
+                &mut buf,
+                crate::VarInt::new(qsi).expect("qsi fits in VarInt"),
+            );
             buf.extend_from_slice(b"x");
             server.feed_datagram(&buf).unwrap();
         }
@@ -5441,7 +5460,10 @@ mod tests {
         // 上限超過の datagram は破棄され、Pending セッション数は増えない
         let overflow_session_id = ((WT_MAX_PENDING_SESSIONS + 1) * 4) as u64;
         let mut buf = Vec::new();
-        crate::varint::encode_into_vec(&mut buf, overflow_session_id / 4);
+        crate::varint::encode_into_vec(
+            &mut buf,
+            crate::VarInt::new(overflow_session_id / 4).expect("quarter session id fits in VarInt"),
+        );
         buf.extend_from_slice(b"x");
         server.feed_datagram(&buf).unwrap();
         assert_eq!(server.count_pending_wt_sessions(), WT_MAX_PENDING_SESSIONS);

--- a/src/frame/decoder.rs
+++ b/src/frame/decoder.rs
@@ -43,13 +43,13 @@ pub fn decode_frame_header(buf: &[u8]) -> Result<FrameHeader, FrameDecodeError> 
         varint::decode(&buf[type_len..]).map_err(|_| FrameDecodeError::BufferTooShort)?;
 
     // HTTP/2 専用フレームのチェック
-    if FrameType::is_http2_only(frame_type) {
-        return Err(FrameDecodeError::Http2Frame(frame_type));
+    if FrameType::is_http2_only(frame_type.get()) {
+        return Err(FrameDecodeError::Http2Frame(frame_type.get()));
     }
 
     Ok(FrameHeader {
-        frame_type,
-        payload_len,
+        frame_type: frame_type.get(),
+        payload_len: payload_len.get(),
         header_len: type_len + len_len,
     })
 }
@@ -118,17 +118,20 @@ fn decode_settings_frame(payload: &[u8]) -> Result<Frame, FrameDecodeError> {
             varint::decode(&payload[offset..]).map_err(|_| FrameDecodeError::InvalidLength)?;
         offset += value_len;
 
+        let id_raw = id.get();
+        let value_raw = value.get();
+
         // HTTP/2 専用設定のチェック (RFC 9114 Section 7.2.4)
-        if SettingsId::is_http2_only(id) {
-            return Err(FrameDecodeError::InvalidSettingsId(id));
+        if SettingsId::is_http2_only(id_raw) {
+            return Err(FrameDecodeError::InvalidSettingsId(id_raw));
         }
 
         // 同一フレーム内の重複 ID チェック (RFC 9114 Section 7.2.4)
-        if !seen_ids.insert(id) {
-            return Err(FrameDecodeError::InvalidSettingsId(id));
+        if !seen_ids.insert(id_raw) {
+            return Err(FrameDecodeError::InvalidSettingsId(id_raw));
         }
 
-        settings.add(id, value);
+        settings.add(id_raw, value_raw);
     }
 
     Ok(Frame::Settings(settings))
@@ -140,7 +143,7 @@ fn decode_goaway_frame(payload: &[u8]) -> Result<Frame, FrameDecodeError> {
     if consumed != payload.len() {
         return Err(FrameDecodeError::InvalidLength);
     }
-    Ok(Frame::Goaway(GoawayPayload::new(id)))
+    Ok(Frame::Goaway(GoawayPayload::new(id.get())))
 }
 
 fn decode_max_push_id_frame(payload: &[u8]) -> Result<Frame, FrameDecodeError> {
@@ -149,7 +152,7 @@ fn decode_max_push_id_frame(payload: &[u8]) -> Result<Frame, FrameDecodeError> {
     if consumed != payload.len() {
         return Err(FrameDecodeError::InvalidLength);
     }
-    Ok(Frame::MaxPushId(id))
+    Ok(Frame::MaxPushId(id.get()))
 }
 
 #[cfg(test)]

--- a/src/frame/encoder.rs
+++ b/src/frame/encoder.rs
@@ -1,17 +1,19 @@
 //! HTTP/3 フレームエンコーダー
 
-use crate::varint;
+use crate::varint::{self, VarInt};
 
 use super::{DataPayload, Frame, FrameType, GoawayPayload, HeadersPayload, SettingsPayload};
 
 /// フレームヘッダーをエンコードする
 ///
-/// 成功時はエンコードしたバイト数を返す
+/// 成功時はエンコードしたバイト数を返す。
+/// `frame_type` または `payload_len` が VarInt 範囲 (RFC 9000 Section 16) を
+/// 超える場合は `None` を返す。
 pub fn encode_frame_header(buf: &mut [u8], frame_type: u64, payload_len: u64) -> Option<usize> {
-    let type_len = varint::encoded_len(frame_type);
-    let len_len = varint::encoded_len(payload_len);
-    let total = type_len + len_len;
+    let frame_type = VarInt::new(frame_type).ok()?;
+    let payload_len = VarInt::new(payload_len).ok()?;
 
+    let total = frame_type.encoded_len() + payload_len.encoded_len();
     if buf.len() < total {
         return None;
     }
@@ -23,41 +25,55 @@ pub fn encode_frame_header(buf: &mut [u8], frame_type: u64, payload_len: u64) ->
     Some(offset)
 }
 
-/// フレームをエンコードするのに必要なバイト数を計算
-pub fn encoded_frame_len(frame: &Frame) -> usize {
+/// フレームをエンコードするのに必要なバイト数を計算する
+///
+/// `Frame::Unknown` / `Frame::Goaway` / `Frame::MaxPushId` 等で
+/// `u64` フィールドが VarInt 範囲を超える場合は `None` を返す。
+/// 呼び出し側は本値を根拠にバッファを確保するため、嘘の長さを返さない。
+pub fn encoded_frame_len(frame: &Frame) -> Option<usize> {
     let (frame_type, payload_len) = match frame {
         Frame::Data(p) => (FrameType::Data as u64, p.data.len() as u64),
         Frame::Headers(p) => (
             FrameType::Headers as u64,
             p.encoded_field_section.len() as u64,
         ),
-        Frame::Settings(p) => (FrameType::Settings as u64, encoded_settings_payload_len(p)),
-        Frame::Goaway(p) => (FrameType::Goaway as u64, varint::encoded_len(p.id) as u64),
-        Frame::MaxPushId(id) => (FrameType::MaxPushId as u64, varint::encoded_len(*id) as u64),
+        Frame::Settings(p) => (FrameType::Settings as u64, encoded_settings_payload_len(p)?),
+        Frame::Goaway(p) => (FrameType::Goaway as u64, encoded_varint_len(p.id)? as u64),
+        Frame::MaxPushId(id) => (FrameType::MaxPushId as u64, encoded_varint_len(*id)? as u64),
         Frame::Unknown {
             frame_type,
             payload,
         } => (*frame_type, payload.len() as u64),
     };
 
-    let header_len = varint::encoded_len(frame_type) + varint::encoded_len(payload_len);
-    header_len + payload_len as usize
+    let header_len = encoded_varint_len(frame_type)? + encoded_varint_len(payload_len)?;
+    Some(header_len + payload_len as usize)
+}
+
+/// `u64` を VarInt とみなしたエンコード長を返す
+///
+/// 値が VarInt 範囲外の場合は `None` を返し、呼び出し側で短絡する。
+fn encoded_varint_len(value: u64) -> Option<usize> {
+    VarInt::new(value).ok().map(|v| v.encoded_len())
 }
 
 /// SETTINGS ペイロードのエンコード長を計算
-fn encoded_settings_payload_len(payload: &SettingsPayload) -> u64 {
-    payload
-        .entries
-        .iter()
-        .map(|(id, value)| varint::encoded_len(*id) + varint::encoded_len(*value))
-        .sum::<usize>() as u64
+fn encoded_settings_payload_len(payload: &SettingsPayload) -> Option<u64> {
+    let mut total: usize = 0;
+    for (id, value) in &payload.entries {
+        total = total.checked_add(encoded_varint_len(*id)?)?;
+        total = total.checked_add(encoded_varint_len(*value)?)?;
+    }
+    Some(total as u64)
 }
 
 /// フレームをエンコードする
 ///
-/// 成功時はエンコードしたバイト数を返す
+/// 成功時はエンコードしたバイト数を返す。
+/// バッファ不足、または `Frame::Unknown` 等の `u64` フィールドが VarInt 範囲外の場合は
+/// `None` を返す。
 pub fn encode_frame(buf: &mut [u8], frame: &Frame) -> Option<usize> {
-    let required = encoded_frame_len(frame);
+    let required = encoded_frame_len(frame)?;
     if buf.len() < required {
         return None;
     }
@@ -100,13 +116,15 @@ fn encode_headers_frame(buf: &mut [u8], payload: &HeadersPayload) -> Option<usiz
 
 fn encode_settings_frame(buf: &mut [u8], payload: &SettingsPayload) -> Option<usize> {
     let frame_type = FrameType::Settings as u64;
-    let payload_len = encoded_settings_payload_len(payload);
+    let payload_len = encoded_settings_payload_len(payload)?;
 
     let mut offset = encode_frame_header(buf, frame_type, payload_len)?;
 
     for (id, value) in &payload.entries {
-        offset += varint::encode(&mut buf[offset..], *id).ok()?;
-        offset += varint::encode(&mut buf[offset..], *value).ok()?;
+        let id = VarInt::new(*id).ok()?;
+        let value = VarInt::new(*value).ok()?;
+        offset += varint::encode(&mut buf[offset..], id).ok()?;
+        offset += varint::encode(&mut buf[offset..], value).ok()?;
     }
 
     Some(offset)
@@ -114,17 +132,19 @@ fn encode_settings_frame(buf: &mut [u8], payload: &SettingsPayload) -> Option<us
 
 fn encode_goaway_frame(buf: &mut [u8], payload: &GoawayPayload) -> Option<usize> {
     let frame_type = FrameType::Goaway as u64;
-    let payload_len = varint::encoded_len(payload.id) as u64;
+    let id = VarInt::new(payload.id).ok()?;
+    let payload_len = id.encoded_len() as u64;
 
     let mut offset = encode_frame_header(buf, frame_type, payload_len)?;
-    offset += varint::encode(&mut buf[offset..], payload.id).ok()?;
+    offset += varint::encode(&mut buf[offset..], id).ok()?;
 
     Some(offset)
 }
 
 fn encode_max_push_id_frame(buf: &mut [u8], id: u64) -> Option<usize> {
     let frame_type = FrameType::MaxPushId as u64;
-    let payload_len = varint::encoded_len(id) as u64;
+    let id = VarInt::new(id).ok()?;
+    let payload_len = id.encoded_len() as u64;
 
     let mut offset = encode_frame_header(buf, frame_type, payload_len)?;
     offset += varint::encode(&mut buf[offset..], id).ok()?;
@@ -159,5 +179,26 @@ mod tests {
         let len = encode_frame_header(&mut buf, 4, 10).unwrap();
         assert_eq!(len, 2);
         assert_eq!(&buf[..2], &[0x04, 0x0a]);
+    }
+
+    #[test]
+    fn test_encode_frame_header_rejects_out_of_range() {
+        // frame_type が VarInt 範囲外の場合は None
+        let mut buf = [0u8; 16];
+        assert_eq!(encode_frame_header(&mut buf, 1u64 << 62, 0), None);
+        // payload_len が VarInt 範囲外の場合は None
+        assert_eq!(encode_frame_header(&mut buf, 0, 1u64 << 62), None);
+    }
+
+    #[test]
+    fn test_encoded_frame_len_rejects_unknown_out_of_range() {
+        // Frame::Unknown で frame_type が VarInt 範囲外の場合は None
+        let frame = Frame::Unknown {
+            frame_type: 1u64 << 62,
+            payload: vec![],
+        };
+        assert_eq!(encoded_frame_len(&frame), None);
+        let mut buf = vec![0u8; 16];
+        assert_eq!(encode_frame(&mut buf, &frame), None);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,3 +71,4 @@ pub use qpack::{
 pub use settings::{Settings, SettingsId};
 pub use stream::{RequestStream, StreamKind, StreamState, UniStreamType};
 pub use validation::HeaderField;
+pub use varint::{VarInt, VarIntError};

--- a/src/stream/control.rs
+++ b/src/stream/control.rs
@@ -71,9 +71,15 @@ impl ControlStreamSend {
         // SETTINGS フレーム
         let payload = SettingsPayload::from_settings(settings);
         let frame = Frame::Settings(payload);
-        let frame_len = frame::encoded_frame_len(&frame);
+        // SETTINGS の id / value はアプリ層が `Settings` 経由で構築するため、
+        // 本 issue 時点では VarInt 範囲内であることをアプリ層責務として扱う。
+        // 後続 issue 0086 で `Setting` enum に昇格して型レベルに移す。
+        let frame_len =
+            frame::encoded_frame_len(&frame).expect("SETTINGS frame fields fit in VarInt");
         buf.resize(1 + frame_len, 0);
-        frame::encode_frame(&mut buf[1..], &frame);
+        let written =
+            frame::encode_frame(&mut buf[1..], &frame).expect("encoded_frame_len validated above");
+        debug_assert_eq!(written, frame_len);
 
         self.send_buf.push(&buf);
         self.send_state = ControlSendState::Ready;
@@ -89,10 +95,24 @@ impl ControlStreamSend {
             ));
         }
 
+        // GOAWAY id は RFC 9000 Section 16 の VarInt 範囲内であること
+        // (RFC 9114 Section 7.2.6, RFC 9000 Section 2.1)。
+        // 本 issue 時点では `u64` 受けのまま検査するが、後続 issue 0087 で
+        // 引数型を `VarInt` に昇格させて型レベルで保証する。
+        // 範囲外はローカル API 利用側のバグなので H3_INTERNAL_ERROR で返す
+        // (wire frame の問題ではないため H3_FRAME_ERROR は不適切)。
+        if crate::varint::VarInt::new(id).is_err() {
+            return Err(crate::error::Error::ConnectionError(
+                crate::error::ErrorCode::InternalError,
+            ));
+        }
         let frame = Frame::Goaway(GoawayPayload::new(id));
-        let frame_len = frame::encoded_frame_len(&frame);
+        let frame_len =
+            frame::encoded_frame_len(&frame).expect("GOAWAY id fits in VarInt after check");
         let mut buf = vec![0u8; frame_len];
-        frame::encode_frame(&mut buf, &frame);
+        let written =
+            frame::encode_frame(&mut buf, &frame).expect("encoded_frame_len validated above");
+        debug_assert_eq!(written, frame_len);
 
         self.send_buf.push(&buf);
         Ok(())

--- a/src/stream/request.rs
+++ b/src/stream/request.rs
@@ -167,9 +167,14 @@ impl RequestStream {
 
         // HEADERS フレーム
         let frame = Frame::Headers(HeadersPayload::new(encoded.to_vec()));
-        let frame_len = frame::encoded_frame_len(&frame);
+        // HEADERS は内部で構築するペイロード長 (QPACK エンコード結果) しか扱わず、
+        // 必ず VarInt 範囲内に収まる。後続 issue 0087 で型レベルに昇格予定。
+        let frame_len =
+            frame::encoded_frame_len(&frame).expect("HEADERS frame length fits in VarInt");
         let mut frame_buf = vec![0u8; frame_len];
-        frame::encode_frame(&mut frame_buf, &frame);
+        let written =
+            frame::encode_frame(&mut frame_buf, &frame).expect("encoded_frame_len validated above");
+        debug_assert_eq!(written, frame_len);
 
         self.send_buf.push(&frame_buf);
 
@@ -216,9 +221,14 @@ impl RequestStream {
         if !data.is_empty() {
             // DATA フレーム
             let frame = Frame::Data(DataPayload::new(data.to_vec()));
-            let frame_len = frame::encoded_frame_len(&frame);
+            // DATA フレームのペイロード長は呼び出し側スライス長と一致するため、必ず
+            // VarInt 範囲内 (`usize` の上限値 < 2^62 - 1)。
+            let frame_len =
+                frame::encoded_frame_len(&frame).expect("DATA frame length fits in VarInt");
             let mut frame_buf = vec![0u8; frame_len];
-            frame::encode_frame(&mut frame_buf, &frame);
+            let written = frame::encode_frame(&mut frame_buf, &frame)
+                .expect("encoded_frame_len validated above");
+            debug_assert_eq!(written, frame_len);
 
             self.send_buf.push(&frame_buf);
             self.send_state = RequestSendState::SendingBody;

--- a/src/varint.rs
+++ b/src/varint.rs
@@ -1,11 +1,169 @@
 //! QUIC 可変長整数 (RFC 9000 Section 16)
 //!
 //! QUIC の可変長整数は 1, 2, 4, 8 バイトでエンコードされ、最大 2^62-1 まで表現可能。
+//! 値域 `0..=2^62 - 1` を型で表現するため [`VarInt`] 構造体を提供し、
+//! エンコード / デコード関数は引数 / 戻り値に [`VarInt`] を取り扱う。
 
-/// 可変長整数の最大値 (2^62 - 1)
-pub const MAX_VALUE: u64 = (1 << 62) - 1;
+use core::fmt;
+
+/// QUIC VarInt (RFC 9000 Section 16)
+///
+/// `0..=2^62 - 1` の整数を表現する。エンコード長は値域に応じて 1 / 2 / 4 / 8 バイト。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct VarInt(u64);
+
+/// VarInt 構築時のエラー
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VarIntError {
+    /// 値が VarInt の最大値 (`2^62 - 1`) を超えている
+    OutOfRange {
+        /// 範囲外と判定された元の値
+        value: u64,
+    },
+}
+
+impl fmt::Display for VarIntError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::OutOfRange { value } => {
+                write!(
+                    f,
+                    "varint value {value} exceeds the maximum allowed by RFC 9000 Section 16 (2^62 - 1)"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for VarIntError {}
+
+impl VarInt {
+    /// VarInt が表現可能な最大値 (`2^62 - 1`)
+    ///
+    /// RFC 9000 Section 16 Table 4 の 8-byte エンコード上限。
+    pub const MAX: Self = Self((1u64 << 62) - 1);
+
+    /// VarInt の最小値 (`0`)
+    pub const ZERO: Self = Self(0);
+
+    /// ランタイム値から検査つきで構築する
+    ///
+    /// 値が [`VarInt::MAX`] を超える場合は [`VarIntError::OutOfRange`] を返す。
+    /// `const fn` のため `const VAL: Result<VarInt, _> = VarInt::new(64);` のように
+    /// `const` 宣言でも使える。
+    pub const fn new(value: u64) -> Result<Self, VarIntError> {
+        if value > Self::MAX.get() {
+            Err(VarIntError::OutOfRange { value })
+        } else {
+            Ok(Self(value))
+        }
+    }
+
+    /// 静的リテラル定数から検査つきで構築する (`const fn`)
+    ///
+    /// 用途は `const` / `static` 宣言で「リテラルが VarInt 範囲内であること」を
+    /// コンパイル時に検証することに限られる。範囲外なら `const` 評価時の panic と
+    /// なりコンパイルエラーになる。
+    ///
+    /// ランタイム値には [`VarInt::new`] を使うこと。本関数を `let x = ...;` の
+    /// ような実行時文脈で呼ぶと、範囲外時にランタイム panic になる。
+    ///
+    /// `#[track_caller]` はランタイム panic 時の呼び出し位置を保持するために
+    /// 付けている (const 評価時の panic 表示には影響しない)。
+    #[track_caller]
+    pub const fn from_static(value: u64) -> Self {
+        assert!(value <= Self::MAX.get(), "VarInt value must be <= 2^62 - 1");
+        Self(value)
+    }
+
+    /// 内部値を取得する
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+
+    /// wire 表現のエンコード長 (1 / 2 / 4 / 8 バイト) を返す
+    ///
+    /// 値域と prefix の対応 (RFC 9000 Section 16 Table 4):
+    ///   - `0 ..= 2^6 - 1` → 1 バイト (00 prefix)
+    ///   - `2^6 ..= 2^14 - 1` → 2 バイト (01 prefix)
+    ///   - `2^14 ..= 2^30 - 1` → 4 バイト (10 prefix)
+    ///   - `2^30 ..= 2^62 - 1` → 8 バイト (11 prefix)
+    pub const fn encoded_len(self) -> usize {
+        if self.0 < 64 {
+            1
+        } else if self.0 < 16_384 {
+            2
+        } else if self.0 < 1_073_741_824 {
+            4
+        } else {
+            8
+        }
+    }
+
+    /// 検証済みの `u64` から検査をスキップして構築する (crate 内部専用)
+    ///
+    /// **release ビルドでは `debug_assert!` が除去される**ため、呼び出し側が
+    /// 値の正当性 (`value <= 2^62 - 1`) を構造的に保証できていることが必須。
+    /// 検証されていない `u64` を渡すと crate 全体の `VarInt` 不変条件を破壊し、
+    /// `encoded_len` の `unreachable` 仮定や `Display` 出力で予期せぬ挙動を起こしうる。
+    ///
+    /// 現状の利用は [`decode`] のみで、wire の最上位 2 ビットがエンコード長を示す
+    /// 構造により mask 後の値が必ず `2^62 - 1` 以下となることを利用している
+    /// (RFC 9000 Section 16 Table 4)。
+    pub(crate) const fn from_validated_parts(value: u64) -> Self {
+        debug_assert!(
+            value <= Self::MAX.get(),
+            "VarInt invariant violated: value exceeds 2^62 - 1"
+        );
+        Self(value)
+    }
+}
+
+impl fmt::Display for VarInt {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl From<u8> for VarInt {
+    fn from(value: u8) -> Self {
+        Self(u64::from(value))
+    }
+}
+
+impl From<u16> for VarInt {
+    fn from(value: u16) -> Self {
+        Self(u64::from(value))
+    }
+}
+
+impl From<u32> for VarInt {
+    fn from(value: u32) -> Self {
+        Self(u64::from(value))
+    }
+}
+
+impl TryFrom<u64> for VarInt {
+    type Error = VarIntError;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl TryFrom<usize> for VarInt {
+    type Error = VarIntError;
+
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        // 32 / 64 bit いずれの環境でも `usize` は `u64` に widen 可能。
+        // (Rust 公式サポートターゲットは pointer width 16/32/64 で、いずれも u64 に収まる)
+        Self::new(value as u64)
+    }
+}
 
 /// 可変長整数デコードエラー
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DecodeError {
     /// バッファが不足している
@@ -13,103 +171,51 @@ pub enum DecodeError {
 }
 
 /// 可変長整数エンコードエラー
+///
+/// 値域は [`VarInt`] が保証するため、ここでは出力バッファ不足だけを表現する。
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EncodeError {
-    /// 値が大きすぎる (> 2^62 - 1)
-    ValueTooLarge,
     /// バッファが不足している
     BufferTooShort,
 }
 
-/// 値をエンコードするのに必要なバイト数を返す
+/// 可変長整数を `Vec` に追記する
 ///
-/// 呼び出し側が値 <= `MAX_VALUE` を保証している場面で使う内部向けヘルパー。
-/// 外部からは `try_encoded_len` を使うこと。
-///
-/// # Panics
-///
-/// 値が `MAX_VALUE` を超える場合はパニックする
-#[inline]
-pub fn encoded_len(value: u64) -> usize {
-    if value < 64 {
-        1
-    } else if value < 16384 {
-        2
-    } else if value < 1_073_741_824 {
-        4
-    } else if value <= MAX_VALUE {
-        8
-    } else {
-        panic!("value exceeds maximum: {value}");
-    }
-}
-
-/// 値をエンコードするのに必要なバイト数を返す (panic しない公開 API)
-///
-/// 値が `MAX_VALUE` を超える場合は `Err(EncodeError::ValueTooLarge)` を返す。
-/// Sans I/O 境界ではこちらを使うこと。
-#[inline]
-pub fn try_encoded_len(value: u64) -> Result<usize, EncodeError> {
-    if value > MAX_VALUE {
-        return Err(EncodeError::ValueTooLarge);
-    }
-    Ok(encoded_len(value))
-}
-
-/// 可変長整数を Vec に追記する
-///
-/// 呼び出し側が値 <= `MAX_VALUE` を保証している場面で使う内部向けヘルパー。
-/// 外部からは `try_encode_into_vec` を使うこと。
-///
-/// # Panics
-///
-/// 値が `MAX_VALUE` を超える場合はパニックする
-pub fn encode_into_vec(buf: &mut Vec<u8>, value: u64) {
-    let len = encoded_len(value);
+/// 必要なバイト数 (`value.encoded_len()`) を確保してから [`encode`] を呼ぶため、
+/// `BufferTooShort` は発生しない。`Vec::resize` のアロケーション失敗
+/// (OS のメモリ枯渇) 以外で panic することはない。
+pub fn encode_into_vec(buf: &mut Vec<u8>, value: VarInt) {
+    let len = value.encoded_len();
     let start = buf.len();
     buf.resize(start + len, 0);
     encode(&mut buf[start..], value).expect("buffer is correctly sized");
 }
 
-/// 可変長整数を Vec に追記する (panic しない公開 API)
-///
-/// 値が `MAX_VALUE` を超える場合は `Err(EncodeError::ValueTooLarge)` を返す。
-/// Sans I/O 境界ではこちらを使うこと。
-pub fn try_encode_into_vec(buf: &mut Vec<u8>, value: u64) -> Result<(), EncodeError> {
-    if value > MAX_VALUE {
-        return Err(EncodeError::ValueTooLarge);
-    }
-    encode_into_vec(buf, value);
-    Ok(())
-}
-
 /// 可変長整数をエンコードする
 ///
-/// 成功時はエンコードしたバイト数を返す
-pub fn encode(buf: &mut [u8], value: u64) -> Result<usize, EncodeError> {
-    if value > MAX_VALUE {
-        return Err(EncodeError::ValueTooLarge);
-    }
-
-    let len = encoded_len(value);
+/// 成功時はエンコードしたバイト数を返す。
+pub fn encode(buf: &mut [u8], value: VarInt) -> Result<usize, EncodeError> {
+    let len = value.encoded_len();
     if buf.len() < len {
         return Err(EncodeError::BufferTooShort);
     }
 
+    let raw = value.get();
     match len {
         1 => {
-            buf[0] = value as u8;
+            buf[0] = raw as u8;
         }
         2 => {
-            let v = (value as u16) | 0x4000;
+            let v = (raw as u16) | 0x4000;
             buf[..2].copy_from_slice(&v.to_be_bytes());
         }
         4 => {
-            let v = (value as u32) | 0x8000_0000;
+            let v = (raw as u32) | 0x8000_0000;
             buf[..4].copy_from_slice(&v.to_be_bytes());
         }
         8 => {
-            let v = value | 0xc000_0000_0000_0000;
+            let v = raw | 0xc000_0000_0000_0000;
             buf[..8].copy_from_slice(&v.to_be_bytes());
         }
         _ => unreachable!(),
@@ -120,8 +226,8 @@ pub fn encode(buf: &mut [u8], value: u64) -> Result<usize, EncodeError> {
 
 /// 可変長整数をデコードする
 ///
-/// 成功時は (値, 消費バイト数) を返す
-pub fn decode(buf: &[u8]) -> Result<(u64, usize), DecodeError> {
+/// 成功時は `(VarInt, 消費バイト数)` を返す。
+pub fn decode(buf: &[u8]) -> Result<(VarInt, usize), DecodeError> {
     if buf.is_empty() {
         return Err(DecodeError::BufferTooShort);
     }
@@ -153,12 +259,14 @@ pub fn decode(buf: &[u8]) -> Result<(u64, usize), DecodeError> {
         _ => unreachable!(),
     };
 
-    Ok((value, len))
+    // wire 表現の最上位 2 ビットがエンコード長を示すため、組み立て後の値は
+    // 必ず 2^62 - 1 以下になる (RFC 9000 Section 16 Table 4)。
+    Ok((VarInt::from_validated_parts(value), len))
 }
 
 /// バッファの先頭バイトから可変長整数のバイト長を取得する
 ///
-/// バッファが空の場合は `None` を返す
+/// バッファが空の場合は `None` を返す。
 #[inline]
 pub fn peek_len(buf: &[u8]) -> Option<usize> {
     buf.first().map(|&b| 1 << (b >> 6))
@@ -168,9 +276,81 @@ pub fn peek_len(buf: &[u8]) -> Option<usize> {
 mod tests {
     use super::*;
 
+    // 値域・ラウンドトリップ・境界・From/TryFrom のラウンドトリップは
+    // `pbt/tests/prop_varint.rs` 側で PBT 化している (CLAUDE.md: PBT で実現できる
+    // ものを単体テストで書かない)。
+    // 本モジュールには PBT で表現しにくいケース (const 文脈の正常系、エラー詳細の
+    // 文面検査、`from_validated_parts` の境界、`u64::MAX` のエラー) のみ残す。
+
+    #[test]
+    fn test_new_rejects_out_of_range() {
+        // VarInt::MAX + 1 と u64::MAX が共に同種のエラーを返すこと
+        assert_eq!(
+            VarInt::new(VarInt::MAX.get() + 1),
+            Err(VarIntError::OutOfRange {
+                value: VarInt::MAX.get() + 1,
+            })
+        );
+        assert_eq!(
+            VarInt::new(u64::MAX),
+            Err(VarIntError::OutOfRange { value: u64::MAX })
+        );
+    }
+
+    #[test]
+    fn test_from_static_const_context() {
+        // const 宣言で `from_static` が使えること (リテラルが範囲内ならコンパイル成功)
+        const ZERO: VarInt = VarInt::from_static(0);
+        const ONE_BYTE_BOUNDARY: VarInt = VarInt::from_static(63);
+        const TWO_BYTE_BOUNDARY: VarInt = VarInt::from_static(16_383);
+        const FOUR_BYTE_BOUNDARY: VarInt = VarInt::from_static(1_073_741_823);
+        const MAX: VarInt = VarInt::from_static((1u64 << 62) - 1);
+        assert_eq!(ZERO, VarInt::ZERO);
+        assert_eq!(ONE_BYTE_BOUNDARY.encoded_len(), 1);
+        assert_eq!(TWO_BYTE_BOUNDARY.encoded_len(), 2);
+        assert_eq!(FOUR_BYTE_BOUNDARY.encoded_len(), 4);
+        assert_eq!(MAX, VarInt::MAX);
+    }
+
+    #[test]
+    fn test_error_display_contains_rfc_reference() {
+        let err = VarIntError::OutOfRange {
+            value: VarInt::MAX.get() + 1,
+        };
+        let s = format!("{err}");
+        assert!(s.contains(&format!("{}", VarInt::MAX.get() + 1)));
+        assert!(s.contains("RFC 9000"));
+        assert!(s.contains("exceeds"));
+    }
+
+    #[test]
+    fn test_try_from_u64_max_is_error() {
+        // PBT は any::<u64>() で広範囲を検査するが、u64::MAX 境界は明示的に固定する
+        assert!(VarInt::try_from(u64::MAX).is_err());
+        assert!(VarInt::try_from(VarInt::MAX.get()).is_ok());
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn test_try_from_usize_rejects_out_of_range_on_64bit() {
+        // 64bit 環境でのみ意味のあるテスト (32bit usize は VarInt::MAX を超えられない)
+        let too_large = (VarInt::MAX.get() + 1) as usize;
+        assert!(VarInt::try_from(too_large).is_err());
+    }
+
+    #[test]
+    fn test_from_validated_parts_boundaries() {
+        // crate 内部からのみ呼ばれるが、境界値で正しく組み立てられることを確認
+        assert_eq!(VarInt::from_validated_parts(0).get(), 0);
+        assert_eq!(VarInt::from_validated_parts(VarInt::MAX.get()), VarInt::MAX);
+    }
+
     #[test]
     fn test_decode_buffer_too_short() {
         assert_eq!(decode(&[]), Err(DecodeError::BufferTooShort));
         assert_eq!(decode(&[0x40]), Err(DecodeError::BufferTooShort));
     }
+
+    // `encode` の BufferTooShort は `pbt/tests/prop_varint.rs::prop_short_buffer_returns_buffer_too_short`
+    // で網羅検査する (CLAUDE.md: PBT で実現できるものは PBT で書く)。
 }

--- a/src/webtransport/capsule.rs
+++ b/src/webtransport/capsule.rs
@@ -1,8 +1,17 @@
 //! WebTransport Capsule Protocol (draft-ietf-webtrans-http3-15 Section 5.6, 6)
 //!
 //! WebTransport セッション管理とフロー制御のための Capsule を定義。
+//!
+//! # Panics
+//!
+//! 本モジュールの `Capsule` 各 variant の `u64` フィールド
+//! (`MaxData::maximum`, `MaxStreams::maximum`, `DataBlocked::maximum`,
+//! `StreamsBlocked::maximum`, `Unknown::payload.len()` 等) は RFC 9000 Section 16 の
+//! VarInt 範囲 (`0..=2^62 - 1`) を超えると `encode` / `encode_as_data_frame` で
+//! panic する。これらの値域検査は後続 issue で Capsule の構築時検査型化を行う際に
+//! 構造的に保証する予定。それまでは利用側で範囲外値を渡さないこと。
 
-use crate::varint;
+use crate::varint::{self, VarInt};
 
 /// Maximum Streams の上限値 (2^60)
 /// draft-ietf-webtrans-http3-15 Section 5.6.2
@@ -153,13 +162,24 @@ pub enum Capsule {
 }
 
 /// 可変長整数を Vec にエンコード
+///
+/// 呼び出し側は値が VarInt 範囲内 (RFC 9000 Section 16) であることを保証する。
+/// 範囲外の値が渡された場合は panic する。
 fn encode_varint(buf: &mut Vec<u8>, value: u64) {
+    let value = VarInt::new(value).expect("capsule field value fits in VarInt");
     varint::encode_into_vec(buf, value);
 }
 
-/// 可変長整数をデコード (Option を返す)
+/// 可変長整数をエンコードしたサイズを返す
+fn varint_encoded_len(value: u64) -> usize {
+    VarInt::new(value)
+        .expect("capsule field value fits in VarInt")
+        .encoded_len()
+}
+
+/// 可変長整数をデコード (生の `u64` 値を返す)
 fn decode_varint(buf: &[u8]) -> Option<(u64, usize)> {
-    varint::decode(buf).ok()
+    varint::decode(buf).ok().map(|(v, n)| (v.get(), n))
 }
 
 impl Capsule {
@@ -188,7 +208,7 @@ impl Capsule {
         let mut capsule_bytes = Vec::new();
         self.encode(&mut capsule_bytes);
         // DATA フレーム: タイプ (0x00) + ペイロード長 + ペイロード
-        encode_varint(buf, 0x00);
+        varint::encode_into_vec(buf, VarInt::ZERO);
         encode_varint(buf, capsule_bytes.len() as u64);
         buf.extend_from_slice(&capsule_bytes);
     }
@@ -214,7 +234,7 @@ impl Capsule {
             }
 
             Self::MaxData { maximum } => {
-                let payload_len = varint::encoded_len(*maximum);
+                let payload_len = varint_encoded_len(*maximum);
                 Self::encode_capsule_header(buf, CapsuleType::MaxData as u64, payload_len);
                 encode_varint(buf, *maximum);
             }
@@ -228,13 +248,13 @@ impl Capsule {
                 } else {
                     CapsuleType::MaxStreamsUni as u64
                 };
-                let payload_len = varint::encoded_len(*maximum);
+                let payload_len = varint_encoded_len(*maximum);
                 Self::encode_capsule_header(buf, capsule_type, payload_len);
                 encode_varint(buf, *maximum);
             }
 
             Self::DataBlocked { maximum } => {
-                let payload_len = varint::encoded_len(*maximum);
+                let payload_len = varint_encoded_len(*maximum);
                 Self::encode_capsule_header(buf, CapsuleType::DataBlocked as u64, payload_len);
                 encode_varint(buf, *maximum);
             }
@@ -248,7 +268,7 @@ impl Capsule {
                 } else {
                     CapsuleType::StreamsBlockedUni as u64
                 };
-                let payload_len = varint::encoded_len(*maximum);
+                let payload_len = varint_encoded_len(*maximum);
                 Self::encode_capsule_header(buf, capsule_type, payload_len);
                 encode_varint(buf, *maximum);
             }

--- a/src/webtransport/datagram.rs
+++ b/src/webtransport/datagram.rs
@@ -23,9 +23,10 @@
 //!
 //! - Section 4.5: Datagrams
 
-use crate::varint;
+use crate::varint::{self, VarInt};
 
 /// `Datagram::new` のバリデーションエラー
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DatagramError {
     /// `session_id` が client-initiated bidirectional stream ID ではない
@@ -34,6 +35,11 @@ pub enum DatagramError {
     /// (draft-ietf-webtrans-http3-15 Section 4.5 / RFC 9000 Section 2.1:
     /// クライアント開始双方向ストリームの ID は 4 の倍数)
     InvalidSessionId,
+
+    /// `session_id` が QUIC ストリーム ID 空間の上限 (`2^62 - 1`) を超えている
+    ///
+    /// (RFC 9000 Section 2.1, Section 16: ストリーム ID は QUIC VarInt)
+    SessionIdOutOfRange,
 }
 
 /// WebTransport データグラム (Section 4.5)
@@ -57,6 +63,13 @@ impl Datagram {
     ///
     /// Sans I/O 境界として呼び出し側にエラー判定を委ねるため、パニックしない。
     pub fn new(session_id: u64, payload: Vec<u8>) -> Result<Self, DatagramError> {
+        // session_id は QUIC ストリーム ID であり、RFC 9000 Section 16 の VarInt 範囲
+        // (`0..=2^62 - 1`) に収まらなければならない。
+        // この検査は `encode` (Quarter Stream ID をエンコードする) の安全性を構造的に
+        // 保証する役割も持つ。
+        if VarInt::new(session_id).is_err() {
+            return Err(DatagramError::SessionIdOutOfRange);
+        }
         if !session_id.is_multiple_of(4) {
             return Err(DatagramError::InvalidSessionId);
         }
@@ -77,7 +90,11 @@ impl Datagram {
     ///
     /// `buf` に Quarter Stream ID (varint) とペイロードを追記する。
     pub fn encode(&self, buf: &mut Vec<u8>) {
-        varint::encode_into_vec(buf, self.quarter_stream_id());
+        // `Datagram::new` で session_id <= 2^62 - 1 を検査済みのため、
+        // quarter_stream_id = session_id / 4 は必ず VarInt 範囲内 (<= 2^60 - 1)。
+        let qsi = VarInt::new(self.quarter_stream_id())
+            .expect("quarter_stream_id is bounded by Datagram::new");
+        varint::encode_into_vec(buf, qsi);
         buf.extend_from_slice(&self.payload);
     }
 
@@ -90,6 +107,7 @@ impl Datagram {
     /// `session_id = quarter_stream_id * 4` として復元する。
     pub fn decode(buf: &[u8]) -> Option<(Self, usize)> {
         let (qsi, varint_len) = varint::decode(buf).ok()?;
+        let qsi = qsi.get();
         // RFC 9297 Section 2.1: Quarter Stream ID は QUIC ストリーム ID 空間
         // (2^62 - 1) を 4 で割った値、すなわち 2^60 - 1 が上限。
         // これを超える値は不正であり、呼び出し側は H3_DATAGRAM_ERROR で
@@ -180,6 +198,17 @@ mod tests {
         assert_eq!(
             Datagram::new(5, vec![0xff]),
             Err(DatagramError::InvalidSessionId)
+        );
+    }
+
+    #[test]
+    fn test_datagram_rejects_session_id_out_of_range() {
+        // session_id が VarInt 範囲 (2^62 - 1) を超える場合は拒否
+        // (4 の倍数判定より先に値域判定を行う)
+        let too_large = (1u64 << 62) & !0x3;
+        assert_eq!(
+            Datagram::new(too_large, vec![]),
+            Err(DatagramError::SessionIdOutOfRange)
         );
     }
 }

--- a/src/webtransport/stream.rs
+++ b/src/webtransport/stream.rs
@@ -2,7 +2,7 @@
 //!
 //! WebTransport データストリームの管理を提供。
 
-use crate::varint;
+use crate::varint::{self, VarInt};
 
 /// WebTransport 単方向ストリームタイプ (0x54)
 pub const UNIDIRECTIONAL_STREAM_TYPE: u64 = 0x54;
@@ -10,9 +10,23 @@ pub const UNIDIRECTIONAL_STREAM_TYPE: u64 = 0x54;
 /// WebTransport 双方向ストリームシグナル値 (WT_STREAM フレーム) (0x41)
 pub const BIDIRECTIONAL_SIGNAL_VALUE: u64 = 0x41;
 
-/// 可変長整数をデコード (Option を返す)
+/// 単方向ストリームタイプの VarInt 表現
+const UNI_TYPE_VARINT: VarInt = VarInt::from_static(UNIDIRECTIONAL_STREAM_TYPE);
+
+/// 双方向シグナル値の VarInt 表現
+const BIDI_SIGNAL_VARINT: VarInt = VarInt::from_static(BIDIRECTIONAL_SIGNAL_VALUE);
+
+/// 可変長整数をデコード (生の `u64` 値を返す)
 fn decode_varint(buf: &[u8]) -> Option<(u64, usize)> {
-    varint::decode(buf).ok()
+    varint::decode(buf).ok().map(|(v, n)| (v.get(), n))
+}
+
+/// `u64` session_id を VarInt に変換する
+///
+/// session_id は QUIC ストリーム ID 空間 (`<= 2^62 - 1`) に収まることを構造的に
+/// 保証している前提で `expect` する。
+fn session_id_to_varint(session_id: u64) -> VarInt {
+    VarInt::new(session_id).expect("session_id fits in VarInt")
 }
 
 /// ストリームヘッダー
@@ -25,6 +39,7 @@ pub struct StreamHeader {
 }
 
 /// ストリームヘッダーデコードエラー
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StreamHeaderDecodeError {
     /// バッファ不足
@@ -36,17 +51,25 @@ pub enum StreamHeaderDecodeError {
     /// 呼び出し側は H3_ID_ERROR で接続を閉じる (draft-ietf-webtrans-http3-15 Section 4)。
     /// 将来のドラフトで変更される可能性がある
     InvalidSessionId,
+    /// Session ID が QUIC ストリーム ID 空間の上限 (`2^62 - 1`) を超えている
+    ///
+    /// (RFC 9000 Section 2.1, Section 16)
+    SessionIdOutOfRange,
 }
 
 impl StreamHeader {
     /// 新しいストリームヘッダーを作成
     ///
-    /// `session_id` は client-initiated bidirectional stream ID
-    /// (`session_id % 4 == 0`) でなければならない。不正な値の場合は
-    /// `Err(StreamHeaderDecodeError::InvalidSessionId)` を返す。
+    /// `session_id` は以下を満たさなければならない:
+    /// - QUIC ストリーム ID 空間 (`<= 2^62 - 1`) 内
+    /// - client-initiated bidirectional stream ID (`session_id % 4 == 0`)
     ///
+    /// 不正な値の場合は対応する `StreamHeaderDecodeError` を返す。
     /// Sans I/O 境界として呼び出し側にエラー判定を委ねるため、パニックしない。
     pub fn new(session_id: u64) -> Result<Self, StreamHeaderDecodeError> {
+        if VarInt::new(session_id).is_err() {
+            return Err(StreamHeaderDecodeError::SessionIdOutOfRange);
+        }
         if !session_id.is_multiple_of(4) {
             return Err(StreamHeaderDecodeError::InvalidSessionId);
         }
@@ -63,8 +86,8 @@ impl StreamHeader {
     /// }
     /// ```
     pub fn encode_unidirectional(&self, buf: &mut Vec<u8>) {
-        varint::encode_into_vec(buf, UNIDIRECTIONAL_STREAM_TYPE);
-        varint::encode_into_vec(buf, self.session_id);
+        varint::encode_into_vec(buf, UNI_TYPE_VARINT);
+        varint::encode_into_vec(buf, session_id_to_varint(self.session_id));
     }
 
     /// 双方向ストリームヘッダーをエンコード
@@ -77,8 +100,8 @@ impl StreamHeader {
     /// }
     /// ```
     pub fn encode_bidirectional(&self, buf: &mut Vec<u8>) {
-        varint::encode_into_vec(buf, BIDIRECTIONAL_SIGNAL_VALUE);
-        varint::encode_into_vec(buf, self.session_id);
+        varint::encode_into_vec(buf, BIDI_SIGNAL_VARINT);
+        varint::encode_into_vec(buf, session_id_to_varint(self.session_id));
     }
 
     /// 単方向ストリームヘッダーをデコード
@@ -160,7 +183,7 @@ impl StreamHeader {
     /// エンコードサイズを計算
     pub fn encoded_size(&self) -> usize {
         // Signal/Type + Session ID
-        varint::encoded_len(BIDIRECTIONAL_SIGNAL_VALUE) + varint::encoded_len(self.session_id)
+        BIDI_SIGNAL_VARINT.encoded_len() + session_id_to_varint(self.session_id).encoded_len()
     }
 }
 
@@ -283,15 +306,15 @@ pub enum ClassifiedUniStream {
 /// (draft-ietf-webtrans-http3-15 Section 4)。
 pub fn classify_uni_stream(buf: &[u8]) -> Result<ClassifiedUniStream, varint::DecodeError> {
     let (stream_type, type_len) = varint::decode(buf)?;
-    if stream_type == UNIDIRECTIONAL_STREAM_TYPE {
+    if stream_type.get() == UNIDIRECTIONAL_STREAM_TYPE {
         let (session_id, session_id_len) = varint::decode(&buf[type_len..])?;
         Ok(ClassifiedUniStream::WebTransport {
-            session_id,
+            session_id: session_id.get(),
             data_offset: type_len + session_id_len,
         })
     } else {
         Ok(ClassifiedUniStream::Http3 {
-            stream_type,
+            stream_type: stream_type.get(),
             data_offset: type_len,
         })
     }
@@ -310,9 +333,10 @@ pub fn classify_uni_stream_checked(
 ) -> Result<ClassifiedUniStream, StreamHeaderDecodeError> {
     let (stream_type, type_len) =
         varint::decode(buf).map_err(|_| StreamHeaderDecodeError::BufferTooShort)?;
-    if stream_type == UNIDIRECTIONAL_STREAM_TYPE {
+    if stream_type.get() == UNIDIRECTIONAL_STREAM_TYPE {
         let (session_id, session_id_len) = varint::decode(&buf[type_len..])
             .map_err(|_| StreamHeaderDecodeError::BufferTooShort)?;
+        let session_id = session_id.get();
         if !session_id.is_multiple_of(4) {
             return Err(StreamHeaderDecodeError::InvalidSessionId);
         }
@@ -322,7 +346,7 @@ pub fn classify_uni_stream_checked(
         })
     } else {
         Ok(ClassifiedUniStream::Http3 {
-            stream_type,
+            stream_type: stream_type.get(),
             data_offset: type_len,
         })
     }
@@ -375,6 +399,17 @@ mod tests {
     }
 
     #[test]
+    fn test_stream_header_new_rejects_session_id_out_of_range() {
+        // session_id が VarInt 範囲 (`2^62 - 1`) を超える場合は SessionIdOutOfRange
+        // (4 の倍数判定より先に値域判定が走る)
+        let too_large = (1u64 << 62) & !0x3;
+        assert_eq!(
+            StreamHeader::new(too_large),
+            Err(StreamHeaderDecodeError::SessionIdOutOfRange)
+        );
+    }
+
+    #[test]
     fn test_stream_creation() {
         let stream = Stream::new(4, 0, true);
         assert_eq!(stream.stream_id(), 4);
@@ -420,8 +455,8 @@ mod tests {
     #[test]
     fn test_decode_unidirectional_checked_invalid_session_id() {
         let mut buf = Vec::new();
-        varint::encode_into_vec(&mut buf, UNIDIRECTIONAL_STREAM_TYPE);
-        varint::encode_into_vec(&mut buf, 5);
+        varint::encode_into_vec(&mut buf, UNI_TYPE_VARINT);
+        varint::encode_into_vec(&mut buf, VarInt::from_static(5));
         let result = StreamHeader::decode_unidirectional_checked(&buf);
         assert_eq!(result, Err(StreamHeaderDecodeError::InvalidSessionId));
     }
@@ -429,8 +464,8 @@ mod tests {
     #[test]
     fn test_decode_bidirectional_checked_invalid_session_id() {
         let mut buf = Vec::new();
-        varint::encode_into_vec(&mut buf, BIDIRECTIONAL_SIGNAL_VALUE);
-        varint::encode_into_vec(&mut buf, 7);
+        varint::encode_into_vec(&mut buf, BIDI_SIGNAL_VARINT);
+        varint::encode_into_vec(&mut buf, VarInt::from_static(7));
         let result = StreamHeader::decode_bidirectional_checked(&buf);
         assert_eq!(result, Err(StreamHeaderDecodeError::InvalidSessionId));
     }
@@ -442,8 +477,8 @@ mod tests {
     #[test]
     fn test_classify_uni_stream_checked_webtransport_valid() {
         let mut buf = Vec::new();
-        varint::encode_into_vec(&mut buf, UNIDIRECTIONAL_STREAM_TYPE);
-        varint::encode_into_vec(&mut buf, 0); // session_id = 0 (0 % 4 == 0)
+        varint::encode_into_vec(&mut buf, UNI_TYPE_VARINT);
+        varint::encode_into_vec(&mut buf, VarInt::ZERO); // session_id = 0 (0 % 4 == 0)
         let expected_offset = buf.len();
         buf.extend_from_slice(b"payload");
         let result = classify_uni_stream_checked(&buf).unwrap();
@@ -459,8 +494,8 @@ mod tests {
     #[test]
     fn test_classify_uni_stream_checked_webtransport_invalid_session_id() {
         let mut buf = Vec::new();
-        varint::encode_into_vec(&mut buf, UNIDIRECTIONAL_STREAM_TYPE);
-        varint::encode_into_vec(&mut buf, 5); // session_id = 5 (5 % 4 != 0)
+        varint::encode_into_vec(&mut buf, UNI_TYPE_VARINT);
+        varint::encode_into_vec(&mut buf, VarInt::from_static(5)); // session_id = 5 (5 % 4 != 0)
         let result = classify_uni_stream_checked(&buf);
         assert_eq!(result, Err(StreamHeaderDecodeError::InvalidSessionId));
     }
@@ -469,7 +504,7 @@ mod tests {
     fn test_classify_uni_stream_checked_http3() {
         // HTTP/3 制御ストリーム (type = 0x00)
         let mut buf = Vec::new();
-        varint::encode_into_vec(&mut buf, 0x00);
+        varint::encode_into_vec(&mut buf, VarInt::ZERO);
         buf.extend_from_slice(b"data");
         let result = classify_uni_stream_checked(&buf).unwrap();
         assert_eq!(
@@ -491,7 +526,7 @@ mod tests {
     fn test_classify_uni_stream_checked_session_id_buffer_too_short() {
         // ストリームタイプは読めるが session_id が不足
         let mut buf = Vec::new();
-        varint::encode_into_vec(&mut buf, UNIDIRECTIONAL_STREAM_TYPE);
+        varint::encode_into_vec(&mut buf, UNI_TYPE_VARINT);
         let result = classify_uni_stream_checked(&buf);
         assert_eq!(result, Err(StreamHeaderDecodeError::BufferTooShort));
     }

--- a/tests/test_webtransport_draft_connect.rs
+++ b/tests/test_webtransport_draft_connect.rs
@@ -26,9 +26,15 @@ fn build_headers_frame(headers: &[Header]) -> Vec<u8> {
 
     let mut frame = Vec::new();
     // HEADERS フレームタイプ: 0x01
-    shiguredo_http3::varint::encode_into_vec(&mut frame, 0x01);
+    shiguredo_http3::varint::encode_into_vec(
+        &mut frame,
+        shiguredo_http3::VarInt::from_static(0x01),
+    );
     // ペイロード長
-    shiguredo_http3::varint::encode_into_vec(&mut frame, qpack_len as u64);
+    shiguredo_http3::varint::encode_into_vec(
+        &mut frame,
+        shiguredo_http3::VarInt::new(qpack_len as u64).expect("qpack length fits in VarInt"),
+    );
     frame.extend_from_slice(&qpack_buf);
     frame
 }
@@ -917,8 +923,11 @@ mod pending_data_frame {
     fn build_headers_then_data(headers: &[Header], body: &[u8]) -> Vec<u8> {
         let mut frame = build_headers_frame(headers);
         // DATA フレーム: type=0x00 + length(varint) + body
-        shiguredo_http3::varint::encode_into_vec(&mut frame, 0x00);
-        shiguredo_http3::varint::encode_into_vec(&mut frame, body.len() as u64);
+        shiguredo_http3::varint::encode_into_vec(&mut frame, shiguredo_http3::VarInt::ZERO);
+        shiguredo_http3::varint::encode_into_vec(
+            &mut frame,
+            shiguredo_http3::VarInt::new(body.len() as u64).expect("body length fits in VarInt"),
+        );
         frame.extend_from_slice(body);
         frame
     }


### PR DESCRIPTION
## 概要

QUIC / HTTP/3 で使われる可変長整数 (VarInt, RFC 9000 Section 16) の値域 `0..=2^62 - 1` を、現状 `u64` 直渡しで扱っている箇所を補助型 `VarInt` に置き換える。リテラル定数向けに `const fn VarInt::from_static` を提供し、`const` / `static` 宣言で範囲外リテラルを **コンパイル時 panic** として検出可能にする。

issue: `issues/closed/0084-add-varint-constructor-type.md`

## 変更内容

- `src/varint.rs` に `VarInt` / `VarIntError` を新設し、値域 `0..=2^62 - 1` を型で表現する。
- `VarInt::from_static` を `const fn` で提供し、`const` / `static` 宣言で範囲外リテラルをコンパイル時 panic として検出可能にする。
- `varint` モジュールの公開 API (`encode` / `encode_into_vec` / `decode`) を `VarInt` を取り扱う形に変更する。
- `varint::MAX_VALUE` / `varint::encoded_len(u64)` / `varint::try_encoded_len` / `varint::try_encode_into_vec` / `EncodeError::ValueTooLarge` を削除する (`VarInt` 型が値域を保証するため)。
- `frame::encoded_frame_len` の戻り値を `usize` から `Option<usize>` に変更し、`Frame::Unknown` 等で VarInt 範囲外フィールドが含まれる場合は嘘の長さを返さないようにする。
- `webtransport::DatagramError::SessionIdOutOfRange` / `webtransport::stream::StreamHeaderDecodeError::SessionIdOutOfRange` を追加し、公開コンストラクタ `Datagram::new` / `StreamHeader::new` で session_id の VarInt 範囲を構造的に保証する。
- `varint::DecodeError` / `EncodeError` / `webtransport::DatagramError` / `webtransport::stream::StreamHeaderDecodeError` に `#[non_exhaustive]` を付与する。
- PBT: `prop_encode_succeeds_for_any_varint` / `prop_short_buffer_returns_buffer_too_short` / `prop_display_matches_u64` / `prop_from_u8_roundtrip` / `prop_from_u16_roundtrip` / `prop_from_u32_roundtrip` / `prop_try_from_u64_value_domain` を追加。
- `src/varint.rs` の単体テストから PBT で代替可能なものを削除し、const 文脈の正常系・エラー文面・64bit ガード付きエラー検査を残す。
- `connection::wt_stream_header_len` / `webtransport::stream` の `UNIDIRECTIONAL_STREAM_TYPE` / `BIDIRECTIONAL_SIGNAL_VALUE` を `VarInt::from_static` 経由で const VarInt 化する。
- `send_settings` / `send_encoded_headers` / `send_body` / `send_goaway` で `encoded_frame_len` と `encode_frame` の整合性を `debug_assert_eq!` で保証する。

## 完了条件

- [x] `VarInt` / `VarIntError` / `from_validated_parts` / `From` / `TryFrom` / `Display` 実装
- [x] `varint` モジュールの公開 API シグネチャ変更と旧 API 削除
- [x] decoder / encoder / connection / webtransport / examples / interop / tests / pbt / fuzz の追従
- [x] 単体テスト + PBT の整備 (issue 0084 受け入れ条件すべて満たす)
- [x] CHANGES.md エントリ追加 (ADD x4 / CHANGE x3)
- [x] `cargo fmt --check` / `cargo clippy -- -D warnings` / `cargo test --workspace --tests --exclude interop_h3 --exclude interop_wt` 全て通過

## 関連 issue

- `issues/closed/0084-add-varint-constructor-type.md`
- 後続: 0085 (Header), 0086 (Settings), 0087 (Frame), 0088 (trybuild + PBT 整合性検証)