### PR TITLE
0086 Setting / SettingsPayload を構築時検査型に変更する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,15 @@
   - @voluntas
 - [ADD] `internal-test` フィーチャーを追加し、PBT / fuzz / 統合テストから検査バイパス API (`Header::from_validated_parts`) を利用できるようにする (通常のアプリケーションでは有効化しない)
   - @voluntas
+- [ADD] `Setting` enum を新設し、SETTINGS パラメータの ID と型安全な値 (`VarInt` または `bool`) を一体で表現する (`#[non_exhaustive]`)
+  - @voluntas
+- [ADD] `UnknownSetting` 構造体を新設し、`Setting::Unknown(UnknownSetting)` のフィールドを
+  private 化することで HTTP/2 専用 ID / 予約 ID が `Setting::Unknown` 経由で構築できない
+  不変条件を保証する
+  - @voluntas
+- [ADD] `SettingError` を新設し、`Setting::from_wire` / `SettingsPayload::add` の検査エラー
+  (HTTP/2 専用 ID / 予約 ID / bool 値域外 / 重複 ID) を構造化エラーで通知する (`#[non_exhaustive]`)
+  - @voluntas
 - [CHANGE] `varint::encode` / `varint::encode_into_vec` / `varint::decode` のシグネチャを `VarInt` を扱う形に変更する
   - @voluntas
 - [CHANGE] `varint::MAX_VALUE` / `varint::encoded_len(u64)` / `varint::try_encoded_len` / `varint::try_encode_into_vec` / `varint::EncodeError::ValueTooLarge` を削除する (`VarInt` 型が値域を保証するため)
@@ -51,6 +60,47 @@
   を `&[Header]` 直受けに変更する
   - @voluntas
 - [CHANGE] `webtransport::ConnectRequest::to_headers` / `webtransport::ConnectResponse::to_headers` の戻り値型を `Result<Vec<Header>, HeaderError>` に変更し、フィールド値の RFC 違反を構造化エラーで通知する
+  - @voluntas
+- [CHANGE] `settings::SettingsId` enum と `webtransport::SettingsId` enum を削除し、`Setting` enum に統合する
+  - @voluntas
+- [CHANGE] `Settings` / `webtransport::Settings` の値フィールドの型を `u64` から `VarInt` に
+  変更し、ビルダーメソッドのシグネチャを `VarInt` 受けに変更する
+  - @voluntas
+- [CHANGE] `Settings::iter()` および `webtransport::Settings::iter()` の戻り値型を
+  `impl Iterator<Item = (u64, u64)>` から `impl Iterator<Item = Setting>` に変更する
+  - @voluntas
+- [CHANGE] `Settings::from_payload` を `&[Setting]` 経由のマッピングに書き換え、bool 値検査と
+  HTTP/2 専用 / 予約 ID 検査を `Setting::from_wire` に集約する。WebTransport 設定は
+  `webtransport::Settings::from_payload(&[Setting])` 経由で組み立てる。重複検出を
+  `SettingsPayload::add` に移したことで失敗経路が無くなり、戻り値型を
+  `Result<Self, Error>` から `Self` に変更する
+  - @voluntas
+- [CHANGE] `webtransport::Settings::from_payload` を `pub fn from_payload(&SettingsPayload) -> Result<Option<Self>, Error>`
+  から `pub(crate) fn from_payload(&[Setting]) -> Option<Self>` に変更する (外部 API から削除)
+  - @voluntas
+- [CHANGE] `Settings::from_limits` のシグネチャを `Result<Self, VarIntError>` に変更し、
+  `Limits` の値が VarInt 範囲外でも panic しないようにする
+  - @voluntas
+- [CHANGE] `frame::SettingsPayload.entries: Vec<(u64, u64)>` (pub フィールド) を private 化し、
+  `settings: Vec<Setting>` + 重複検出用 `HashSet<VarInt>` を内部に保持する。
+  `add(id: u64, value: u64)` のシグネチャを `add(setting: Setting) -> Result<(), SettingError>`
+  に変更し、SETTINGS フレーム内の重複 ID を構築時に弾く (RFC 9114 Section 7.2.4 MUST NOT)。
+  `settings()` / `len()` / `is_empty()` アクセサを提供する
+  - @voluntas
+- [CHANGE] `webtransport::ServerSettingsParams` の各フィールド型を `u64` から `VarInt` に
+  変更し、`DraftVersion::build_*_settings` の panic 経路を解消する
+  - @voluntas
+- [CHANGE] `error::FrameDecodeError::InvalidSettingsId(u64)` を削除し、
+  `InvalidSetting(SettingError)` で HTTP/2 専用 / 予約 / bool 値域外 / 重複 ID の各 SETTINGS
+  検査エラーを単一バリアントで伝播する形に変更する。`core::error::Error::source()` 経由で
+  `SettingError` を辿れるようにする
+  - @voluntas
+- [CHANGE] `error::Error` および `error::FrameDecodeError` に `#[non_exhaustive]` を付与し、
+  将来のバリアント追加を後方互換に保つ
+  - @voluntas
+- [CHANGE] `webtransport::Settings::flow_control_enabled` と
+  `webtransport::Settings::allows_multiple_sessions_with_peer` を削除する
+  (それぞれ `declares_flow_control` / `flow_control_enabled_with_peer` への単純委譲だった)
   - @voluntas
 
 ### misc

--- a/crates/tokio-s2n-quic/examples/wt_echo_client.rs
+++ b/crates/tokio-s2n-quic/examples/wt_echo_client.rs
@@ -2,20 +2,21 @@
 
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
-use shiguredo_http3::webtransport;
+use shiguredo_http3::{VarInt, webtransport};
 use tokio_s2n_quic::{ClientConfig, WtClient};
 
 #[tokio::main]
 async fn main() -> tokio_s2n_quic::Result<()> {
     let remote_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 4433);
 
+    let v = |value: u64| VarInt::new(value).expect("WT settings value must fit VarInt");
     let wt = webtransport::Settings::new()
-        .wt_enabled(1)
+        .wt_enabled(VarInt::from_static(1))
         .enable_webtransport_draft02(true)
-        .webtransport_max_sessions_draft07(1)
-        .wt_initial_max_streams_bidi(100)
-        .wt_initial_max_streams_uni(100)
-        .wt_initial_max_data(1048576);
+        .webtransport_max_sessions_draft07(VarInt::from_static(1))
+        .wt_initial_max_streams_bidi(v(100))
+        .wt_initial_max_streams_uni(v(100))
+        .wt_initial_max_data(v(1_048_576));
     let config = ClientConfig::new(remote_addr, "localhost")
         .insecure()
         .enable_webtransport(wt);

--- a/crates/tokio-s2n-quic/examples/wt_echo_server.rs
+++ b/crates/tokio-s2n-quic/examples/wt_echo_server.rs
@@ -3,7 +3,7 @@
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use rcgen::generate_simple_self_signed;
-use shiguredo_http3::webtransport;
+use shiguredo_http3::{VarInt, webtransport};
 use tokio_s2n_quic::{ServerConfig, WtServer};
 
 fn generate_certificate() -> Result<(String, String), Box<dyn std::error::Error + Send + Sync>> {
@@ -20,13 +20,14 @@ async fn main() -> tokio_s2n_quic::Result<()> {
         .map_err(|e| tokio_s2n_quic::Error::Internal(format!("証明書生成エラー: {e}")))?;
 
     let listen_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 4433);
+    let v = |value: u64| VarInt::new(value).expect("WT settings value must fit VarInt");
     let wt = webtransport::Settings::new()
-        .wt_enabled(1)
+        .wt_enabled(VarInt::from_static(1))
         .enable_webtransport_draft02(true)
-        .webtransport_max_sessions_draft07(1)
-        .wt_initial_max_streams_bidi(100)
-        .wt_initial_max_streams_uni(100)
-        .wt_initial_max_data(1048576);
+        .webtransport_max_sessions_draft07(VarInt::from_static(1))
+        .wt_initial_max_streams_bidi(v(100))
+        .wt_initial_max_streams_uni(v(100))
+        .wt_initial_max_data(v(1_048_576));
     let config = ServerConfig::new(listen_addr, &cert_pem, &key_pem).enable_webtransport(wt);
 
     let mut server = WtServer::bind(config)?;

--- a/crates/tokio-s2n-quic/src/config.rs
+++ b/crates/tokio-s2n-quic/src/config.rs
@@ -42,7 +42,8 @@ impl ServerConfig {
             idle_timeout_ms: 30000,
             peer_bidi_stream_count: 100,
             peer_unidi_stream_count: 3,
-            h3_settings: H3Settings::from_limits(&Limits::default()),
+            h3_settings: H3Settings::from_limits(&Limits::default())
+                .expect("Limits::default() values must fit VarInt (RFC 9000 Section 16)"),
         }
     }
 
@@ -83,7 +84,8 @@ impl ClientConfig {
             idle_timeout_ms: 5000,
             ca_cert_pem: None,
             disable_cert_validation: false,
-            h3_settings: H3Settings::from_limits(&Limits::default()),
+            h3_settings: H3Settings::from_limits(&Limits::default())
+                .expect("Limits::default() values must fit VarInt (RFC 9000 Section 16)"),
             draft_version: DraftVersion::Draft15,
         }
     }

--- a/examples/wt_server/src/main.rs
+++ b/examples/wt_server/src/main.rs
@@ -68,12 +68,15 @@ async fn run_server(listen: &str, reject_connect: bool) -> Result<(), Error> {
     // WebTransport 用の HTTP/3 設定
     // draft-15: SETTINGS_WT_INITIAL_MAX_STREAMS で初期ストリーム上限を通知する
     // 動的な WT_MAX_STREAMS カプセルによる上限更新は未実装のため、初期値を大きく設定する
+    let v = |value: u64| {
+        shiguredo_http3::VarInt::new(value).expect("WT settings value must fit VarInt")
+    };
     let wt_settings = shiguredo_http3::webtransport::Settings::new()
-        .wt_enabled(1)
-        .wt_initial_max_streams_uni(1000)
-        .wt_initial_max_streams_bidi(1000)
+        .wt_enabled(shiguredo_http3::VarInt::from_static(1))
+        .wt_initial_max_streams_uni(v(1000))
+        .wt_initial_max_streams_bidi(v(1000))
         .enable_webtransport_draft02(true)
-        .webtransport_max_sessions_draft07(100);
+        .webtransport_max_sessions_draft07(v(100));
     let h3_settings = shiguredo_http3::Settings::default().enable_webtransport_server(wt_settings);
 
     loop {

--- a/examples/wt_server/src/webtransport.rs
+++ b/examples/wt_server/src/webtransport.rs
@@ -17,7 +17,9 @@ use shiguredo_http3::webtransport::connect::{ConnectRequest, ConnectResponse};
 use shiguredo_http3::webtransport::stream::{
     ClassifiedUniStream, StreamHeader, StreamHeaderDecodeError, classify_uni_stream_checked,
 };
-use shiguredo_http3::{Connection, Event, Settings as H3Settings, SettingsPayload};
+use shiguredo_http3::{
+    Connection, Event, Setting, Settings as H3Settings, SettingsPayload, VarInt,
+};
 use tokio::sync::Notify;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
@@ -993,14 +995,20 @@ fn parse_settings_from_control(buf: &[u8]) -> std::result::Result<H3Settings, Se
         let (value, value_len) = shiguredo_http3::varint::decode(&payload_buf[pos..])
             .map_err(|_| SettingsParseState::Error("settings value decode error".into()))?;
         pos += value_len;
-        let id = id.get();
-        let value = value.get();
-        tracing::info!("WebTransport: client SETTINGS entry: id=0x{id:x}, value={value}");
-        payload.add(id, value);
+        tracing::info!(
+            "WebTransport: client SETTINGS entry: id=0x{:x}, value={}",
+            id.get(),
+            value.get()
+        );
+        let setting = Setting::from_wire(id, value).map_err(|e| {
+            SettingsParseState::Error(format!("invalid client SETTINGS entry: {e}"))
+        })?;
+        payload
+            .add(setting)
+            .map_err(|e| SettingsParseState::Error(format!("settings payload add failed: {e}")))?;
     }
 
-    let settings = H3Settings::from_payload(&payload)
-        .map_err(|e| SettingsParseState::Error(format!("settings parse error: {e}")))?;
+    let settings = H3Settings::from_payload(&payload);
     tracing::info!("WebTransport: client SETTINGS parsed: {settings:?}");
     Ok(settings)
 }
@@ -1008,26 +1016,27 @@ fn parse_settings_from_control(buf: &[u8]) -> std::result::Result<H3Settings, Se
 /// draft バージョンに合わせたサーバー WT 設定を構築する
 fn build_server_wt_settings(draft: DraftVersion) -> shiguredo_http3::webtransport::Settings {
     tracing::info!("WebTransport: building server settings for {draft:?}");
+    let v = |value: u64| VarInt::new(value).expect("WT settings value must fit VarInt");
     match draft {
         DraftVersion::Draft15 => shiguredo_http3::webtransport::Settings::new()
-            .wt_enabled(1)
-            .wt_initial_max_streams_uni(1000)
-            .wt_initial_max_streams_bidi(1000),
+            .wt_enabled(VarInt::from_static(1))
+            .wt_initial_max_streams_uni(v(1000))
+            .wt_initial_max_streams_bidi(v(1000)),
         // Draft-14: Safari 26.4 は 0xc671706a (draft-07) と 0x14e9cd29 (draft-14) の両方を送る。
         // サーバーも両方返すことで、どちらの ID で判定しても WebTransport 対応と認識させる。
         DraftVersion::Draft14 => shiguredo_http3::webtransport::Settings::new()
-            .wt_max_sessions_draft14(100)
-            .webtransport_max_sessions_draft07(100)
-            .wt_initial_max_streams_uni(1000)
-            .wt_initial_max_streams_bidi(1000)
-            .wt_initial_max_data(8 * 1024 * 1024),
+            .wt_max_sessions_draft14(v(100))
+            .webtransport_max_sessions_draft07(v(100))
+            .wt_initial_max_streams_uni(v(1000))
+            .wt_initial_max_streams_bidi(v(1000))
+            .wt_initial_max_data(v(8 * 1024 * 1024)),
         // Draft-07: Safari 26.4 は応答 SETTINGS に draft-14 系の
         // WT_INITIAL_MAX_STREAMS_* / WT_INITIAL_MAX_DATA を含めると
         // H3_REQUEST_CANCELLED (0x10C) で CONNECT をリセットする。
         // (docs/SAFARI_WT.md 参照) 初期フロー制御値はセッション確立後の
         // WT_MAX_STREAMS / WT_MAX_DATA カプセルで通知する。
         DraftVersion::Draft07 => {
-            shiguredo_http3::webtransport::Settings::new().webtransport_max_sessions_draft07(100)
+            shiguredo_http3::webtransport::Settings::new().webtransport_max_sessions_draft07(v(100))
         }
         DraftVersion::Draft02 => {
             shiguredo_http3::webtransport::Settings::new().enable_webtransport_draft02(true)

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -119,7 +119,7 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "shiguredo_http3"
-version = "2026.1.0-canary.0"
+version = "2026.1.0-canary.1"
 
 [[package]]
 name = "shlex"

--- a/fuzz/fuzz_targets/fuzz_settings.rs
+++ b/fuzz/fuzz_targets/fuzz_settings.rs
@@ -2,8 +2,14 @@
 
 use arbitrary::Arbitrary;
 use libfuzzer_sys::fuzz_target;
-use shiguredo_http3::{Settings, SettingsPayload};
+use shiguredo_http3::{Setting, Settings, SettingsPayload, VarInt};
 
+/// fuzz 入力
+///
+/// `Setting::from_wire` で `Err` が返るペアも意図的にスキップせず、`from_wire` 自体の
+/// panic 安全性を検証する。`from_wire` が `Ok` を返したものは `SettingsPayload::add`
+/// に流し込み、重複時のエラーは握り潰して `Settings::from_payload` の panic 安全性を
+/// 検証する。
 #[derive(Debug, Arbitrary)]
 struct FuzzInput {
     entries: Vec<(u64, u64)>,
@@ -12,12 +18,21 @@ struct FuzzInput {
 fuzz_target!(|input: FuzzInput| {
     let mut payload = SettingsPayload::new();
     for (id, value) in input.entries {
-        // HTTP/2 専用設定 ID (0x02-0x05) を除外
-        if matches!(id, 0x02..=0x05) {
+        let Ok(id_v) = VarInt::new(id) else { continue };
+        let Ok(value_v) = VarInt::new(value) else {
             continue;
+        };
+        // from_wire 自体の panic 安全性も同時に検査
+        match Setting::from_wire(id_v, value_v) {
+            Ok(setting) => {
+                // 重複は SettingsPayload::add が拒否するが、panic させない
+                let _ = payload.add(setting);
+            }
+            Err(e) => {
+                // SettingError の Display も panic させない検査
+                let _ = format!("{e}");
+            }
         }
-        payload.add(id, value);
     }
-    // 任意のペイロードに対してパニックしないことを検証
     let _ = Settings::from_payload(&payload);
 });

--- a/interop/wt/src/lib.rs
+++ b/interop/wt/src/lib.rs
@@ -10,13 +10,15 @@ use rcgen::generate_simple_self_signed;
 
 /// テスト用の WebTransport Settings を作成
 pub fn test_wt_settings() -> shiguredo_http3::webtransport::Settings {
+    use shiguredo_http3::VarInt;
+    let v = |value: u64| VarInt::new(value).expect("WT settings value must fit VarInt");
     shiguredo_http3::webtransport::Settings::new()
-        .wt_enabled(1)
+        .wt_enabled(VarInt::from_static(1))
         .enable_webtransport_draft02(true)
-        .webtransport_max_sessions_draft07(1)
-        .wt_initial_max_streams_bidi(100)
-        .wt_initial_max_streams_uni(100)
-        .wt_initial_max_data(1048576)
+        .webtransport_max_sessions_draft07(VarInt::from_static(1))
+        .wt_initial_max_streams_bidi(v(100))
+        .wt_initial_max_streams_uni(v(100))
+        .wt_initial_max_data(v(1_048_576))
 }
 
 /// 共有証明書を生成 (すべての実装で使用)

--- a/issues/closed/0086-change-settings-construct-time-validation.md
+++ b/issues/closed/0086-change-settings-construct-time-validation.md
@@ -1,7 +1,9 @@
 # 0086: Setting / SettingsPayload を構築時検査型に変更する
 
 Created: 2026-05-23
+Completed: 2026-05-23
 Model: Opus 4.7
+Branch: feature/change-settings-construct-time-validation
 
 ## 概要
 
@@ -307,27 +309,53 @@ const BAD: Setting = Setting::QpackMaxTableCapacity(
 
 ## 受け入れ条件
 
-- `Setting` enum が既知パラメータ + `Unknown` variant で定義され、
+注: 設計の初期案から実装段階で変更された項目は「(実装時に変更)」と併記する。
+最終仕様は「## 解決方法」を参照。
+
+- `Setting` enum が既知パラメータ + `Unknown(UnknownSetting)` variant で定義され、
   WebTransport の全 7 コードポイントをカバーしている
+  (実装時に変更: `Unknown` を newtype `UnknownSetting` でラップし、フィールドを
+   private 化することで HTTP/2 専用 / 予約 ID の混入を構造的に防ぐ)
 - `Setting::from_wire` が既知 ID かつ値範囲内で `Ok`、HTTP/2 専用 / 予約済み /
   bool 値範囲外で `Err(SettingError)` を返す
 - `SettingError` のフィールド型が `VarInt` になっている
+- `SettingError` に `DuplicateId { id: VarInt }` を追加し、SETTINGS フレーム内の
+  重複 ID 検出も `SettingError` で表現する
+  (実装時に変更: 当初は `FrameDecodeError::DuplicateSettingsId` を予定したが、
+   `SettingsPayload::add` で重複を構築時に弾くため `SettingError::DuplicateId` に統合)
 - `Setting::as_wire` が wire 表現 `(VarInt, VarInt)` を返す
 - `SettingsId` enum (src/settings.rs) が削除されている
 - `webtransport::SettingsId` enum も `Setting` enum に統合され削除されている
 - `MaxFieldSectionSize` 型は導入せず `VarInt` を直接使用している
-- `FrameDecodeError::InvalidSettingsId` が削除され、
-  代わりに `DuplicateSettingsId { id: VarInt }` が追加されている
-- decoder の `seen_ids` 重複チェックが維持され、`DuplicateSettingsId` を返す
+- `FrameDecodeError::InvalidSettingsId` が削除され、`InvalidSetting(SettingError)`
+  で HTTP/2 専用 / 予約 / bool 値域外 / 重複 ID の全 SETTINGS 検査エラーを伝播する
+- decoder は重複 ID を `SettingsPayload::add(setting)` で弾き、エラーは
+  `SettingError::DuplicateId { id }` 経由で報告する
 - `SettingError` が `Display` + `std::error::Error` を実装している
 - `SettingsPayload.entries` が `Vec<Setting>` 型で private 化されている
-- `SettingsPayload::add` が `(setting: Setting)` を受け取るシグネチャになっている
-- `Settings::from_payload` で重複パラメータが `H3_SETTINGS_ERROR` を返す
+- `SettingsPayload::add` が `(setting: Setting) -> Result<(), SettingError>` の
+  シグネチャになっている (重複検出を内部で行う)
+  (実装時に変更: 当初は `add(setting: Setting)` (戻り値なし) を予定したが、
+   構築時に重複を弾くため `Result` 化)
+- `Settings::from_payload` は失敗しない (`Self` を返す)。重複検出は
+  `SettingsPayload::add` 側に集約済み
 - `webtransport::Settings::from_payload` が `&[Setting]` を受け取る形に変更されている
-- `Settings::iter()` が `impl Iterator<Item = Setting> + '_` を返す
-- `Settings::from_limits` が `VarInt::new().unwrap()` 経由で変換している
+  (`pub` → `pub(crate)`、戻り値 `Result<Option<Self>, Error>` → `Option<Self>`)
+- `Settings::iter()` および `webtransport::Settings::iter()` が
+  `impl Iterator<Item = Setting> + '_` を返す
+- `Settings::from_limits` が `Result<Self, VarIntError>` を返し、`Limits` の値が
+  VarInt 範囲外でも panic しない
+  (実装時に変更: 当初は `VarInt::new().unwrap()` で済ます予定だったが、堅牢性を
+   優先して `Result` 化)
+- `webtransport::ServerSettingsParams` のフィールド型を `u64` から `VarInt` に
+  変更し、ビルダーで `expect` で panic する経路を解消する (実装時に追加)
+- `Error` および `FrameDecodeError` に `#[non_exhaustive]` を付与し、将来の
+  バリアント追加を後方互換に保つ (実装時に追加)
+- `webtransport::Settings::flow_control_enabled` および
+  `allows_multiple_sessions_with_peer` を削除する (実装時に追加、死にコード)
 - 既存の全テスト・PBT・fuzz が通る
-- PBT の不正値注入テストが `Setting::from_wire` の単体テストへ移行されている
+- PBT の不正値注入テスト (HTTP/2 専用 ID / bool 不正値) は単体テストと役割重複
+  していたため削除し、`SettingsPayload::add` の重複検出 PBT (variant 横断) に置換
 
 ## 依存
 
@@ -339,3 +367,81 @@ const BAD: Setting = Setting::QpackMaxTableCapacity(
 - [[0085-change-header-construct-time-validation]]
 - [[0087-change-frame-construct-time-validation]] (SettingsPayload を共有)
 - [[0088-add-trybuild-and-pbt-construct-time-validation]] (`from_static` の compile_fail テスト)
+
+## 解決方法
+
+### `Setting` enum / `SettingError` の新設 (`src/settings.rs`)
+
+- `Setting` enum (`#[non_exhaustive]`) に 12 個の既知 variant と `Unknown(UnknownSetting)` を追加し、ID と型安全な値 (`VarInt` または `bool`) を一体で保持する形にした
+- `UnknownSetting` 構造体を private フィールド (`id: VarInt`, `value: VarInt`) + アクセサで定義し、`Setting::Unknown` への直接構築経路を `Setting::from_wire` の検査済みパスに限定。HTTP/2 専用 ID / 予約 ID が `Unknown` 経由で混入できない不変条件を保証
+- `SettingError` (`#[non_exhaustive]`) に `Http2OnlyId { id }` / `ReservedId { id }` / `InvalidBooleanValue { id, value }` / `DuplicateId { id }` を定義し、`Display` + `core::error::Error` を実装した
+- `Setting::from_wire(VarInt, VarInt) -> Result<Self, SettingError>` で HTTP/2 専用 ID (0x02-0x05, RFC 9114 §7.2.4.1 + §11.2.2 Table 3) / 予約済み ID (0x00, §11.2.2 Table 3) / bool 値域外を構築時に弾く。未知 ID は `Setting::Unknown(UnknownSetting)` として受理する (RFC 9114 §7.2.4 末尾: MUST ignore)
+- `Setting::as_wire(self) -> (VarInt, VarInt)` と `Setting::id(self) -> VarInt` を提供。bool 値 → VarInt 変換は `as_wire` 内のローカル `const` (`V_ZERO`/`V_ONE`) で行うよう簡素化
+- `is_http2_only_id(u64) -> bool` を `const fn` で公開し、外部からの ID 判定にも利用できるようにした
+
+### `settings::SettingsId` / `webtransport::SettingsId` の削除
+
+- `src/settings.rs` の `SettingsId` enum を完全に削除し、`Setting` enum に統合
+- `src/webtransport/settings.rs` の `SettingsId` enum と `is_webtransport` 関数を削除し、ID 識別を `Setting` enum の variant に置き換え
+- `src/lib.rs` の `pub use settings::SettingsId` を削除して `Setting` / `SettingError` を公開
+- `src/webtransport/mod.rs` の `pub use settings::SettingsId` を削除
+
+### `Settings` / `webtransport::Settings` の VarInt 化
+
+- 値フィールドを `Option<u64>` → `Option<VarInt>` (H3) / `u64` → `VarInt` (WT) に変更
+- ビルダーメソッド (`qpack_max_table_capacity` / `max_field_section_size` / `qpack_blocked_streams` / `wt_enabled` / `wt_initial_max_*` / `wt_max_sessions_draft14` / `webtransport_max_sessions_draft07`) のシグネチャを `VarInt` 受けに変更
+- `Settings::from_limits` を `Result<Self, VarIntError>` に変更し、`Limits` の値が VarInt 範囲外でも panic しないようにした
+- `Settings::iter()` / `webtransport::Settings::iter()` の戻り値型を `(u64, u64)` → `Setting` に変更
+- `webtransport::Settings::from_payload(&[Setting]) -> Option<Self>` を `pub(crate)` で追加し、WebTransport 関連 variant を 1 箇所でマッピングする責務分離を回復
+- `webtransport::Settings::flow_control_enabled` (互換性偽装の単純委譲) と `allows_multiple_sessions_with_peer` (未使用) を削除
+- `webtransport::Settings::iter()` のゼロ判定を `.get() > 0` から `!= VarInt::ZERO` に変更し VarInt 型抽象を保つ
+
+### `SettingsPayload` のフィールド private 化 + 重複検出を構築時に集約
+
+- `entries: Vec<(u64, u64)>` (`pub`) を削除し、`settings: Vec<Setting>` + `seen_ids: HashSet<VarInt>` (private) に置き換え
+- `add(id: u64, value: u64)` → `add(setting: Setting) -> Result<(), SettingError>`。`SettingError::DuplicateId { id }` で同一フレーム内の重複 ID を構築時に弾く (RFC 9114 Section 7.2.4 MUST NOT)
+- `settings()` / `len()` / `is_empty()` アクセサを追加
+- `from_settings(&Settings)` は `add` 経由で組み立てるよう変更 (内部 invariant が常に `add` を通る)
+- 重複検出を `SettingsPayload::add` に集約したことで、decoder 側の `seen_ids` 管理と `Settings::from_payload` 側の重複検出が冗長化していた問題を解消
+
+### `Settings::from_payload` の整理
+
+- `SettingsPayload` 内の各 `Setting` は構築時検査済みかつ ID 重複なしのため、`from_payload` は H3 フィールドへのマッピングと WT 設定の委譲のみに専念
+- WebTransport 関連 variant は `webtransport::Settings::from_payload(&[Setting])` に委譲し、責務を 1 モジュールに集約
+- `Setting::Unknown` は `from_payload` 側で無視 (MUST ignore, RFC 9114 §7.2.4 末尾)
+
+### decoder / encoder の追従
+
+- `src/frame/decoder.rs::decode_settings_frame` から HTTP/2 専用 ID チェック / bool 値検査 / 重複検査を全て削除し、`Setting::from_wire(id, value)?` と `SettingsPayload::add(setting)?` の組合せに集約
+- `src/frame/encoder.rs::encoded_settings_payload_len` と `encode_settings_frame` を `Setting::as_wire()` 経由に書き換え。各 VarInt は `encoded_len()` を直接使えるため `VarInt::new` での再ラップ不要
+- `src/error.rs::FrameDecodeError::InvalidSettingsId(u64)` を削除し、`InvalidSetting(SettingError)` 単一バリアントで HTTP/2 専用 / 予約 / bool 値域外 / 重複 ID の全ての SETTINGS 検査エラーを伝播。`From<SettingError> for FrameDecodeError` および `FrameDecodeError::source()` 実装で `SettingError` を辿れるようにした
+- SETTINGS 検査エラーは `FrameDecodeError::InvalidSetting(SettingError)` 経由でのみ伝播する設計に統一。`From<SettingError> for crate::error::Error` および `Error::Settings(SettingError)` バリアントは dead code (decoder 経路は必ず `FrameDecodeError` を通る) のため新設せず、2 周目のレビューを経て初期案から削除した
+- `src/error.rs::Error` および `FrameDecodeError` に `#[non_exhaustive]` を付与し、本 PR を含めた将来のバリアント追加を後方互換に保つ
+- `src/stream/control.rs` の SETTINGS フレームデコードエラーの分岐を `InvalidSetting` のみで `H3_SETTINGS_ERROR` に変換する形に統一
+
+### connection / WebTransport の追従
+
+- `src/connection/mod.rs` 内の `Settings` フィールド参照 (`qpack_max_table_capacity` / `qpack_blocked_streams` / `max_field_section_size`) と WT 設定 (`wt_initial_max_streams_*` / `wt_initial_max_data` / `wt_enabled`) を `VarInt::get()` 経由で `u64` 取り出しに変更
+- `Connection::new` 内の `Settings::from_limits(&limits)` は `Limits::default()` のフィールドが静的に VarInt 範囲内のため `.expect("Limits::default() values must fit VarInt (RFC 9000 Section 16)")` で受ける
+- `src/webtransport/connect.rs` の `ServerSettingsParams` のフィールド型を `u64` から `VarInt` に変更し、`Default` 実装も `VarInt::from_static(...)` で構築。`DraftVersion::build_server_settings` / `build_client_settings` の panic 経路 (`params_varint` ヘルパー経由の `expect`) を完全に解消
+
+### テスト整備
+
+- `src/settings.rs` の `#[cfg(test)] mod tests` に `Setting::from_wire` / `as_wire` / 各 variant の境界 / HTTP/2 専用 / 予約 / bool 不正値 / 未知 ID (`UnknownSetting` アクセサ経由) / `SettingError::Display` / `SettingsPayload::add` の重複検出 / `Setting::Unknown` の無視 / `from_limits` の VarInt 範囲外エラーを網羅
+- `src/webtransport/settings.rs` の `#[cfg(test)] mod tests` を VarInt 化し、`from_payload(&[Setting])` の WT variant 反映 / 非 WT variant 無視 / Unknown 無視 / WT エントリ無し時 `None` 返却を検証
+- `src/frame/decoder.rs::tests` に `ReservedId` / `InvalidBooleanValue(0x08)` / `InvalidBooleanValue(0x33)` の decoder エラーパス単体テストを追加
+- `pbt/tests/prop_settings.rs` を全面的に書き直し、Strategy で生成する VarInt 中規模域 (`0..2^30`) でラウンドトリップ / iter 合計 / `enable_webtransport_server` の自動設定 / `webtransport_draft_pattern` 一貫性を検証。`Setting::from_wire` の wire ↔ Setting ラウンドトリップは VarInt 全域 (`arbitrary_varint_full`) で叩き、`encoded_settings_payload_len` の合算境界もカバー。`SettingsPayload::add` の重複検出を PBT で検証
+- HTTP/2 専用 ID / bool 不正値の PBT は単体テストと重複していたため削除 (CLAUDE.md「PBT で実現できるものを単体テストで書かない / 単体テストで十分なものを PBT に書かない」の役割分担遵守)
+- `pbt/tests/prop_frame.rs::valid_settings_entries` の ID プールに WebTransport 系 ID (0x2b61 / 0x2b64 / 0x2b65 / 0x14e9cd29 / 0x2c7cf000 / 0x2b603742 / 0xc671706a) を追加し、bool 値正規化対象に draft-02 (0x2b603742) を含める
+- `pbt/tests/prop_webtransport.rs` の `SettingsId` 参照を削除し、`Setting` variant ベースの比較に書き換え。`flow_control_enabled` 呼び出しを `declares_flow_control` に置換
+- `fuzz/fuzz_targets/fuzz_settings.rs` を改善し、`Setting::from_wire` 拒否ケースも `Err` パスを意図的に叩いて `SettingError::Display` の panic 安全性まで検証。`Settings::from_payload` 経路への伝播も維持
+- `tests/integration.rs` / `tests/test_webtransport_draft_connect.rs` を VarInt 化 (`vi(u64) -> VarInt` ヘルパー導入)
+
+### サンプル / 相互運用クレートの追従
+
+- `examples/wt_server` (`main.rs` / `webtransport.rs`) / `crates/tokio-s2n-quic/examples/wt_echo_*.rs` / `interop/wt/src/lib.rs` の `webtransport::Settings` ビルダー呼び出しを `VarInt::from_static` / `VarInt::new(_).expect(_)` 経由に書き換え
+- `examples/wt_server/src/webtransport.rs` の SETTINGS パース箇所は `SettingsPayload::add(id, value)` から `Setting::from_wire(id, value)?` + `payload.add(setting)?` の組合せに変更
+
+### CHANGES.md 更新
+
+- `## develop` に `[ADD]` 3 件 (`Setting` / `UnknownSetting` / `SettingError`) と `[CHANGE]` 11 件 (`SettingsId` 削除 / VarInt 化 / `iter()` 戻り値 / `from_payload` 再設計 / `from_limits` Result 化 / `SettingsPayload` private 化 + `add` Result 化 / `ServerSettingsParams` VarInt 化 / `FrameDecodeError` 整理 / `webtransport::Settings::from_payload` の `pub` → `pub(crate)` 化 / `Error` / `FrameDecodeError` `#[non_exhaustive]` 付与 / `flow_control_enabled` / `allows_multiple_sessions_with_peer` 削除) を追記

--- a/pbt/tests/prop_frame.rs
+++ b/pbt/tests/prop_frame.rs
@@ -56,15 +56,38 @@ prop_compose! {
 
 prop_compose! {
     /// 有効な SETTINGS エントリを生成
+    ///
+    /// 重複 ID を除外し、bool 値 ID (0x08 / 0x33 / 0x2b603742) は値域を 0/1 に制限する。
+    /// H3 コア (0x01 / 0x06 / 0x07 / 0x08 / 0x33) と WebTransport 拡張 ID を網羅する。
+    /// [`shiguredo_http3::Setting::from_wire`] で構築可能な値のみを返す。
     fn valid_settings_entries()(
         entries in prop::collection::vec(
-            (prop::sample::select(vec![0x01u64, 0x06, 0x07, 0x08, 0x33]), 0u64..65536),
-            0..5
+            (
+                prop::sample::select(vec![
+                    0x01u64, 0x06, 0x07, 0x08, 0x33,
+                    0x2b61, 0x2b64, 0x2b65, 0x14e9cd29, 0x2c7cf000,
+                    0x2b603742, 0xc671706a,
+                ]),
+                0u64..65536,
+            ),
+            0..8
         )
-    ) -> Vec<(u64, u64)> {
-        // 重複を除去
+    ) -> Vec<shiguredo_http3::Setting> {
+        use shiguredo_http3::{Setting, VarInt};
         let mut seen = std::collections::HashSet::new();
-        entries.into_iter().filter(|(k, _)| seen.insert(*k)).collect()
+        entries
+            .into_iter()
+            .filter(|(k, _)| seen.insert(*k))
+            .map(|(id, value)| {
+                let normalized = if matches!(id, 0x08 | 0x33 | 0x2b603742) {
+                    value & 1
+                } else {
+                    value
+                };
+                Setting::from_wire(VarInt::new(id).unwrap(), VarInt::new(normalized).unwrap())
+                    .unwrap()
+            })
+            .collect()
     }
 }
 
@@ -205,9 +228,10 @@ proptest! {
     /// Property: SETTINGS フレームのエンコード/デコードラウンドトリップ
     #[test]
     fn prop_settings_frame_roundtrip(entries in valid_settings_entries()) {
+        // valid_settings_entries() は重複 ID を除外済みのため `add` は必ず Ok
         let mut payload = SettingsPayload::new();
-        for (id, value) in &entries {
-            payload.add(*id, *value);
+        for setting in &entries {
+            payload.add(*setting).unwrap();
         }
         let frame = Frame::Settings(payload);
 
@@ -219,12 +243,9 @@ proptest! {
         prop_assert_eq!(encoded_len, decoded_len);
 
         if let Frame::Settings(settings) = decoded {
-            prop_assert_eq!(
-                settings.entries.len(), entries.len(),
-                "Settings count mismatch"
-            );
-            for (orig, decoded) in entries.iter().zip(settings.entries.iter()) {
-                prop_assert_eq!(orig, decoded, "Settings entry mismatch");
+            prop_assert_eq!(settings.settings().len(), entries.len());
+            for (orig, decoded) in entries.iter().zip(settings.settings().iter()) {
+                prop_assert_eq!(orig, decoded);
             }
         } else {
             prop_assert!(false, "Expected SETTINGS frame");
@@ -244,7 +265,7 @@ proptest! {
         prop_assert_eq!(encoded_len, decoded_len);
 
         if let Frame::Settings(settings) = decoded {
-            prop_assert!(settings.entries.is_empty());
+            prop_assert!(settings.is_empty());
         } else {
             prop_assert!(false, "Expected SETTINGS frame");
         }

--- a/pbt/tests/prop_settings.rs
+++ b/pbt/tests/prop_settings.rs
@@ -1,24 +1,59 @@
-//! Property-Based Testing for HTTP/3 Settings (RFC 9114 Section 7.2.4)
+//! Property-Based Testing for HTTP/3 Settings (RFC 9114 §7.2.4)
+//!
+//! 値域や bool 値検査は `Setting::from_wire` 側で構築時に検査されるため、
+//! 不正値の単体テストは `src/settings.rs` の `#[cfg(test)]` に移してある。
+//! 本ファイルは Strategy で構築した正常値が SettingsPayload とのラウンドトリップ /
+//! `Setting::from_wire` ↔ `Setting::as_wire` の対称性を満たすことを検査する。
 
 use proptest::prelude::*;
-use shiguredo_http3::Settings;
-use shiguredo_http3::error::{Error, ErrorCode};
 use shiguredo_http3::frame::SettingsPayload;
-use shiguredo_http3::webtransport;
+use shiguredo_http3::{Setting, SettingError, Settings, VarInt, webtransport};
 
-// =============================================================================
-// Strategy ヘルパー
-// =============================================================================
+fn vi(value: u64) -> VarInt {
+    VarInt::new(value).unwrap()
+}
+
+// `arbitrary_settings` / `arbitrary_wt_settings` で生成する範囲は中規模 (`1 << 30`)
+// に絞り、Strategy ノイズを抑える。`prop_setting_wire_roundtrip` 等で VarInt
+// 全域を叩く場合は別 Strategy (`arbitrary_varint_full`) を用いる。
+const VARINT_TEST_MAX: u64 = 1 << 30;
+
+prop_compose! {
+    fn arbitrary_varint()(value in 0u64..VARINT_TEST_MAX) -> VarInt {
+        vi(value)
+    }
+}
+
+prop_compose! {
+    /// VarInt 全域 (`0..=VarInt::MAX`) を生成する Strategy
+    fn arbitrary_varint_full()(value in 0u64..=VarInt::MAX.get()) -> VarInt {
+        vi(value)
+    }
+}
+
+/// `Setting::from_wire` で受理される ID のみを生成する Strategy
+///
+/// HTTP/2 専用 ID (0x02..=0x05) と予約 ID (0x00) を Strategy 段階で除外し、
+/// `prop_assume!` の reject カウンタ消費を回避する。
+fn settable_id() -> impl Strategy<Value = VarInt> {
+    arbitrary_varint_full().prop_filter(
+        "HTTP/2 専用 ID と予約 ID は構築時拒否されるため除外",
+        |v| {
+            let raw = v.get();
+            raw != 0 && !matches!(raw, 0x02..=0x05)
+        },
+    )
+}
 
 prop_compose! {
     /// 任意の webtransport::Settings を生成
     fn arbitrary_wt_settings()(
-        wt_enabled in 0u64..256,
-        wt_initial_max_streams_uni in 0u64..256,
-        wt_initial_max_streams_bidi in 0u64..256,
-        wt_initial_max_data in 0u64..1_000_000,
+        wt_enabled in arbitrary_varint(),
+        wt_initial_max_streams_uni in arbitrary_varint(),
+        wt_initial_max_streams_bidi in arbitrary_varint(),
+        wt_initial_max_data in arbitrary_varint(),
         enable_webtransport_draft02 in proptest::option::of(any::<bool>()),
-        webtransport_max_sessions_draft07 in proptest::option::of(0u64..256),
+        webtransport_max_sessions_draft07 in proptest::option::of(arbitrary_varint()),
     ) -> webtransport::Settings {
         let mut wt = webtransport::Settings::new()
             .wt_enabled(wt_enabled)
@@ -38,9 +73,9 @@ prop_compose! {
 prop_compose! {
     /// 任意の Settings を生成 (各フィールドが Some または None)
     fn arbitrary_settings()(
-        qpack_max_table_capacity in proptest::option::of(0u64..65536),
-        max_field_section_size in proptest::option::of(0u64..1_000_000),
-        qpack_blocked_streams in proptest::option::of(0u64..256),
+        qpack_max_table_capacity in proptest::option::of(arbitrary_varint()),
+        max_field_section_size in proptest::option::of(arbitrary_varint()),
+        qpack_blocked_streams in proptest::option::of(arbitrary_varint()),
         enable_connect_protocol in proptest::option::of(any::<bool>()),
         h3_datagram in proptest::option::of(any::<bool>()),
         wt_settings in proptest::option::of(arbitrary_wt_settings()),
@@ -68,53 +103,29 @@ prop_compose! {
     }
 }
 
-// =============================================================================
-// (a) Settings → SettingsPayload → Settings ラウンドトリップ
-// =============================================================================
-
 proptest! {
     /// Property: Settings を SettingsPayload に変換して from_payload で復元すると元と一致する
     #[test]
     fn prop_settings_roundtrip(settings in arbitrary_settings()) {
-        // H3 + WT の全エントリを SettingsPayload に入れる
         let payload = SettingsPayload::from_settings(&settings);
+        let restored = Settings::from_payload(&payload);
 
-        // ビルダーで構築した Settings は必ず有効な値のみ含むため unwrap 可
-        let restored = Settings::from_payload(&payload).unwrap();
+        prop_assert_eq!(settings.qpack_max_table_capacity, restored.qpack_max_table_capacity);
+        prop_assert_eq!(settings.max_field_section_size, restored.max_field_section_size);
+        prop_assert_eq!(settings.qpack_blocked_streams, restored.qpack_blocked_streams);
+        prop_assert_eq!(settings.enable_connect_protocol, restored.enable_connect_protocol);
+        prop_assert_eq!(settings.h3_datagram, restored.h3_datagram);
 
-        // H3 フィールド比較
-        prop_assert_eq!(
-            settings.qpack_max_table_capacity, restored.qpack_max_table_capacity,
-            "qpack_max_table_capacity が不一致"
-        );
-        prop_assert_eq!(
-            settings.max_field_section_size, restored.max_field_section_size,
-            "max_field_section_size が不一致"
-        );
-        prop_assert_eq!(
-            settings.qpack_blocked_streams, restored.qpack_blocked_streams,
-            "qpack_blocked_streams が不一致"
-        );
-        prop_assert_eq!(
-            settings.enable_connect_protocol, restored.enable_connect_protocol,
-            "enable_connect_protocol が不一致"
-        );
-        prop_assert_eq!(
-            settings.h3_datagram, restored.h3_datagram,
-            "h3_datagram が不一致"
-        );
-
-        // enable_webtransport() で wt_settings を設定した場合、
+        // enable_webtransport_server() で wt_settings を設定した場合、
         // enable_connect_protocol と h3_datagram も自動設定されるため、
         // from_payload 側では wt_settings の有無が元と一致することを確認する。
         // ただし iter() は 0 の値を出力しないため、全フィールドが 0 の wt_settings は
-        // from_payload で None になる点に注意。
+        // from_payload で None になる。
         match (&settings.wt_settings, &restored.wt_settings) {
             (Some(orig), Some(rest)) => {
                 prop_assert_eq!(orig, rest, "wt_settings が不一致");
             }
             (Some(orig), None) => {
-                // 全フィールドがデフォルト (0/None) なら iter() が空になるので None は正常
                 prop_assert!(
                     orig.iter().count() == 0,
                     "元の wt_settings にエントリがあるのに復元が None"
@@ -128,10 +139,6 @@ proptest! {
     }
 }
 
-// =============================================================================
-// (b) iter() の要素数と len() が一致
-// =============================================================================
-
 proptest! {
     /// Property: Settings::len() は H3 + WT のエントリ合計数と一致する
     #[test]
@@ -142,20 +149,12 @@ proptest! {
             .map(|wt| wt.iter().count())
             .unwrap_or(0);
         let total = h3_count + wt_count;
-        let len = settings.len();
-        prop_assert_eq!(
-            total, len,
-            "iter 合計 ({}) と len() ({}) が不一致", total, len
-        );
+        prop_assert_eq!(total, settings.len());
     }
 }
 
-// =============================================================================
-// (c) enable_webtransport で必要な設定が全て有効
-// =============================================================================
-
 proptest! {
-    /// Property: enable_webtransport(wt) 後は is_webtransport_enabled() == true かつ
+    /// Property: enable_webtransport_server(wt) 後は is_webtransport_enabled() == true かつ
     ///           enable_connect_protocol と h3_datagram が Some(true)
     #[test]
     fn prop_enable_webtransport_sets_required_fields(
@@ -165,27 +164,11 @@ proptest! {
         )
     ) {
         let settings = Settings::new().enable_webtransport_server(wt_settings);
-
-        prop_assert!(
-            settings.is_webtransport_enabled(),
-            "enable_webtransport 後に is_webtransport_enabled() が false"
-        );
-        prop_assert_eq!(
-            settings.enable_connect_protocol,
-            Some(true),
-            "enable_connect_protocol が Some(true) でない"
-        );
-        prop_assert_eq!(
-            settings.h3_datagram,
-            Some(true),
-            "h3_datagram が Some(true) でない"
-        );
+        prop_assert!(settings.is_webtransport_enabled());
+        prop_assert_eq!(settings.enable_connect_protocol, Some(true));
+        prop_assert_eq!(settings.h3_datagram, Some(true));
     }
 }
-
-// =============================================================================
-// (d) webtransport_draft_pattern は wt_settings.detect_draft_pattern() と一致
-// =============================================================================
 
 proptest! {
     /// Property: Settings::webtransport_draft_pattern() は
@@ -196,68 +179,67 @@ proptest! {
             .as_ref()
             .and_then(|wt| wt.detect_draft_pattern());
         let actual = settings.webtransport_draft_pattern();
-        prop_assert_eq!(
-            actual, expected,
-            "webtransport_draft_pattern() が wt_settings.detect_draft_pattern() と不一致"
-        );
+        prop_assert_eq!(actual, expected);
     }
 }
 
-// =============================================================================
-// (e) ブール SETTINGS の不正値で H3_SETTINGS_ERROR
-// =============================================================================
+proptest! {
+    /// Property: `Setting::from_wire` → `as_wire` → `from_wire` のラウンドトリップ
+    ///
+    /// VarInt 全域 (`encoded_settings_payload_len` の合算境界含む) を叩く。
+    /// HTTP/2 専用 / 予約 ID は Strategy 段で除外して shrink ノイズを抑える。
+    #[test]
+    fn prop_setting_wire_roundtrip(
+        id in settable_id(),
+        value in arbitrary_varint_full(),
+    ) {
+        // bool 値 ID の場合は値域を 0/1 に正規化する
+        let id_raw = id.get();
+        let bool_ids = [0x08u64, 0x33, 0x2b603742];
+        let value = if bool_ids.contains(&id_raw) {
+            vi(value.get() & 1)
+        } else {
+            value
+        };
+        let setting = Setting::from_wire(id, value).unwrap();
+        let (id2, value2) = setting.as_wire();
+        prop_assert_eq!(id, id2);
+        prop_assert_eq!(value, value2);
+        let restored = Setting::from_wire(id2, value2).unwrap();
+        prop_assert_eq!(setting, restored);
+    }
+}
+
+/// 任意の `Setting` variant を 1 つ生成する Strategy
+///
+/// HTTP/2 専用 / 予約 ID は `Setting::from_wire` で構築不可のため除外。
+/// 重複検出 PBT で variant 全体に検査が及ぶことを保証するために定義する。
+fn arbitrary_setting() -> impl Strategy<Value = Setting> {
+    prop_oneof![
+        arbitrary_varint().prop_map(Setting::QpackMaxTableCapacity),
+        arbitrary_varint().prop_map(Setting::MaxFieldSectionSize),
+        arbitrary_varint().prop_map(Setting::QpackBlockedStreams),
+        any::<bool>().prop_map(Setting::EnableConnectProtocol),
+        any::<bool>().prop_map(Setting::H3Datagram),
+        arbitrary_varint().prop_map(Setting::WtEnabled),
+        arbitrary_varint().prop_map(Setting::WtMaxSessionsDraft14),
+        any::<bool>().prop_map(Setting::EnableWebTransportDraft02),
+        arbitrary_varint().prop_map(Setting::WebTransportMaxSessionsDraft07),
+        arbitrary_varint().prop_map(Setting::WtInitialMaxData),
+        arbitrary_varint().prop_map(Setting::WtInitialMaxStreamsUni),
+        arbitrary_varint().prop_map(Setting::WtInitialMaxStreamsBidi),
+    ]
+}
 
 proptest! {
-    /// Property: SETTINGS_ENABLE_CONNECT_PROTOCOL (0x08) に 2 以上の値を設定すると
-    /// H3_SETTINGS_ERROR が返る (RFC 8441 Section 3)
+    /// Property: 任意の `Setting` variant を 2 回 `add` すると `DuplicateId { id }`
+    /// エラーが返る (variant 横断で `Setting::id()` ベースの重複検出が機能することを検証)
     #[test]
-    fn prop_enable_connect_protocol_invalid_value(value in 2u64..=u64::MAX) {
+    fn prop_settings_payload_add_duplicate_rejected(setting in arbitrary_setting()) {
+        use shiguredo_http3::frame::SettingsPayload;
         let mut payload = SettingsPayload::new();
-        payload.add(0x08, value);
-        let result = Settings::from_payload(&payload);
-        match result {
-            Err(Error::ConnectionError(ErrorCode::SettingsError)) => {}
-            other => prop_assert!(
-                false,
-                "0x08 に値 {} を設定したとき H3_SETTINGS_ERROR を期待したが {:?} が返った",
-                value, other
-            ),
-        }
+        payload.add(setting).unwrap();
+        let err = payload.add(setting).unwrap_err();
+        prop_assert_eq!(err, SettingError::DuplicateId { id: setting.id() });
     }
-
-    /// Property: SETTINGS_H3_DATAGRAM (0x33) に 2 以上の値を設定すると
-    /// H3_SETTINGS_ERROR が返る (RFC 9297 Section 2.1.1)
-    #[test]
-    fn prop_h3_datagram_invalid_value(value in 2u64..=u64::MAX) {
-        let mut payload = SettingsPayload::new();
-        payload.add(0x33, value);
-        let result = Settings::from_payload(&payload);
-        match result {
-            Err(Error::ConnectionError(ErrorCode::SettingsError)) => {}
-            other => prop_assert!(
-                false,
-                "0x33 に値 {} を設定したとき H3_SETTINGS_ERROR を期待したが {:?} が返った",
-                value, other
-            ),
-        }
-    }
-
-    /// Property: SETTINGS_ENABLE_WEBTRANSPORT_DRAFT02 (0x2b603742) に 2 以上の値を設定すると
-    /// H3_SETTINGS_ERROR が返る
-    /// (draft-ietf-webtrans-http3-02 由来、将来変更される可能性がある)
-    #[test]
-    fn prop_enable_webtransport_draft02_invalid_value(value in 2u64..=u64::MAX) {
-        let mut payload = SettingsPayload::new();
-        payload.add(0x2b603742, value);
-        let result = Settings::from_payload(&payload);
-        match result {
-            Err(Error::ConnectionError(ErrorCode::SettingsError)) => {}
-            other => prop_assert!(
-                false,
-                "0x2b603742 に値 {} を設定したとき H3_SETTINGS_ERROR を期待したが {:?} が返った",
-                value, other
-            ),
-        }
-    }
-
 }

--- a/pbt/tests/prop_webtransport.rs
+++ b/pbt/tests/prop_webtransport.rs
@@ -3,9 +3,10 @@
 use proptest::prelude::*;
 use shiguredo_http3::webtransport::{
     ApplicationErrorCode, Capsule, ConnectRequest, ConnectResponse, Datagram, Error, ErrorCode,
-    FlowControlLimits, MAX_STREAMS_LIMIT, Session, SessionState, Settings, SettingsId, Stream,
-    StreamHeader, stream_type,
+    FlowControlLimits, MAX_STREAMS_LIMIT, Session, SessionState, Settings, Stream, StreamHeader,
+    stream_type,
 };
+use shiguredo_http3::{Setting, VarInt};
 
 // =============================================================================
 // Capsule Properties
@@ -819,8 +820,8 @@ proptest! {
     /// Property: wt_enabled のみではフロー制御無効 (draft-15)
     #[test]
     fn prop_settings_flow_control_wt_enabled_only(wt_enabled in 1u64..100) {
-        let settings = Settings::new().wt_enabled(wt_enabled);
-        prop_assert!(!settings.flow_control_enabled());
+        let settings = Settings::new().wt_enabled(VarInt::new(wt_enabled).unwrap());
+        prop_assert!(!settings.declares_flow_control());
     }
 
     /// Property: INITIAL_MAX_* が 0 以外ならフロー制御有効 (draft-15)
@@ -830,23 +831,24 @@ proptest! {
         max_streams_bidi in 1u64..100,
         max_data in 1u64..100000,
     ) {
+        let v = |x: u64| VarInt::new(x).unwrap();
         // max_streams_uni != 0
         let settings = Settings::new()
-            .wt_enabled(1)
-            .wt_initial_max_streams_uni(max_streams_uni);
-        prop_assert!(settings.flow_control_enabled());
+            .wt_enabled(VarInt::from_static(1))
+            .wt_initial_max_streams_uni(v(max_streams_uni));
+        prop_assert!(settings.declares_flow_control());
 
         // max_streams_bidi != 0
         let settings = Settings::new()
-            .wt_enabled(1)
-            .wt_initial_max_streams_bidi(max_streams_bidi);
-        prop_assert!(settings.flow_control_enabled());
+            .wt_enabled(VarInt::from_static(1))
+            .wt_initial_max_streams_bidi(v(max_streams_bidi));
+        prop_assert!(settings.declares_flow_control());
 
         // max_data != 0
         let settings = Settings::new()
-            .wt_enabled(1)
-            .wt_initial_max_data(max_data);
-        prop_assert!(settings.flow_control_enabled());
+            .wt_enabled(VarInt::from_static(1))
+            .wt_initial_max_data(v(max_data));
+        prop_assert!(settings.declares_flow_control());
     }
 
     /// Property: 全て 0 または wt_enabled = 0 なら無効
@@ -854,7 +856,7 @@ proptest! {
     fn prop_settings_disabled_when_zero(_dummy in Just(())) {
         let settings = Settings::new();
         prop_assert!(!settings.is_enabled());
-        prop_assert!(!settings.flow_control_enabled());
+        prop_assert!(!settings.declares_flow_control());
     }
 }
 
@@ -1476,31 +1478,33 @@ proptest! {
         max_streams_bidi in 0u64..1000,
         max_data in 0u64..100000,
     ) {
+        let v = |x: u64| VarInt::new(x).unwrap();
         let settings = Settings::new()
-            .wt_enabled(max_sessions)
-            .wt_initial_max_streams_uni(max_streams_uni)
-            .wt_initial_max_streams_bidi(max_streams_bidi)
-            .wt_initial_max_data(max_data);
+            .wt_enabled(v(max_sessions))
+            .wt_initial_max_streams_uni(v(max_streams_uni))
+            .wt_initial_max_streams_bidi(v(max_streams_bidi))
+            .wt_initial_max_data(v(max_data));
 
-        let entries: Vec<(u64, u64)> = settings.iter().collect();
+        let entries: Vec<Setting> = settings.iter().collect();
 
-        // 0 の値は含まれない
-        for &(_, v) in &entries {
-            prop_assert!(v > 0, "iter() should not include zero values");
+        // 0 の値は含まれない (`iter` は 0 をスキップする)
+        for e in &entries {
+            let (_, val) = e.as_wire();
+            prop_assert!(val.get() > 0);
         }
 
         // 0 でない値は全て含まれる
         if max_sessions > 0 {
-            prop_assert!(entries.contains(&(SettingsId::WtEnabled as u64, max_sessions)));
+            prop_assert!(entries.contains(&Setting::WtEnabled(v(max_sessions))));
         }
         if max_streams_uni > 0 {
-            prop_assert!(entries.contains(&(SettingsId::WtInitialMaxStreamsUni as u64, max_streams_uni)));
+            prop_assert!(entries.contains(&Setting::WtInitialMaxStreamsUni(v(max_streams_uni))));
         }
         if max_streams_bidi > 0 {
-            prop_assert!(entries.contains(&(SettingsId::WtInitialMaxStreamsBidi as u64, max_streams_bidi)));
+            prop_assert!(entries.contains(&Setting::WtInitialMaxStreamsBidi(v(max_streams_bidi))));
         }
         if max_data > 0 {
-            prop_assert!(entries.contains(&(SettingsId::WtInitialMaxData as u64, max_data)));
+            prop_assert!(entries.contains(&Setting::WtInitialMaxData(v(max_data))));
         }
 
         // エントリ数は 0 でないフィールド数と一致

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -53,6 +53,7 @@ use crate::qpack::{
 use crate::settings::Settings;
 use crate::stream::request::{RawReceivedData, RequestStream};
 use crate::stream::{ControlStreamRecv, ControlStreamSend, StreamKind, StreamState};
+use crate::varint::VarInt;
 use crate::webtransport::error::ErrorCode as WtErrorCode;
 use crate::webtransport::session::{DataFlowControl, DirectionalStreamFlowControl};
 
@@ -221,34 +222,34 @@ impl WtSession {
             return;
         }
         self.recv_stream_fc_uni = Some(DirectionalStreamFlowControl::new(
-            local_wt.wt_initial_max_streams_uni,
+            local_wt.wt_initial_max_streams_uni.get(),
         ));
         self.recv_stream_fc_bidi = Some(DirectionalStreamFlowControl::new(
-            local_wt.wt_initial_max_streams_bidi,
+            local_wt.wt_initial_max_streams_bidi.get(),
         ));
-        self.recv_data_fc = Some(DataFlowControl::new(local_wt.wt_initial_max_data));
+        self.recv_data_fc = Some(DataFlowControl::new(local_wt.wt_initial_max_data.get()));
 
         if !queue_initial_capsules {
             return;
         }
-        if local_wt.wt_initial_max_streams_bidi > 0 {
+        if local_wt.wt_initial_max_streams_bidi.get() > 0 {
             self.pending_capsules
                 .push(crate::webtransport::Capsule::MaxStreams {
                     bidirectional: true,
-                    maximum: local_wt.wt_initial_max_streams_bidi,
+                    maximum: local_wt.wt_initial_max_streams_bidi.get(),
                 });
         }
-        if local_wt.wt_initial_max_streams_uni > 0 {
+        if local_wt.wt_initial_max_streams_uni.get() > 0 {
             self.pending_capsules
                 .push(crate::webtransport::Capsule::MaxStreams {
                     bidirectional: false,
-                    maximum: local_wt.wt_initial_max_streams_uni,
+                    maximum: local_wt.wt_initial_max_streams_uni.get(),
                 });
         }
-        if local_wt.wt_initial_max_data > 0 {
+        if local_wt.wt_initial_max_data.get() > 0 {
             self.pending_capsules
                 .push(crate::webtransport::Capsule::MaxData {
-                    maximum: local_wt.wt_initial_max_data,
+                    maximum: local_wt.wt_initial_max_data.get(),
                 });
         }
     }
@@ -621,8 +622,10 @@ impl Connection {
         let mut limits = Limits::default();
 
         // 引数の settings を使用して SETTINGS を送信
-        // デフォルトの QPACK 設定と引数の WebTransport 設定をマージ
-        let mut local_settings = Settings::from_limits(&limits);
+        // デフォルトの QPACK 設定と引数の WebTransport 設定をマージ。
+        // `Limits::default()` のフィールドは静的に VarInt 範囲内のため `expect`。
+        let mut local_settings = Settings::from_limits(&limits)
+            .expect("Limits::default() values must fit VarInt (RFC 9000 Section 16)");
         if let Some(v) = settings.enable_connect_protocol {
             local_settings.enable_connect_protocol = Some(v);
         }
@@ -645,13 +648,13 @@ impl Connection {
 
         // limits を local_settings と同期 (検証で使用する値が SETTINGS 送信値と一致するようにする)
         if let Some(v) = local_settings.qpack_max_table_capacity {
-            limits.qpack_max_table_capacity = v;
+            limits.qpack_max_table_capacity = v.get();
         }
         if let Some(v) = local_settings.qpack_blocked_streams {
-            limits.qpack_blocked_streams = v;
+            limits.qpack_blocked_streams = v.get();
         }
         if let Some(v) = local_settings.max_field_section_size {
-            limits.max_field_section_size = v;
+            limits.max_field_section_size = v.get();
         }
 
         let mut control_send = ControlStreamSend::new();
@@ -664,14 +667,17 @@ impl Connection {
         };
 
         // QPACK 最大テーブル容量を設定 (local_settings から取得)
-        let max_table_capacity = local_settings.qpack_max_table_capacity.unwrap_or(0);
+        let max_table_capacity = local_settings
+            .qpack_max_table_capacity
+            .map(VarInt::get)
+            .unwrap_or(0);
         let mut encoder_stream_recv = EncoderStreamReceiver::new();
         encoder_stream_recv.set_max_table_capacity(max_table_capacity);
         let mut qpack_dynamic_decoder = DynamicDecoder::new();
         qpack_dynamic_decoder.set_max_table_capacity(max_table_capacity);
         // ローカル設定の max_field_section_size をデコーダーに反映 (RFC 9114 Section 4.2.2)
         if let Some(max_size) = local_settings.max_field_section_size {
-            qpack_dynamic_decoder.set_max_field_section_size(max_size);
+            qpack_dynamic_decoder.set_max_field_section_size(max_size.get());
         }
 
         Self {
@@ -1874,9 +1880,11 @@ impl Connection {
         };
         let advertises = |s: &crate::webtransport::Settings, d: DraftVersion| -> bool {
             match d {
-                DraftVersion::Draft15 => s.wt_enabled > 0,
-                DraftVersion::Draft14 => s.wt_max_sessions_draft14.is_some_and(|v| v > 0),
-                DraftVersion::Draft07 => s.webtransport_max_sessions_draft07.is_some_and(|v| v > 0),
+                DraftVersion::Draft15 => s.wt_enabled.get() > 0,
+                DraftVersion::Draft14 => s.wt_max_sessions_draft14.is_some_and(|v| v.get() > 0),
+                DraftVersion::Draft07 => s
+                    .webtransport_max_sessions_draft07
+                    .is_some_and(|v| v.get() > 0),
                 DraftVersion::Draft02 => s.enable_webtransport_draft02 == Some(true),
             }
         };
@@ -2470,10 +2478,11 @@ impl Connection {
         while let Some(frame) = self.control_recv.process()? {
             match frame {
                 crate::frame::Frame::Settings(payload) => {
-                    let settings = Settings::from_payload(&payload)?;
+                    let settings = Settings::from_payload(&payload);
 
                     // ピアの QPACK 設定をエンコーダーに適用
                     if let Some(capacity) = settings.qpack_max_table_capacity {
+                        let capacity = capacity.get();
                         self.qpack_encoder.set_max_table_capacity(capacity);
                         self.encoder_stream.set_max_table_capacity(capacity);
                         // 実際に使用するテーブル容量を設定
@@ -2499,7 +2508,8 @@ impl Connection {
                     // ピアの QPACK blocked streams 設定をエンコーダーに適用
                     // (RFC 9204 Section 2.1.2)
                     if let Some(blocked) = settings.qpack_blocked_streams {
-                        self.qpack_encoder.set_peer_max_blocked_streams(blocked);
+                        self.qpack_encoder
+                            .set_peer_max_blocked_streams(blocked.get());
                     }
 
                     let wt_settings = settings.wt_settings;
@@ -3355,7 +3365,9 @@ impl Connection {
         crate::validation::validate_request_headers(headers)?;
 
         // peer の SETTINGS_MAX_FIELD_SECTION_SIZE を超えていないかチェック (RFC 9114 Section 4.2.2)
-        let peer_max = self.peer_settings.and_then(|s| s.max_field_section_size);
+        let peer_max = self
+            .peer_settings
+            .and_then(|s| s.max_field_section_size.map(VarInt::get));
         crate::validation::check_field_section_size(headers, peer_max)?;
 
         // WebTransport CONNECT の場合、peer の WebTransport サポートを確認する
@@ -3499,7 +3511,9 @@ impl Connection {
         crate::validation::validate_response_headers(headers)?;
 
         // peer の SETTINGS_MAX_FIELD_SECTION_SIZE を超えていないかチェック (RFC 9114 Section 4.2.2)
-        let peer_max = self.peer_settings.and_then(|s| s.max_field_section_size);
+        let peer_max = self
+            .peer_settings
+            .and_then(|s| s.max_field_section_size.map(VarInt::get));
         crate::validation::check_field_section_size(headers, peer_max)?;
 
         // WebTransport: 2xx レスポンスの WT-Protocol がクライアントの WT-Available-Protocols に
@@ -3881,7 +3895,11 @@ impl Connection {
     ///
     /// 動的テーブル容量が 0 の場合は送信不要。
     fn send_stream_cancellation_if_needed(&mut self, stream_id: u64) {
-        let max_capacity = self.local_settings.qpack_max_table_capacity.unwrap_or(0);
+        let max_capacity = self
+            .local_settings
+            .qpack_max_table_capacity
+            .map(VarInt::get)
+            .unwrap_or(0);
         if max_capacity == 0 {
             return;
         }
@@ -4229,21 +4247,26 @@ mod tests {
     // (draft-ietf-webtrans-http3-15 Section 4.2)
     // =========================================================================
 
+    /// テスト用の VarInt 構築ショートカット
+    fn vi(value: u64) -> VarInt {
+        VarInt::new(value).unwrap()
+    }
+
     /// WebTransport 有効な Settings を作成するヘルパー
     fn wt_enabled_settings() -> Settings {
-        let wt = crate::webtransport::Settings::new().wt_enabled(1);
+        let wt = crate::webtransport::Settings::new().wt_enabled(vi(1));
         Settings::new().enable_webtransport_server(wt)
     }
 
     fn wt_multi_draft_settings_with_flow_control() -> Settings {
         let wt = crate::webtransport::Settings::new()
-            .wt_enabled(1)
+            .wt_enabled(vi(1))
             .enable_webtransport_draft02(true)
-            .webtransport_max_sessions_draft07(100)
-            .wt_max_sessions_draft14(100)
-            .wt_initial_max_streams_uni(100)
-            .wt_initial_max_streams_bidi(100)
-            .wt_initial_max_data(8 * 1024 * 1024);
+            .webtransport_max_sessions_draft07(vi(100))
+            .wt_max_sessions_draft14(vi(100))
+            .wt_initial_max_streams_uni(vi(100))
+            .wt_initial_max_streams_bidi(vi(100))
+            .wt_initial_max_data(vi(8 * 1024 * 1024));
         Settings::new().enable_webtransport_server(wt)
     }
 
@@ -4876,7 +4899,8 @@ mod tests {
         // サーバーはこれを受理しなければならない
 
         // サーバー: draft-07 対応
-        let server_wt = crate::webtransport::Settings::new().webtransport_max_sessions_draft07(1);
+        let server_wt =
+            crate::webtransport::Settings::new().webtransport_max_sessions_draft07(vi(1));
         let server_settings = Settings::new().enable_webtransport_server(server_wt);
         let mut server = Connection::server(server_settings);
         server.set_control_stream_id(3).unwrap();
@@ -4886,7 +4910,8 @@ mod tests {
 
         // draft-07 クライアントの SETTINGS: H3_DATAGRAM=1 + WEBTRANSPORT_MAX_SESSIONS=1
         // ENABLE_CONNECT_PROTOCOL は含めない (Safari と同じパターン)
-        let client_wt = crate::webtransport::Settings::new().webtransport_max_sessions_draft07(1);
+        let client_wt =
+            crate::webtransport::Settings::new().webtransport_max_sessions_draft07(vi(1));
         // enable_webtransport は enable_connect_protocol を自動設定するので、
         // 手動で None に戻して Safari のパターンを再現する
         let client_settings = Settings {
@@ -4947,7 +4972,7 @@ mod tests {
             .unwrap();
 
         // draft-15 クライアント: ENABLE_CONNECT_PROTOCOL なし (正当)
-        let client_wt = crate::webtransport::Settings::new().wt_enabled(1);
+        let client_wt = crate::webtransport::Settings::new().wt_enabled(vi(1));
         let client_settings = Settings {
             enable_connect_protocol: None,
             ..Settings::new()
@@ -5114,10 +5139,10 @@ mod tests {
     #[test]
     fn test_server_queues_initial_flow_control_capsules_for_safari_observed_pattern() {
         let client_wt = crate::webtransport::Settings::new()
-            .webtransport_max_sessions_draft07(1)
-            .wt_initial_max_streams_uni(100)
-            .wt_initial_max_streams_bidi(100)
-            .wt_initial_max_data(8 * 1024 * 1024);
+            .webtransport_max_sessions_draft07(vi(1))
+            .wt_initial_max_streams_uni(vi(100))
+            .wt_initial_max_streams_bidi(vi(100))
+            .wt_initial_max_data(vi(8 * 1024 * 1024));
         let client_settings = Settings::new().enable_webtransport_client(client_wt);
         let mut client = Connection::client(client_settings);
         client.set_control_stream_id(2).unwrap();
@@ -5172,7 +5197,8 @@ mod tests {
 
     #[test]
     fn test_server_does_not_queue_initial_flow_control_capsules_for_plain_draft07() {
-        let client_wt = crate::webtransport::Settings::new().webtransport_max_sessions_draft07(1);
+        let client_wt =
+            crate::webtransport::Settings::new().webtransport_max_sessions_draft07(vi(1));
         let client_settings = Settings::new().enable_webtransport_client(client_wt);
         let mut client = Connection::client(client_settings);
         client.set_control_stream_id(2).unwrap();

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,6 +4,10 @@
 
 use core::fmt;
 
+use crate::settings::SettingError;
+// `Error::Settings(SettingError)` は dead code であったため削除した。
+// SETTINGS 検査エラーは `FrameDecodeError::InvalidSetting(SettingError)` 経由で伝播する。
+
 /// HTTP/3 エラーコード (RFC 9114 Section 8.1)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u64)]
@@ -122,6 +126,7 @@ impl fmt::Display for ErrorCode {
 }
 
 /// HTTP/3 エラー
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Error {
     /// 接続エラー (接続をクローズすべき)
@@ -179,6 +184,7 @@ impl core::error::Error for Error {
 }
 
 /// フレームデコードエラー
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FrameDecodeError {
     /// バッファ不足
@@ -187,8 +193,11 @@ pub enum FrameDecodeError {
     UnknownFrameType(u64),
     /// 無効なフレーム長
     InvalidLength,
-    /// 無効な設定 ID
-    InvalidSettingsId(u64),
+    /// SETTINGS パラメータの構築時検査でエラーが発生した
+    ///
+    /// 内部に [`SettingError`] を保持し、ID / 値 / 重複の詳細を伝える
+    /// (RFC 9114 §7.2.4 / §7.2.4.1)。
+    InvalidSetting(SettingError),
     /// HTTP/2 専用フレームの検出
     Http2Frame(u64),
     /// サーバープッシュはサポートしない (CANCEL_PUSH, PUSH_PROMISE, MAX_PUSH_ID)
@@ -201,7 +210,7 @@ impl fmt::Display for FrameDecodeError {
             Self::BufferTooShort => write!(f, "buffer too short"),
             Self::UnknownFrameType(t) => write!(f, "unknown frame type: {t:#x}"),
             Self::InvalidLength => write!(f, "invalid frame length"),
-            Self::InvalidSettingsId(id) => write!(f, "invalid settings id: {id:#x}"),
+            Self::InvalidSetting(e) => write!(f, "invalid settings parameter: {e}"),
             Self::Http2Frame(t) => write!(f, "http/2 frame not allowed: {t:#x}"),
             Self::ServerPushNotSupported(t) => {
                 write!(f, "server push not supported: {t:#x}")
@@ -210,7 +219,20 @@ impl fmt::Display for FrameDecodeError {
     }
 }
 
-impl core::error::Error for FrameDecodeError {}
+impl core::error::Error for FrameDecodeError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::InvalidSetting(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<SettingError> for FrameDecodeError {
+    fn from(e: SettingError) -> Self {
+        Self::InvalidSetting(e)
+    }
+}
 
 /// QPACK エラー
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/frame/decoder.rs
+++ b/src/frame/decoder.rs
@@ -1,7 +1,7 @@
 //! HTTP/3 フレームデコーダー
 
 use crate::error::FrameDecodeError;
-use crate::settings::SettingsId;
+use crate::settings::Setting;
 use crate::varint;
 
 use super::{DataPayload, Frame, FrameType, GoawayPayload, HeadersPayload, SettingsPayload};
@@ -106,7 +106,6 @@ fn decode_headers_frame(payload: &[u8]) -> Result<Frame, FrameDecodeError> {
 fn decode_settings_frame(payload: &[u8]) -> Result<Frame, FrameDecodeError> {
     let mut settings = SettingsPayload::new();
     let mut offset = 0;
-    let mut seen_ids = std::collections::HashSet::new();
 
     while offset < payload.len() {
         // payload は完全に受信済みなので、途中切れは H3_FRAME_ERROR (RFC 9114 Section 7.1)
@@ -118,20 +117,9 @@ fn decode_settings_frame(payload: &[u8]) -> Result<Frame, FrameDecodeError> {
             varint::decode(&payload[offset..]).map_err(|_| FrameDecodeError::InvalidLength)?;
         offset += value_len;
 
-        let id_raw = id.get();
-        let value_raw = value.get();
-
-        // HTTP/2 専用設定のチェック (RFC 9114 Section 7.2.4)
-        if SettingsId::is_http2_only(id_raw) {
-            return Err(FrameDecodeError::InvalidSettingsId(id_raw));
-        }
-
-        // 同一フレーム内の重複 ID チェック (RFC 9114 Section 7.2.4)
-        if !seen_ids.insert(id_raw) {
-            return Err(FrameDecodeError::InvalidSettingsId(id_raw));
-        }
-
-        settings.add(id_raw, value_raw);
+        // 値域 / HTTP2 専用 / 予約 / bool / 重複は全て SettingsPayload::add 経路で検査
+        let setting = Setting::from_wire(id, value)?;
+        settings.add(setting)?;
     }
 
     Ok(Frame::Settings(settings))
@@ -190,10 +178,20 @@ mod tests {
 
     #[test]
     fn test_decode_settings_frame_http2_setting() {
+        use crate::settings::SettingError;
+        use crate::varint::VarInt;
+
         // SETTINGS frame with HTTP/2-only setting (ENABLE_PUSH=0x02)
         let buf = [0x04, 0x02, 0x02, 0x01];
         let result = decode_frame(&buf);
-        assert_eq!(result, Err(FrameDecodeError::InvalidSettingsId(0x02)));
+        assert_eq!(
+            result,
+            Err(FrameDecodeError::InvalidSetting(
+                SettingError::Http2OnlyId {
+                    id: VarInt::new(0x02).unwrap()
+                }
+            ))
+        );
     }
 
     #[test]
@@ -217,12 +215,74 @@ mod tests {
 
     #[test]
     fn test_decode_settings_frame_duplicate_id() {
-        // SETTINGS フレームに同一 ID が 2 回含まれる場合 (RFC 9114 Section 7.2.4)
-        // QPACK_MAX_TABLE_CAPACITY (0x01) = 4, QPACK_MAX_TABLE_CAPACITY (0x01) = 8
-        // Frame: type=0x04, len=4, payload=[0x01, 0x04, 0x01, 0x08]
+        use crate::settings::SettingError;
+        use crate::varint::VarInt;
+
+        // SETTINGS フレームに同一 ID が 2 回含まれる場合 (RFC 9114 §7.2.4 MUST NOT)
         let buf = [0x04, 0x04, 0x01, 0x04, 0x01, 0x08];
         let result = decode_frame(&buf);
-        assert_eq!(result, Err(FrameDecodeError::InvalidSettingsId(0x01)));
+        assert_eq!(
+            result,
+            Err(FrameDecodeError::InvalidSetting(
+                SettingError::DuplicateId {
+                    id: VarInt::new(0x01).unwrap()
+                }
+            ))
+        );
+    }
+
+    #[test]
+    fn test_decode_settings_frame_reserved_id() {
+        use crate::settings::SettingError;
+        use crate::varint::VarInt;
+
+        // SETTINGS フレームに予約 ID 0x00 が含まれる場合 (RFC 9114 §11.2.2 Table 3)
+        let buf = [0x04, 0x02, 0x00, 0x00];
+        let result = decode_frame(&buf);
+        assert_eq!(
+            result,
+            Err(FrameDecodeError::InvalidSetting(SettingError::ReservedId {
+                id: VarInt::ZERO
+            }))
+        );
+    }
+
+    #[test]
+    fn test_decode_settings_frame_invalid_boolean_ecp() {
+        use crate::settings::SettingError;
+        use crate::varint::VarInt;
+
+        // SETTINGS_ENABLE_CONNECT_PROTOCOL (0x08) に 2 を設定する (RFC 8441 §3 違反)
+        let buf = [0x04, 0x02, 0x08, 0x02];
+        let result = decode_frame(&buf);
+        assert_eq!(
+            result,
+            Err(FrameDecodeError::InvalidSetting(
+                SettingError::InvalidBooleanValue {
+                    id: VarInt::new(0x08).unwrap(),
+                    value: VarInt::new(0x02).unwrap(),
+                }
+            ))
+        );
+    }
+
+    #[test]
+    fn test_decode_settings_frame_invalid_boolean_h3_datagram() {
+        use crate::settings::SettingError;
+        use crate::varint::VarInt;
+
+        // SETTINGS_H3_DATAGRAM (0x33) に 5 を設定する (RFC 9297 §2.1.1 違反)
+        let buf = [0x04, 0x02, 0x33, 0x05];
+        let result = decode_frame(&buf);
+        assert_eq!(
+            result,
+            Err(FrameDecodeError::InvalidSetting(
+                SettingError::InvalidBooleanValue {
+                    id: VarInt::new(0x33).unwrap(),
+                    value: VarInt::new(0x05).unwrap(),
+                }
+            ))
+        );
     }
 
     #[test]

--- a/src/frame/encoder.rs
+++ b/src/frame/encoder.rs
@@ -58,11 +58,16 @@ fn encoded_varint_len(value: u64) -> Option<usize> {
 }
 
 /// SETTINGS ペイロードのエンコード長を計算
+///
+/// 各 [`Setting`](crate::settings::Setting) の wire 表現が VarInt 範囲内である
+/// ことは構築時に保証されているため、本関数はバッファサイズの合算のみを行う。
+/// 内部総和の `usize` オーバーフローのみ `None` で返す。
 fn encoded_settings_payload_len(payload: &SettingsPayload) -> Option<u64> {
     let mut total: usize = 0;
-    for (id, value) in &payload.entries {
-        total = total.checked_add(encoded_varint_len(*id)?)?;
-        total = total.checked_add(encoded_varint_len(*value)?)?;
+    for setting in payload.settings() {
+        let (id, value) = setting.as_wire();
+        total = total.checked_add(id.encoded_len())?;
+        total = total.checked_add(value.encoded_len())?;
     }
     Some(total as u64)
 }
@@ -120,9 +125,8 @@ fn encode_settings_frame(buf: &mut [u8], payload: &SettingsPayload) -> Option<us
 
     let mut offset = encode_frame_header(buf, frame_type, payload_len)?;
 
-    for (id, value) in &payload.entries {
-        let id = VarInt::new(*id).ok()?;
-        let value = VarInt::new(*value).ok()?;
+    for setting in payload.settings() {
+        let (id, value) = setting.as_wire();
         offset += varint::encode(&mut buf[offset..], id).ok()?;
         offset += varint::encode(&mut buf[offset..], value).ok()?;
     }

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -17,6 +17,11 @@ mod encoder;
 pub use decoder::{FrameHeader, decode_frame, decode_frame_header};
 pub use encoder::{encode_frame, encode_frame_header, encoded_frame_len};
 
+use std::collections::HashSet;
+
+use crate::settings::{Setting, SettingError};
+use crate::varint::VarInt;
+
 /// フレームタイプ (RFC 9114 Section 7.2)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u64)]
@@ -123,10 +128,16 @@ impl HeadersPayload {
 }
 
 /// SETTINGS フレームペイロード
+///
+/// 内部の [`Setting`] は構築時に値検査済みかつ ID 重複が無いことを保証する。
+/// wire 表現の `(id, value)` から構築するには [`Setting::from_wire`] で先に
+/// [`Setting`] を作って [`SettingsPayload::add`] に渡す。
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct SettingsPayload {
-    /// 設定エントリのリスト (ID, 値)
-    pub entries: Vec<(u64, u64)>,
+    /// 設定エントリのリスト (構築順を維持し、ID 重複は許容しない)
+    settings: Vec<Setting>,
+    /// `add` 経由で投入された ID の集合 (重複検出用)
+    seen_ids: HashSet<VarInt>,
 }
 
 impl SettingsPayload {
@@ -135,20 +146,57 @@ impl SettingsPayload {
         Self::default()
     }
 
-    /// 設定エントリを追加
-    pub fn add(&mut self, id: u64, value: u64) {
-        self.entries.push((id, value));
+    /// 検査済みの [`Setting`] を追加する
+    ///
+    /// 同一 SETTINGS ID が既に存在する場合は
+    /// [`SettingError::DuplicateId`] を返す (RFC 9114 §7.2.4: MUST NOT
+    /// occur more than once)。
+    pub fn add(&mut self, setting: Setting) -> Result<(), SettingError> {
+        let id = setting.id();
+        if !self.seen_ids.insert(id) {
+            return Err(SettingError::DuplicateId { id });
+        }
+        self.settings.push(setting);
+        Ok(())
+    }
+
+    /// 保持する全 [`Setting`] のスライス
+    ///
+    /// 追加順を維持し、ID 重複は構築時に弾かれているため存在しない。
+    pub fn settings(&self) -> &[Setting] {
+        &self.settings
+    }
+
+    /// エントリ数
+    pub fn len(&self) -> usize {
+        self.settings.len()
+    }
+
+    /// エントリが空かどうか
+    pub fn is_empty(&self) -> bool {
+        self.settings.is_empty()
     }
 
     /// Settings から SettingsPayload を作成
     ///
-    /// H3 設定と WebTransport 設定の両方を含める。
+    /// H3 設定と WebTransport 設定の両方を含める。`Settings` のフィールドは
+    /// 各 ID と 1 対 1 に対応するため、追加時に [`SettingError::DuplicateId`] が
+    /// 発生する可能性は無い (`expect` で握り潰す)。
     pub fn from_settings(settings: &crate::settings::Settings) -> Self {
-        let mut entries: Vec<_> = settings.iter().collect();
-        if let Some(wt) = &settings.wt_settings {
-            entries.extend(wt.iter());
+        let mut payload = Self::new();
+        for setting in settings.iter() {
+            payload
+                .add(setting)
+                .expect("Settings::iter() yields unique IDs");
         }
-        Self { entries }
+        if let Some(wt) = &settings.wt_settings {
+            for setting in wt.iter() {
+                payload
+                    .add(setting)
+                    .expect("webtransport::Settings::iter() yields unique IDs");
+            }
+        }
+        payload
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,6 @@ pub use qpack::{
     DynamicDecoder, DynamicEncoder, DynamicEntry, DynamicTable, Encoder as QpackEncoder,
     EncoderInstruction, EncoderStream, EncoderStreamReceiver, Header, HeaderError,
 };
-pub use settings::{Settings, SettingsId};
+pub use settings::{Setting, SettingError, Settings, UnknownSetting};
 pub use stream::{RequestStream, StreamKind, StreamState, UniStreamType};
 pub use varint::{VarInt, VarIntError};

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,54 +1,314 @@
 //! HTTP/3 Settings (RFC 9114 Section 7.2.4)
 //!
-//! SETTINGS フレームで交換される設定パラメータを管理。
+//! SETTINGS フレームで交換される設定パラメータを管理する。
+//!
+//! [`Setting`] は既知 SETTINGS パラメータの enum 表現で、各 variant が ID と
+//! 型安全な値 ([`VarInt`] または `bool`) を保持する。wire 上の `(id, value)` ペアは
+//! [`Setting::from_wire`] で検査つきに [`Setting`] へ変換され、
+//! [`Setting::as_wire`] で逆方向に変換される。
+
+use core::fmt;
 
 use crate::limits::Limits;
+use crate::varint::VarInt;
 use crate::webtransport;
 
-/// SETTINGS パラメータ ID
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[repr(u64)]
-pub enum SettingsId {
-    /// QPACK 最大テーブル容量
-    QpackMaxTableCapacity = 0x01,
-    /// 最大ヘッダーセクションサイズ
-    MaxFieldSectionSize = 0x06,
-    /// QPACK ブロックストリーム数
-    QpackBlockedStreams = 0x07,
-    /// CONNECT プロトコル有効化
-    EnableConnectProtocol = 0x08,
-    /// H3 Datagram 有効化
-    H3Datagram = 0x33,
+// 既知 SETTINGS パラメータの ID 定数 (RFC 9114 / RFC 9204 / RFC 8441 / RFC 9297,
+// draft-ietf-webtrans-http3-02 / -07 / -14 / -15)
+const ID_QPACK_MAX_TABLE_CAPACITY: u64 = 0x01;
+const ID_MAX_FIELD_SECTION_SIZE: u64 = 0x06;
+const ID_QPACK_BLOCKED_STREAMS: u64 = 0x07;
+const ID_ENABLE_CONNECT_PROTOCOL: u64 = 0x08;
+const ID_H3_DATAGRAM: u64 = 0x33;
+const ID_WT_INITIAL_MAX_DATA: u64 = 0x2b61;
+const ID_WT_INITIAL_MAX_STREAMS_UNI: u64 = 0x2b64;
+const ID_WT_INITIAL_MAX_STREAMS_BIDI: u64 = 0x2b65;
+const ID_ENABLE_WEBTRANSPORT_DRAFT02: u64 = 0x2b603742;
+const ID_WT_MAX_SESSIONS_DRAFT14: u64 = 0x14e9cd29;
+const ID_WT_ENABLED: u64 = 0x2c7cf000;
+const ID_WEBTRANSPORT_MAX_SESSIONS_DRAFT07: u64 = 0xc671706a;
+
+/// SETTINGS ID が HTTP/2 専用のものかどうかを判定する
+///
+/// RFC 9114 §7.2.4.1: 「Setting identifiers that were defined in [HTTP/2] where
+/// there is no corresponding HTTP/3 setting have also been reserved
+/// (Section 11.2.2). These reserved settings MUST NOT be sent, and their receipt
+/// MUST be treated as a connection error of type H3_SETTINGS_ERROR」。
+/// §11.2.2 Table 3 で 0x02 / 0x03 / 0x04 / 0x05 が Reserved として列挙される。
+///
+/// 0x00 も Table 3 で Reserved として列挙されるが §7.2.4.1 の MUST 文には
+/// 含まれない (HTTP/2 由来ではない)。本実装は [`SettingError::ReservedId`] で
+/// 別途検出する。
+pub const fn is_http2_only_id(id: u64) -> bool {
+    matches!(id, 0x02..=0x05)
 }
 
-impl SettingsId {
-    /// ID から `SettingsId` を作成
-    pub fn from_id(id: u64) -> Option<Self> {
-        match id {
-            0x01 => Some(Self::QpackMaxTableCapacity),
-            0x06 => Some(Self::MaxFieldSectionSize),
-            0x07 => Some(Self::QpackBlockedStreams),
-            0x08 => Some(Self::EnableConnectProtocol),
-            0x33 => Some(Self::H3Datagram),
-            _ => None,
+/// 既知の SETTINGS パラメータ (RFC 9114 §7.2.4)
+///
+/// 各 variant が ID と型安全な値を保持する。wire 表現との変換は
+/// [`Setting::from_wire`] / [`Setting::as_wire`] で行う。
+///
+/// `Unknown` variant は [`Setting::from_wire`] 経由でのみ生成され、内部の
+/// [`UnknownSetting`] は private フィールドで HTTP/2 専用 / 予約 ID が
+/// 混入できない不変条件を保証する。RFC 9114 §7.2.4 末尾「An implementation
+/// MUST ignore any parameter with an identifier it does not understand」に対応。
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Setting {
+    /// QPACK 最大テーブル容量 (RFC 9204 §5, ID = 0x01)
+    QpackMaxTableCapacity(VarInt),
+    /// 最大ヘッダーセクションサイズ (RFC 9114 §7.2.4.2, ID = 0x06)
+    MaxFieldSectionSize(VarInt),
+    /// QPACK ブロックストリーム数 (RFC 9204 §5, ID = 0x07)
+    QpackBlockedStreams(VarInt),
+    /// CONNECT プロトコル有効化 (RFC 8441 §3, RFC 9220 §3, ID = 0x08)
+    EnableConnectProtocol(bool),
+    /// H3 Datagram 有効化 (RFC 9297 §2.1.1, ID = 0x33)
+    H3Datagram(bool),
+
+    /// SETTINGS_WT_ENABLED (draft-ietf-webtrans-http3-15 §3.1, §9.2, ID = 0x2c7cf000)
+    ///
+    /// 将来のドラフトで変更される可能性がある。
+    WtEnabled(VarInt),
+    /// SETTINGS_WT_MAX_SESSIONS (draft-ietf-webtrans-http3-14 §9.2, ID = 0x14e9cd29)
+    ///
+    /// 将来のドラフトで変更される可能性がある。
+    WtMaxSessionsDraft14(VarInt),
+    /// SETTINGS_ENABLE_WEBTRANSPORT (draft-ietf-webtrans-http3-02 §3.1, ID = 0x2b603742)
+    ///
+    /// 将来のドラフトで変更される可能性がある。
+    EnableWebTransportDraft02(bool),
+    /// SETTINGS_WEBTRANSPORT_MAX_SESSIONS (draft-ietf-webtrans-http3-07 §3.2, ID = 0xc671706a)
+    ///
+    /// 将来のドラフトで変更される可能性がある。
+    WebTransportMaxSessionsDraft07(VarInt),
+    /// SETTINGS_WT_INITIAL_MAX_DATA (draft-ietf-webtrans-http3-14/15, ID = 0x2b61)
+    ///
+    /// 将来のドラフトで変更される可能性がある。
+    WtInitialMaxData(VarInt),
+    /// SETTINGS_WT_INITIAL_MAX_STREAMS_UNI (draft-ietf-webtrans-http3-14/15, ID = 0x2b64)
+    ///
+    /// 将来のドラフトで変更される可能性がある。
+    WtInitialMaxStreamsUni(VarInt),
+    /// SETTINGS_WT_INITIAL_MAX_STREAMS_BIDI (draft-ietf-webtrans-http3-14/15, ID = 0x2b65)
+    ///
+    /// 将来のドラフトで変更される可能性がある。
+    WtInitialMaxStreamsBidi(VarInt),
+
+    /// 未知の SETTINGS パラメータ
+    ///
+    /// 内部の [`UnknownSetting`] は private フィールドで構築経路を
+    /// [`Setting::from_wire`] 経由に限定し、HTTP/2 専用 / 予約 ID が
+    /// 混入できない不変条件を維持する。
+    Unknown(UnknownSetting),
+}
+
+/// 未知 SETTINGS パラメータの ID と値
+///
+/// フィールドは private で、構築は [`Setting::from_wire`] (HTTP/2 専用 / 予約 ID
+/// チェック後) を経由する以外の手段は存在しない。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UnknownSetting {
+    id: VarInt,
+    value: VarInt,
+}
+
+impl UnknownSetting {
+    /// crate 内部で `Setting::from_wire` から呼び出すコンストラクタ
+    ///
+    /// 呼び出し時点で `id` が HTTP/2 専用 / 予約済みでないことを保証する責務は
+    /// 呼び出し側 ([`Setting::from_wire`] の検査済みパス) が持つ。
+    pub(crate) const fn new(id: VarInt, value: VarInt) -> Self {
+        Self { id, value }
+    }
+
+    /// 未知パラメータの ID を取得する
+    pub fn id(&self) -> VarInt {
+        self.id
+    }
+
+    /// 未知パラメータの値を取得する
+    pub fn value(&self) -> VarInt {
+        self.value
+    }
+}
+
+/// Setting / SettingsPayload 構築時のエラー (RFC 9114 §7.2.4 / §7.2.4.1)
+///
+/// いずれのエラーも上位の SETTINGS フレームハンドラで H3_SETTINGS_ERROR に
+/// 変換される。
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SettingError {
+    /// HTTP/2 専用の SETTINGS ID を受信した (0x02, 0x03, 0x04, 0x05)
+    ///
+    /// RFC 9114 §7.2.4.1 + §11.2.2 Table 3: H3_SETTINGS_ERROR。
+    Http2OnlyId {
+        /// 受信した ID
+        id: VarInt,
+    },
+
+    /// 予約済み SETTINGS ID を受信した (0x00)
+    ///
+    /// RFC 9114 §11.2.2 Table 3 で 0x00 は Reserved として登録されている。
+    /// §7.2.4.1 の MUST H3_SETTINGS_ERROR 規定は HTTP/2 由来の予約 ID
+    /// (0x02-0x05) を直接の対象とするが、Reserved に分類された 0x00 を受信した
+    /// 場合も接続クローズで処理するのが実装として妥当な選択。
+    /// 注: 0x02-0x05 は [`SettingError::Http2OnlyId`] で別途検出する。
+    ReservedId {
+        /// 受信した ID
+        id: VarInt,
+    },
+
+    /// bool 値の SETTINGS が 0/1 以外の値を持つ
+    ///
+    /// 対象 ID:
+    /// - 0x08 (`SETTINGS_ENABLE_CONNECT_PROTOCOL`, RFC 8441 §3 / RFC 9220 §3)
+    /// - 0x33 (`SETTINGS_H3_DATAGRAM`, RFC 9297 §2.1.1)
+    /// - 0x2b603742 (`SETTINGS_ENABLE_WEBTRANSPORT`, draft-ietf-webtrans-http3-02 §3.1)
+    InvalidBooleanValue {
+        /// 対象 ID
+        id: VarInt,
+        /// 受信した値
+        value: VarInt,
+    },
+
+    /// 同一 SETTINGS フレーム内に同じ ID が複数含まれる
+    ///
+    /// RFC 9114 §7.2.4「The same setting identifier MUST NOT occur more than
+    /// once in the SETTINGS frame」(送信側 MUST NOT) / 受信側は MAY treat
+    /// as H3_SETTINGS_ERROR。本実装は常に H3_SETTINGS_ERROR として扱う。
+    DuplicateId {
+        /// 重複した ID
+        id: VarInt,
+    },
+}
+
+impl fmt::Display for SettingError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Http2OnlyId { id } => {
+                write!(f, "http/2 only settings id received: {:#x}", id.get())
+            }
+            Self::ReservedId { id } => {
+                write!(f, "reserved settings id received: {:#x}", id.get())
+            }
+            Self::InvalidBooleanValue { id, value } => write!(
+                f,
+                "boolean settings {:#x} has invalid value {}",
+                id.get(),
+                value.get()
+            ),
+            Self::DuplicateId { id } => {
+                write!(f, "duplicate settings id: {:#x}", id.get())
+            }
+        }
+    }
+}
+
+impl core::error::Error for SettingError {}
+
+impl Setting {
+    /// wire 上の `(id, value)` ペアから [`Setting`] を構築する
+    ///
+    /// 既知パラメータは対応する variant に変換され、値の範囲外なら
+    /// [`SettingError`] を返す。HTTP/2 専用 ID (0x02-0x05) と予約済み ID (0x00) は
+    /// 拒否する。未知の ID は [`Setting::Unknown`] として受理する
+    /// (RFC 9114 §7.2.4.1: 未知パラメータは MUST ignore)。
+    pub fn from_wire(id: VarInt, value: VarInt) -> Result<Self, SettingError> {
+        let raw = id.get();
+        if is_http2_only_id(raw) {
+            return Err(SettingError::Http2OnlyId { id });
+        }
+        // 予約済み ID 0x00 を弾く (RFC 9114 §11.2.2 Table 3)。
+        // 0x02-0x05 は Http2OnlyId で先に分岐済み。
+        if raw == 0x00 {
+            return Err(SettingError::ReservedId { id });
+        }
+        let setting = match raw {
+            ID_QPACK_MAX_TABLE_CAPACITY => Self::QpackMaxTableCapacity(value),
+            ID_MAX_FIELD_SECTION_SIZE => Self::MaxFieldSectionSize(value),
+            ID_QPACK_BLOCKED_STREAMS => Self::QpackBlockedStreams(value),
+            ID_ENABLE_CONNECT_PROTOCOL => Self::EnableConnectProtocol(check_bool(id, value)?),
+            ID_H3_DATAGRAM => Self::H3Datagram(check_bool(id, value)?),
+            ID_WT_ENABLED => Self::WtEnabled(value),
+            ID_WT_MAX_SESSIONS_DRAFT14 => Self::WtMaxSessionsDraft14(value),
+            ID_ENABLE_WEBTRANSPORT_DRAFT02 => {
+                Self::EnableWebTransportDraft02(check_bool(id, value)?)
+            }
+            ID_WEBTRANSPORT_MAX_SESSIONS_DRAFT07 => Self::WebTransportMaxSessionsDraft07(value),
+            ID_WT_INITIAL_MAX_DATA => Self::WtInitialMaxData(value),
+            ID_WT_INITIAL_MAX_STREAMS_UNI => Self::WtInitialMaxStreamsUni(value),
+            ID_WT_INITIAL_MAX_STREAMS_BIDI => Self::WtInitialMaxStreamsBidi(value),
+            _ => Self::Unknown(UnknownSetting::new(id, value)),
+        };
+        Ok(setting)
+    }
+
+    /// wire 上の `(id, value)` ペアに変換する
+    pub fn as_wire(self) -> (VarInt, VarInt) {
+        let bool_v = |b: bool| {
+            if b {
+                VarInt::from_static(1)
+            } else {
+                VarInt::ZERO
+            }
+        };
+        match self {
+            Self::QpackMaxTableCapacity(v) => (VarInt::from_static(ID_QPACK_MAX_TABLE_CAPACITY), v),
+            Self::MaxFieldSectionSize(v) => (VarInt::from_static(ID_MAX_FIELD_SECTION_SIZE), v),
+            Self::QpackBlockedStreams(v) => (VarInt::from_static(ID_QPACK_BLOCKED_STREAMS), v),
+            Self::EnableConnectProtocol(b) => {
+                (VarInt::from_static(ID_ENABLE_CONNECT_PROTOCOL), bool_v(b))
+            }
+            Self::H3Datagram(b) => (VarInt::from_static(ID_H3_DATAGRAM), bool_v(b)),
+            Self::WtEnabled(v) => (VarInt::from_static(ID_WT_ENABLED), v),
+            Self::WtMaxSessionsDraft14(v) => (VarInt::from_static(ID_WT_MAX_SESSIONS_DRAFT14), v),
+            Self::EnableWebTransportDraft02(b) => (
+                VarInt::from_static(ID_ENABLE_WEBTRANSPORT_DRAFT02),
+                bool_v(b),
+            ),
+            Self::WebTransportMaxSessionsDraft07(v) => {
+                (VarInt::from_static(ID_WEBTRANSPORT_MAX_SESSIONS_DRAFT07), v)
+            }
+            Self::WtInitialMaxData(v) => (VarInt::from_static(ID_WT_INITIAL_MAX_DATA), v),
+            Self::WtInitialMaxStreamsUni(v) => {
+                (VarInt::from_static(ID_WT_INITIAL_MAX_STREAMS_UNI), v)
+            }
+            Self::WtInitialMaxStreamsBidi(v) => {
+                (VarInt::from_static(ID_WT_INITIAL_MAX_STREAMS_BIDI), v)
+            }
+            Self::Unknown(u) => (u.id(), u.value()),
         }
     }
 
-    /// HTTP/2 専用の設定 ID かどうか
-    pub fn is_http2_only(id: u64) -> bool {
-        matches!(id, 0x02..=0x05)
+    /// この `Setting` の ID を返す
+    pub fn id(self) -> VarInt {
+        self.as_wire().0
     }
 }
 
-/// HTTP/3 設定
+/// bool 値 SETTINGS の値検査
+fn check_bool(id: VarInt, value: VarInt) -> Result<bool, SettingError> {
+    match value.get() {
+        0 => Ok(false),
+        1 => Ok(true),
+        _ => Err(SettingError::InvalidBooleanValue { id, value }),
+    }
+}
+
+/// HTTP/3 設定 (型付きフィールドのコレクション)
+///
+/// `Settings` は SETTINGS フレームで送受信される設定値の論理表現。
+/// wire 表現との変換は [`crate::frame::SettingsPayload`] を介する。
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Settings {
     /// QPACK 最大テーブル容量
-    pub qpack_max_table_capacity: Option<u64>,
+    pub qpack_max_table_capacity: Option<VarInt>,
     /// 最大ヘッダーセクションサイズ
-    pub max_field_section_size: Option<u64>,
+    pub max_field_section_size: Option<VarInt>,
     /// QPACK ブロックストリーム数
-    pub qpack_blocked_streams: Option<u64>,
+    pub qpack_blocked_streams: Option<VarInt>,
     /// CONNECT プロトコル有効化
     pub enable_connect_protocol: Option<bool>,
     /// H3 Datagram 有効化
@@ -77,31 +337,35 @@ impl Settings {
     }
 
     /// Limits から Settings を作成
-    pub fn from_limits(limits: &Limits) -> Self {
-        Self {
-            qpack_max_table_capacity: Some(limits.qpack_max_table_capacity),
-            max_field_section_size: Some(limits.max_field_section_size),
-            qpack_blocked_streams: Some(limits.qpack_blocked_streams),
+    ///
+    /// `Limits` のフィールドは `u64` だが、SETTINGS で送出する値域は
+    /// VarInt (RFC 9000 §16) に制約される。`Limits` 側の値域が VarInt 範囲外なら
+    /// [`crate::varint::VarIntError::OutOfRange`] を返し panic させない。
+    pub fn from_limits(limits: &Limits) -> Result<Self, crate::varint::VarIntError> {
+        Ok(Self {
+            qpack_max_table_capacity: Some(VarInt::new(limits.qpack_max_table_capacity)?),
+            max_field_section_size: Some(VarInt::new(limits.max_field_section_size)?),
+            qpack_blocked_streams: Some(VarInt::new(limits.qpack_blocked_streams)?),
             enable_connect_protocol: None,
             h3_datagram: None,
             wt_settings: None,
-        }
+        })
     }
 
     /// QPACK 最大テーブル容量を設定
-    pub fn qpack_max_table_capacity(mut self, capacity: u64) -> Self {
+    pub fn qpack_max_table_capacity(mut self, capacity: VarInt) -> Self {
         self.qpack_max_table_capacity = Some(capacity);
         self
     }
 
     /// 最大ヘッダーセクションサイズを設定
-    pub fn max_field_section_size(mut self, size: u64) -> Self {
+    pub fn max_field_section_size(mut self, size: VarInt) -> Self {
         self.max_field_section_size = Some(size);
         self
     }
 
     /// QPACK ブロックストリーム数を設定
-    pub fn qpack_blocked_streams(mut self, streams: u64) -> Self {
+    pub fn qpack_blocked_streams(mut self, streams: VarInt) -> Self {
         self.qpack_blocked_streams = Some(streams);
         self
     }
@@ -168,7 +432,7 @@ impl Settings {
 
     /// WebTransport が有効かどうか
     ///
-    /// draft-02/07/15 のいずれかで有効になっていれば true
+    /// draft-02/07/14/15 のいずれかで有効になっていれば true
     pub fn is_webtransport_enabled(&self) -> bool {
         self.wt_settings.as_ref().is_some_and(|wt| wt.is_enabled())
     }
@@ -184,65 +448,69 @@ impl Settings {
 
     /// SettingsPayload から Settings を作成
     ///
-    /// H3 設定と WebTransport 設定の両方をパースする。
-    /// WebTransport 関連の ID は `webtransport::Settings::from_payload()` に委譲する。
+    /// `SettingsPayload` 内の各 [`Setting`] は構築時に値検査済み (ID 重複なし、
+    /// HTTP/2 専用 / 予約 ID / bool 値域外を弾き済み) のため、本関数は以下のみを
+    /// 担当する:
     ///
-    /// `SETTINGS_ENABLE_CONNECT_PROTOCOL` (0x08) と `SETTINGS_H3_DATAGRAM` (0x33) は
-    /// 値が 0 または 1 でなければ `H3_SETTINGS_ERROR` を返す。
-    /// (RFC 8441 Section 3, RFC 9297 Section 2.1.1)
-    pub fn from_payload(
-        payload: &crate::frame::SettingsPayload,
-    ) -> Result<Self, crate::error::Error> {
+    /// - 既知パラメータ (H3) を [`Settings`] のフィールドにマッピングする
+    /// - WebTransport 関連の variant は [`webtransport::Settings::from_payload`] に委譲する
+    /// - [`Setting::Unknown`] は MUST ignore (RFC 9114 §7.2.4 末尾) として無視する
+    ///
+    /// SETTINGS フレームレベルの重複 ID 検出は [`crate::frame::SettingsPayload::add`]
+    /// 側で構築時に行うため、本関数は失敗しない。`Setting` enum に新 variant が
+    /// 追加された場合は本 `match` がコンパイル時に網羅性チェックで検出する
+    /// (ワイルドカードを使わず明示列挙する)。
+    pub fn from_payload(payload: &crate::frame::SettingsPayload) -> Self {
         let mut settings = Self::new();
-        for (id, value) in &payload.entries {
-            match *id {
-                0x01 => settings.qpack_max_table_capacity = Some(*value),
-                0x06 => settings.max_field_section_size = Some(*value),
-                0x07 => settings.qpack_blocked_streams = Some(*value),
-                // SETTINGS_ENABLE_CONNECT_PROTOCOL: 値は 0 または 1 のみ
-                // (RFC 8441 Section 3)
-                0x08 => {
-                    if *value > 1 {
-                        return Err(crate::error::Error::ConnectionError(
-                            crate::error::ErrorCode::SettingsError,
-                        ));
-                    }
-                    settings.enable_connect_protocol = Some(*value == 1);
+
+        for setting in payload.settings() {
+            match *setting {
+                Setting::QpackMaxTableCapacity(v) => {
+                    settings.qpack_max_table_capacity = Some(v);
                 }
-                // SETTINGS_H3_DATAGRAM: 値は 0 または 1 のみ
-                // (RFC 9297 Section 2.1.1)
-                0x33 => {
-                    if *value > 1 {
-                        return Err(crate::error::Error::ConnectionError(
-                            crate::error::ErrorCode::SettingsError,
-                        ));
-                    }
-                    settings.h3_datagram = Some(*value == 1);
+                Setting::MaxFieldSectionSize(v) => {
+                    settings.max_field_section_size = Some(v);
                 }
-                _ => {} // WebTransport 設定と不明な設定は個別処理
+                Setting::QpackBlockedStreams(v) => {
+                    settings.qpack_blocked_streams = Some(v);
+                }
+                Setting::EnableConnectProtocol(b) => {
+                    settings.enable_connect_protocol = Some(b);
+                }
+                Setting::H3Datagram(b) => {
+                    settings.h3_datagram = Some(b);
+                }
+                // WebTransport variant は `webtransport::Settings::from_payload` で反映する。
+                // ここでは H3 フィールドに反映しないことを明示する。
+                Setting::WtEnabled(_)
+                | Setting::WtMaxSessionsDraft14(_)
+                | Setting::EnableWebTransportDraft02(_)
+                | Setting::WebTransportMaxSessionsDraft07(_)
+                | Setting::WtInitialMaxData(_)
+                | Setting::WtInitialMaxStreamsUni(_)
+                | Setting::WtInitialMaxStreamsBidi(_) => {}
+                Setting::Unknown(_) => {}
             }
         }
-        // WebTransport 関連 ID をまとめてパース
-        settings.wt_settings = webtransport::Settings::from_payload(payload)?;
-        Ok(settings)
+
+        settings.wt_settings = webtransport::Settings::from_payload(payload.settings());
+        settings
     }
 
     /// H3 設定エントリのイテレータを返す
     ///
     /// WebTransport 設定は含まない。WebTransport 設定は
     /// `wt_settings.iter()` で別途取得する。
-    pub fn iter(&self) -> impl Iterator<Item = (u64, u64)> + '_ {
+    pub fn iter(&self) -> impl Iterator<Item = Setting> + '_ {
         let entries = [
             self.qpack_max_table_capacity
-                .map(|v| (SettingsId::QpackMaxTableCapacity as u64, v)),
+                .map(Setting::QpackMaxTableCapacity),
             self.max_field_section_size
-                .map(|v| (SettingsId::MaxFieldSectionSize as u64, v)),
-            self.qpack_blocked_streams
-                .map(|v| (SettingsId::QpackBlockedStreams as u64, v)),
+                .map(Setting::MaxFieldSectionSize),
+            self.qpack_blocked_streams.map(Setting::QpackBlockedStreams),
             self.enable_connect_protocol
-                .map(|v| (SettingsId::EnableConnectProtocol as u64, u64::from(v))),
-            self.h3_datagram
-                .map(|v| (SettingsId::H3Datagram as u64, u64::from(v))),
+                .map(Setting::EnableConnectProtocol),
+            self.h3_datagram.map(Setting::H3Datagram),
         ];
         entries.into_iter().flatten()
     }
@@ -264,31 +532,182 @@ impl Settings {
     }
 }
 
+// `From<SettingError> for crate::error::Error` は提供しない。
+// SETTINGS フレーム由来の `SettingError` は decoder で `FrameDecodeError::InvalidSetting`
+// に変換され、最終的に `Error::FrameDecode(FrameDecodeError::InvalidSetting(_))` で
+// 伝播する。直接 SETTINGS 検証 API (`SettingsPayload::add` 等) を呼ぶ利用者は
+// `Result<_, SettingError>` をそのまま受けて扱う。
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_settings_id_from_id() {
-        assert_eq!(
-            SettingsId::from_id(0x01),
-            Some(SettingsId::QpackMaxTableCapacity)
-        );
-        assert_eq!(
-            SettingsId::from_id(0x06),
-            Some(SettingsId::MaxFieldSectionSize)
-        );
-        assert_eq!(SettingsId::from_id(0x99), None);
+    fn v(n: u64) -> VarInt {
+        VarInt::new(n).unwrap()
     }
 
     #[test]
-    fn test_settings_id_is_http2_only() {
-        assert!(SettingsId::is_http2_only(0x02)); // ENABLE_PUSH
-        assert!(SettingsId::is_http2_only(0x03)); // MAX_CONCURRENT_STREAMS
-        assert!(SettingsId::is_http2_only(0x04)); // INITIAL_WINDOW_SIZE
-        assert!(SettingsId::is_http2_only(0x05)); // MAX_FRAME_SIZE
-        assert!(!SettingsId::is_http2_only(0x01));
-        assert!(!SettingsId::is_http2_only(0x06));
+    fn test_is_http2_only_id() {
+        assert!(is_http2_only_id(0x02));
+        assert!(is_http2_only_id(0x03));
+        assert!(is_http2_only_id(0x04));
+        assert!(is_http2_only_id(0x05));
+        assert!(!is_http2_only_id(0x00));
+        assert!(!is_http2_only_id(0x01));
+        assert!(!is_http2_only_id(0x06));
+    }
+
+    #[test]
+    fn test_setting_from_wire_known_ids() {
+        assert_eq!(
+            Setting::from_wire(v(0x01), v(4096)).unwrap(),
+            Setting::QpackMaxTableCapacity(v(4096))
+        );
+        assert_eq!(
+            Setting::from_wire(v(0x06), v(16384)).unwrap(),
+            Setting::MaxFieldSectionSize(v(16384))
+        );
+        assert_eq!(
+            Setting::from_wire(v(0x07), v(50)).unwrap(),
+            Setting::QpackBlockedStreams(v(50))
+        );
+        assert_eq!(
+            Setting::from_wire(v(0x08), v(1)).unwrap(),
+            Setting::EnableConnectProtocol(true)
+        );
+        assert_eq!(
+            Setting::from_wire(v(0x33), v(0)).unwrap(),
+            Setting::H3Datagram(false)
+        );
+    }
+
+    #[test]
+    fn test_setting_from_wire_http2_only_rejected() {
+        for id in [0x02u64, 0x03, 0x04, 0x05] {
+            let err = Setting::from_wire(v(id), v(0)).unwrap_err();
+            assert_eq!(err, SettingError::Http2OnlyId { id: v(id) });
+        }
+    }
+
+    #[test]
+    fn test_setting_from_wire_reserved_id_rejected() {
+        let err = Setting::from_wire(v(0x00), v(0)).unwrap_err();
+        assert_eq!(err, SettingError::ReservedId { id: v(0x00) });
+    }
+
+    #[test]
+    fn test_setting_from_wire_invalid_boolean() {
+        let err = Setting::from_wire(v(0x08), v(2)).unwrap_err();
+        assert_eq!(
+            err,
+            SettingError::InvalidBooleanValue {
+                id: v(0x08),
+                value: v(2)
+            }
+        );
+        let err = Setting::from_wire(v(0x33), v(u64::from(u8::MAX))).unwrap_err();
+        assert_eq!(
+            err,
+            SettingError::InvalidBooleanValue {
+                id: v(0x33),
+                value: v(u64::from(u8::MAX))
+            }
+        );
+    }
+
+    #[test]
+    fn test_setting_from_wire_unknown_id() {
+        let s = Setting::from_wire(v(0x99), v(42)).unwrap();
+        let Setting::Unknown(u) = s else {
+            panic!("expected Unknown");
+        };
+        assert_eq!(u.id(), v(0x99));
+        assert_eq!(u.value(), v(42));
+    }
+
+    #[test]
+    fn test_setting_from_wire_wt_ids() {
+        assert_eq!(
+            Setting::from_wire(v(0x2c7cf000), v(1)).unwrap(),
+            Setting::WtEnabled(v(1))
+        );
+        assert_eq!(
+            Setting::from_wire(v(0x14e9cd29), v(1)).unwrap(),
+            Setting::WtMaxSessionsDraft14(v(1))
+        );
+        assert_eq!(
+            Setting::from_wire(v(0x2b603742), v(1)).unwrap(),
+            Setting::EnableWebTransportDraft02(true)
+        );
+        assert_eq!(
+            Setting::from_wire(v(0xc671706a), v(3)).unwrap(),
+            Setting::WebTransportMaxSessionsDraft07(v(3))
+        );
+        assert_eq!(
+            Setting::from_wire(v(0x2b61), v(1024)).unwrap(),
+            Setting::WtInitialMaxData(v(1024))
+        );
+        assert_eq!(
+            Setting::from_wire(v(0x2b64), v(100)).unwrap(),
+            Setting::WtInitialMaxStreamsUni(v(100))
+        );
+        assert_eq!(
+            Setting::from_wire(v(0x2b65), v(50)).unwrap(),
+            Setting::WtInitialMaxStreamsBidi(v(50))
+        );
+    }
+
+    #[test]
+    fn test_setting_as_wire_roundtrip() {
+        let cases = [
+            Setting::QpackMaxTableCapacity(v(4096)),
+            Setting::MaxFieldSectionSize(v(16384)),
+            Setting::QpackBlockedStreams(v(100)),
+            Setting::EnableConnectProtocol(true),
+            Setting::EnableConnectProtocol(false),
+            Setting::H3Datagram(true),
+            Setting::H3Datagram(false),
+            Setting::WtEnabled(v(1)),
+            Setting::WtMaxSessionsDraft14(v(7)),
+            Setting::EnableWebTransportDraft02(true),
+            Setting::WebTransportMaxSessionsDraft07(v(3)),
+            Setting::WtInitialMaxData(v(1024)),
+            Setting::WtInitialMaxStreamsUni(v(100)),
+            Setting::WtInitialMaxStreamsBidi(v(50)),
+            Setting::from_wire(v(0xdead_beef), v(42)).unwrap(),
+        ];
+        for setting in cases {
+            let (id, value) = setting.as_wire();
+            let restored = Setting::from_wire(id, value).unwrap();
+            assert_eq!(restored, setting);
+        }
+    }
+
+    #[test]
+    fn test_setting_id() {
+        assert_eq!(Setting::QpackMaxTableCapacity(v(4096)).id(), v(0x01));
+        assert_eq!(Setting::H3Datagram(true).id(), v(0x33));
+        let unknown = Setting::from_wire(v(0xfeed), v(0)).unwrap();
+        assert_eq!(unknown.id(), v(0xfeed));
+    }
+
+    #[test]
+    fn test_setting_error_display() {
+        let err = SettingError::Http2OnlyId { id: v(0x02) };
+        let s = format!("{err}");
+        assert!(s.contains("0x2"));
+
+        let err = SettingError::ReservedId { id: v(0x00) };
+        let s = format!("{err}");
+        assert!(s.contains("0x0"));
+
+        let err = SettingError::InvalidBooleanValue {
+            id: v(0x08),
+            value: v(2),
+        };
+        let s = format!("{err}");
+        assert!(s.contains("0x8"));
+        assert!(s.contains('2'));
     }
 
     #[test]
@@ -300,15 +719,15 @@ mod tests {
     #[test]
     fn test_settings_builder() {
         let settings = Settings::new()
-            .qpack_max_table_capacity(4096)
-            .max_field_section_size(16384)
-            .qpack_blocked_streams(100)
+            .qpack_max_table_capacity(v(4096))
+            .max_field_section_size(v(16384))
+            .qpack_blocked_streams(v(100))
             .enable_connect_protocol(true)
             .h3_datagram(false);
 
-        assert_eq!(settings.qpack_max_table_capacity, Some(4096));
-        assert_eq!(settings.max_field_section_size, Some(16384));
-        assert_eq!(settings.qpack_blocked_streams, Some(100));
+        assert_eq!(settings.qpack_max_table_capacity, Some(v(4096)));
+        assert_eq!(settings.max_field_section_size, Some(v(16384)));
+        assert_eq!(settings.qpack_blocked_streams, Some(v(100)));
         assert_eq!(settings.enable_connect_protocol, Some(true));
         assert_eq!(settings.h3_datagram, Some(false));
         assert_eq!(settings.len(), 5);
@@ -321,33 +740,33 @@ mod tests {
             .max_field_section_size(32768)
             .qpack_blocked_streams(50);
 
-        let settings = Settings::from_limits(&limits);
-        assert_eq!(settings.qpack_max_table_capacity, Some(4096));
-        assert_eq!(settings.max_field_section_size, Some(32768));
-        assert_eq!(settings.qpack_blocked_streams, Some(50));
+        let settings = Settings::from_limits(&limits).unwrap();
+        assert_eq!(settings.qpack_max_table_capacity, Some(v(4096)));
+        assert_eq!(settings.max_field_section_size, Some(v(32768)));
+        assert_eq!(settings.qpack_blocked_streams, Some(v(50)));
     }
 
     #[test]
     fn test_settings_iter() {
         let settings = Settings::new()
-            .qpack_max_table_capacity(4096)
-            .max_field_section_size(16384);
+            .qpack_max_table_capacity(v(4096))
+            .max_field_section_size(v(16384));
 
         let entries: Vec<_> = settings.iter().collect();
         assert_eq!(entries.len(), 2);
-        assert!(entries.contains(&(0x01, 4096)));
-        assert!(entries.contains(&(0x06, 16384)));
+        assert!(entries.contains(&Setting::QpackMaxTableCapacity(v(4096))));
+        assert!(entries.contains(&Setting::MaxFieldSectionSize(v(16384))));
     }
 
     #[test]
     fn test_enable_webtransport() {
         let wt = webtransport::Settings::new()
-            .wt_enabled(1)
+            .wt_enabled(v(1))
             .enable_webtransport_draft02(true)
-            .webtransport_max_sessions_draft07(1)
-            .wt_initial_max_streams_bidi(100)
-            .wt_initial_max_streams_uni(100)
-            .wt_initial_max_data(1048576);
+            .webtransport_max_sessions_draft07(v(1))
+            .wt_initial_max_streams_bidi(v(100))
+            .wt_initial_max_streams_uni(v(100))
+            .wt_initial_max_data(v(1_048_576));
 
         let settings = Settings::new().enable_webtransport_server(wt);
 
@@ -356,12 +775,12 @@ mod tests {
         assert!(settings.is_webtransport_enabled());
 
         let wt = settings.wt_settings.unwrap();
-        assert_eq!(wt.wt_enabled, 1);
+        assert_eq!(wt.wt_enabled, v(1));
         assert_eq!(wt.enable_webtransport_draft02, Some(true));
-        assert_eq!(wt.webtransport_max_sessions_draft07, Some(1));
-        assert_eq!(wt.wt_initial_max_streams_bidi, 100);
-        assert_eq!(wt.wt_initial_max_streams_uni, 100);
-        assert_eq!(wt.wt_initial_max_data, 1048576);
+        assert_eq!(wt.webtransport_max_sessions_draft07, Some(v(1)));
+        assert_eq!(wt.wt_initial_max_streams_bidi, v(100));
+        assert_eq!(wt.wt_initial_max_streams_uni, v(100));
+        assert_eq!(wt.wt_initial_max_data, v(1_048_576));
     }
 
     #[test]
@@ -369,7 +788,7 @@ mod tests {
         let settings = Settings::new();
         assert!(!settings.is_webtransport_enabled());
 
-        let wt = webtransport::Settings::new().wt_enabled(1);
+        let wt = webtransport::Settings::new().wt_enabled(v(1));
         let settings = Settings::new().enable_webtransport_server(wt);
         assert!(settings.is_webtransport_enabled());
     }
@@ -377,11 +796,11 @@ mod tests {
     #[test]
     fn test_len_includes_wt_settings() {
         let wt = webtransport::Settings::new()
-            .wt_enabled(1)
-            .wt_initial_max_streams_bidi(100);
+            .wt_enabled(v(1))
+            .wt_initial_max_streams_bidi(v(100));
 
         let settings = Settings::new()
-            .qpack_max_table_capacity(4096)
+            .qpack_max_table_capacity(v(4096))
             .enable_webtransport_server(wt);
 
         // H3: qpack_max_table_capacity, enable_connect_protocol, h3_datagram = 3
@@ -390,53 +809,62 @@ mod tests {
     }
 
     #[test]
-    fn test_from_payload_boolean_settings_valid() {
+    fn test_add_duplicate_rejected_at_payload() {
+        // 重複 ID 検出は SettingsPayload::add の責務 (構築時)
         use crate::frame::SettingsPayload;
-
-        // 0x08 = 0 は有効
         let mut payload = SettingsPayload::new();
-        payload.add(0x08, 0);
-        let settings = Settings::from_payload(&payload).unwrap();
-        assert_eq!(settings.enable_connect_protocol, Some(false));
-
-        // 0x08 = 1 は有効
-        let mut payload = SettingsPayload::new();
-        payload.add(0x08, 1);
-        let settings = Settings::from_payload(&payload).unwrap();
-        assert_eq!(settings.enable_connect_protocol, Some(true));
-
-        // 0x33 = 0 は有効
-        let mut payload = SettingsPayload::new();
-        payload.add(0x33, 0);
-        let settings = Settings::from_payload(&payload).unwrap();
-        assert_eq!(settings.h3_datagram, Some(false));
-
-        // 0x33 = 1 は有効
-        let mut payload = SettingsPayload::new();
-        payload.add(0x33, 1);
-        let settings = Settings::from_payload(&payload).unwrap();
-        assert_eq!(settings.h3_datagram, Some(true));
+        payload
+            .add(Setting::QpackMaxTableCapacity(v(4096)))
+            .unwrap();
+        let err = payload
+            .add(Setting::QpackMaxTableCapacity(v(8192)))
+            .unwrap_err();
+        assert_eq!(err, SettingError::DuplicateId { id: v(0x01) });
     }
 
     #[test]
-    fn test_from_payload_boolean_settings_invalid() {
-        use crate::error::{Error, ErrorCode};
+    fn test_from_payload_ignores_unknown() {
         use crate::frame::SettingsPayload;
 
-        // 0x08 = 2 は不正 (RFC 8441 Section 3)
+        // Setting::Unknown は from_wire 経由でしか作れないため、wire からの構築をシミュレート
+        let unknown = Setting::from_wire(v(0xdead), v(1)).unwrap();
         let mut payload = SettingsPayload::new();
-        payload.add(0x08, 2);
-        assert!(matches!(
-            Settings::from_payload(&payload),
-            Err(Error::ConnectionError(ErrorCode::SettingsError))
-        ));
+        payload.add(unknown).unwrap();
+        payload.add(Setting::H3Datagram(true)).unwrap();
+        let settings = Settings::from_payload(&payload);
+        assert_eq!(settings.h3_datagram, Some(true));
+        assert!(settings.qpack_max_table_capacity.is_none());
+    }
 
-        // 0x33 = 2 は不正 (RFC 9297 Section 2.1.1)
-        let mut payload = SettingsPayload::new();
-        payload.add(0x33, 2);
-        assert!(matches!(
-            Settings::from_payload(&payload),
-            Err(Error::ConnectionError(ErrorCode::SettingsError))
-        ));
+    #[test]
+    fn test_setting_error_duplicate_id_display() {
+        let err = SettingError::DuplicateId { id: v(0x01) };
+        let s = format!("{err}");
+        assert!(s.contains("duplicate"));
+        assert!(s.contains("0x1"));
+    }
+
+    #[test]
+    fn test_from_limits_out_of_range_qpack_max_table_capacity() {
+        let mut limits = Limits::new();
+        limits.qpack_max_table_capacity = 1u64 << 62;
+        let err = Settings::from_limits(&limits).unwrap_err();
+        assert!(matches!(err, crate::varint::VarIntError::OutOfRange { .. }));
+    }
+
+    #[test]
+    fn test_from_limits_out_of_range_max_field_section_size() {
+        let mut limits = Limits::new();
+        limits.max_field_section_size = 1u64 << 62;
+        let err = Settings::from_limits(&limits).unwrap_err();
+        assert!(matches!(err, crate::varint::VarIntError::OutOfRange { .. }));
+    }
+
+    #[test]
+    fn test_from_limits_out_of_range_qpack_blocked_streams() {
+        let mut limits = Limits::new();
+        limits.qpack_blocked_streams = 1u64 << 62;
+        let err = Settings::from_limits(&limits).unwrap_err();
+        assert!(matches!(err, crate::varint::VarIntError::OutOfRange { .. }));
     }
 }

--- a/src/stream/control.rs
+++ b/src/stream/control.rs
@@ -245,8 +245,9 @@ impl ControlStreamRecv {
                         crate::error::FrameDecodeError::ServerPushNotSupported(_) => {
                             Error::ConnectionError(ErrorCode::FrameUnexpected)
                         }
-                        // HTTP/2 専用設定 ID は設定エラー (RFC 9114 Section 7.2.4)
-                        crate::error::FrameDecodeError::InvalidSettingsId(_) => {
+                        // SETTINGS パラメータの構築時検査エラー (重複 / HTTP/2 専用 / 予約 / bool 値域外)
+                        // は H3_SETTINGS_ERROR (RFC 9114 §7.2.4 / §7.2.4.1)
+                        crate::error::FrameDecodeError::InvalidSetting(_) => {
                             Error::ConnectionError(ErrorCode::SettingsError)
                         }
                         // payload 途中切れはフレームエラー (RFC 9114 Section 7.1)
@@ -260,7 +261,7 @@ impl ControlStreamRecv {
                     // SETTINGS が最初のフレームである必要がある (RFC 9114 Section 6.2.1)
                     if self.recv_state == ControlRecvState::WaitingSettings {
                         if let Frame::Settings(ref payload) = frame {
-                            self.peer_settings = Some(Settings::from_payload(payload)?);
+                            self.peer_settings = Some(Settings::from_payload(payload));
                             self.recv_state = ControlRecvState::Ready;
                         } else {
                             return Err(Error::ConnectionError(ErrorCode::MissingSettings));
@@ -305,8 +306,9 @@ mod tests {
 
     #[test]
     fn test_control_stream_send() {
+        use crate::varint::VarInt;
         let mut stream = ControlStreamSend::new();
-        let settings = Settings::new().max_field_section_size(16384);
+        let settings = Settings::new().max_field_section_size(VarInt::from_static(16384));
 
         stream.send_settings(&settings);
         assert!(stream.has_pending());

--- a/src/webtransport/connect.rs
+++ b/src/webtransport/connect.rs
@@ -13,6 +13,7 @@
 use core::fmt;
 
 use crate::qpack::Header;
+use crate::varint::VarInt;
 
 /// `:protocol` 疑似ヘッダーの値 (draft-ietf-webtrans-http3-15 Section 3.2)
 ///
@@ -54,25 +55,27 @@ pub enum DraftVersion {
 /// `DraftVersion::build_server_settings()` および
 /// `DraftVersion::build_client_settings()` で使用する。
 /// ドラフトバージョンに応じて必要なパラメータのみが反映される。
+///
+/// 各フィールドは VarInt (RFC 9000 §16) に制約される。
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ServerSettingsParams {
     /// 最大セッション数 (draft-07/14 で使用)
-    pub max_sessions: u64,
+    pub max_sessions: VarInt,
     /// 初期単方向ストリーム上限 (draft-14/15 で使用)
-    pub initial_max_streams_uni: u64,
+    pub initial_max_streams_uni: VarInt,
     /// 初期双方向ストリーム上限 (draft-14/15 で使用)
-    pub initial_max_streams_bidi: u64,
+    pub initial_max_streams_bidi: VarInt,
     /// 初期データ上限 (draft-14/15 で使用)
-    pub initial_max_data: u64,
+    pub initial_max_data: VarInt,
 }
 
 impl Default for ServerSettingsParams {
     fn default() -> Self {
         Self {
-            max_sessions: 1,
-            initial_max_streams_uni: 100,
-            initial_max_streams_bidi: 100,
-            initial_max_data: 8 * 1024 * 1024,
+            max_sessions: VarInt::from_static(1),
+            initial_max_streams_uni: VarInt::from_static(100),
+            initial_max_streams_bidi: VarInt::from_static(100),
+            initial_max_data: VarInt::from_static(8 * 1024 * 1024),
         }
     }
 }
@@ -106,7 +109,7 @@ impl DraftVersion {
     ) -> super::settings::Settings {
         match self {
             Self::Draft15 => super::settings::Settings::new()
-                .wt_enabled(1)
+                .wt_enabled(VarInt::from_static(1))
                 .wt_initial_max_streams_uni(params.initial_max_streams_uni)
                 .wt_initial_max_streams_bidi(params.initial_max_streams_bidi)
                 .wt_initial_max_data(params.initial_max_data),
@@ -206,7 +209,7 @@ impl DraftVersion {
     ) -> super::settings::Settings {
         match self {
             Self::Draft15 => super::settings::Settings::new()
-                .wt_enabled(1)
+                .wt_enabled(VarInt::from_static(1))
                 .wt_initial_max_streams_uni(params.initial_max_streams_uni)
                 .wt_initial_max_streams_bidi(params.initial_max_streams_bidi)
                 .wt_initial_max_data(params.initial_max_data),
@@ -1106,17 +1109,21 @@ mod tests {
         );
     }
 
+    fn vi(value: u64) -> VarInt {
+        VarInt::new(value).unwrap()
+    }
+
     #[test]
     fn test_build_server_settings_draft15() {
         let params = ServerSettingsParams {
-            initial_max_streams_uni: 500,
-            initial_max_streams_bidi: 300,
+            initial_max_streams_uni: vi(500),
+            initial_max_streams_bidi: vi(300),
             ..Default::default()
         };
         let s = DraftVersion::Draft15.build_server_settings(&params);
-        assert_eq!(s.wt_enabled, 1);
-        assert_eq!(s.wt_initial_max_streams_uni, 500);
-        assert_eq!(s.wt_initial_max_streams_bidi, 300);
+        assert_eq!(s.wt_enabled, vi(1));
+        assert_eq!(s.wt_initial_max_streams_uni, vi(500));
+        assert_eq!(s.wt_initial_max_streams_bidi, vi(300));
         // draft-15 でも wt_initial_max_data を反映する (Section 5.5.3)
         assert_eq!(
             s.wt_initial_max_data,
@@ -1129,27 +1136,27 @@ mod tests {
     #[test]
     fn test_build_server_settings_draft14() {
         let params = ServerSettingsParams {
-            max_sessions: 100,
-            initial_max_streams_uni: 1000,
-            initial_max_streams_bidi: 1000,
-            initial_max_data: 8 * 1024 * 1024,
+            max_sessions: vi(100),
+            initial_max_streams_uni: vi(1000),
+            initial_max_streams_bidi: vi(1000),
+            initial_max_data: vi(8 * 1024 * 1024),
         };
         let s = DraftVersion::Draft14.build_server_settings(&params);
         // Safari 互換: draft-07 と draft-14 の両方の max_sessions を設定し、
         // 初期フロー制御値はカプセルで通知するため SETTINGS には含めない。
-        assert_eq!(s.wt_max_sessions_draft14, Some(100));
-        assert_eq!(s.webtransport_max_sessions_draft07, Some(100));
-        assert_eq!(s.wt_initial_max_streams_uni, 0);
-        assert_eq!(s.wt_initial_max_streams_bidi, 0);
-        assert_eq!(s.wt_initial_max_data, 0);
+        assert_eq!(s.wt_max_sessions_draft14, Some(vi(100)));
+        assert_eq!(s.webtransport_max_sessions_draft07, Some(vi(100)));
+        assert_eq!(s.wt_initial_max_streams_uni, VarInt::ZERO);
+        assert_eq!(s.wt_initial_max_streams_bidi, VarInt::ZERO);
+        assert_eq!(s.wt_initial_max_data, VarInt::ZERO);
     }
 
     #[test]
     fn test_build_server_settings_draft07() {
         let params = ServerSettingsParams::default();
         let s = DraftVersion::Draft07.build_server_settings(&params);
-        assert_eq!(s.webtransport_max_sessions_draft07, Some(1));
-        assert_eq!(s.wt_enabled, 0);
+        assert_eq!(s.webtransport_max_sessions_draft07, Some(vi(1)));
+        assert_eq!(s.wt_enabled, VarInt::ZERO);
         assert_eq!(s.wt_max_sessions_draft14, None);
         assert_eq!(s.enable_webtransport_draft02, None);
     }
@@ -1159,7 +1166,7 @@ mod tests {
         let params = ServerSettingsParams::default();
         let s = DraftVersion::Draft02.build_server_settings(&params);
         assert_eq!(s.enable_webtransport_draft02, Some(true));
-        assert_eq!(s.wt_enabled, 0);
+        assert_eq!(s.wt_enabled, VarInt::ZERO);
         assert_eq!(s.webtransport_max_sessions_draft07, None);
     }
 
@@ -1207,7 +1214,7 @@ mod tests {
     fn test_build_client_settings_draft15() {
         let params = ServerSettingsParams::default();
         let s = DraftVersion::Draft15.build_client_settings(&params);
-        assert_eq!(s.wt_enabled, 1);
+        assert_eq!(s.wt_enabled, vi(1));
         assert_eq!(s.wt_initial_max_streams_uni, params.initial_max_streams_uni);
         assert_eq!(
             s.wt_initial_max_streams_bidi,
@@ -1232,7 +1239,7 @@ mod tests {
             params.initial_max_streams_bidi
         );
         assert_eq!(s.wt_initial_max_data, params.initial_max_data);
-        assert_eq!(s.wt_enabled, 0);
+        assert_eq!(s.wt_enabled, VarInt::ZERO);
         assert_eq!(s.detect_draft_pattern(), Some(DraftVersion::Draft14));
     }
 
@@ -1245,7 +1252,7 @@ mod tests {
             Some(params.max_sessions)
         );
         assert_eq!(s.wt_max_sessions_draft14, None);
-        assert_eq!(s.wt_enabled, 0);
+        assert_eq!(s.wt_enabled, VarInt::ZERO);
         assert_eq!(s.enable_webtransport_draft02, None);
         assert_eq!(s.detect_draft_pattern(), Some(DraftVersion::Draft07));
     }
@@ -1255,7 +1262,7 @@ mod tests {
         let params = ServerSettingsParams::default();
         let s = DraftVersion::Draft02.build_client_settings(&params);
         assert_eq!(s.enable_webtransport_draft02, Some(true));
-        assert_eq!(s.wt_enabled, 0);
+        assert_eq!(s.wt_enabled, VarInt::ZERO);
         assert_eq!(s.webtransport_max_sessions_draft07, None);
         assert_eq!(s.wt_max_sessions_draft14, None);
         assert_eq!(s.detect_draft_pattern(), Some(DraftVersion::Draft02));

--- a/src/webtransport/mod.rs
+++ b/src/webtransport/mod.rs
@@ -46,7 +46,7 @@ pub use error::{ApplicationErrorCode, Error, ErrorCode};
 pub use session::{
     BufferedStream, CapsuleProcessError, FlowControlLimits, FlowControlState, Session, SessionState,
 };
-pub use settings::{Settings, SettingsId};
+pub use settings::Settings;
 pub use stream::{
     BIDIRECTIONAL_SIGNAL_VALUE, ClassifiedUniStream, Stream, StreamHeader, StreamHeaderDecodeError,
     UNIDIRECTIONAL_STREAM_TYPE, classify_uni_stream, classify_uni_stream_checked, stream_type,

--- a/src/webtransport/settings.rs
+++ b/src/webtransport/settings.rs
@@ -1,76 +1,38 @@
 //! WebTransport SETTINGS (draft-ietf-webtrans-http3-15 Section 9.2)
 //!
-//! HTTP/3 SETTINGS パラメータの WebTransport 拡張を定義。
+//! HTTP/3 SETTINGS パラメータの WebTransport 拡張を定義する。
+//!
+//! ID 別の wire 構造とブール値の検査は [`crate::settings::Setting`] が一手に
+//! 担うため、本モジュールは「WebTransport 固有フィールドの型付きコレクション」
+//! と「`Setting` から本構造体への流し込み」のみを提供する。
 
 use super::connect::DraftVersion;
+use crate::settings::Setting;
+use crate::varint::VarInt;
 
-/// WebTransport SETTINGS パラメータ ID
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[repr(u64)]
-pub enum SettingsId {
-    /// WebTransport 有効化 (SETTINGS_WT_ENABLED)
-    /// draft-ietf-webtrans-http3-15 Section 3.1, Section 9.2
-    /// 将来のドラフトで変更される可能性がある
-    WtEnabled = 0x2c7cf000,
-    /// 初期単方向ストリーム上限 (SETTINGS_WT_INITIAL_MAX_STREAMS_UNI)
-    WtInitialMaxStreamsUni = 0x2b64,
-    /// 初期双方向ストリーム上限 (SETTINGS_WT_INITIAL_MAX_STREAMS_BIDI)
-    WtInitialMaxStreamsBidi = 0x2b65,
-    /// 初期データ上限 (SETTINGS_WT_INITIAL_MAX_DATA)
-    WtInitialMaxData = 0x2b61,
-    /// WebTransport 有効化 (draft-02)
-    EnableWebTransportDraft02 = 0x2b603742,
-    /// WebTransport 最大セッション数 (draft-07)
-    WebTransportMaxSessionsDraft07 = 0xc671706a,
-    /// WebTransport 最大セッション数 (draft-14)
-    /// draft-14 Section 9.2
-    WtMaxSessionsDraft14 = 0x14e9cd29,
-}
-
-impl SettingsId {
-    /// ID から `SettingsId` を作成
-    pub fn from_id(id: u64) -> Option<Self> {
-        match id {
-            0x2c7cf000 => Some(Self::WtEnabled),
-            0x2b64 => Some(Self::WtInitialMaxStreamsUni),
-            0x2b65 => Some(Self::WtInitialMaxStreamsBidi),
-            0x2b61 => Some(Self::WtInitialMaxData),
-            0x2b603742 => Some(Self::EnableWebTransportDraft02),
-            0xc671706a => Some(Self::WebTransportMaxSessionsDraft07),
-            0x14e9cd29 => Some(Self::WtMaxSessionsDraft14),
-            _ => None,
-        }
-    }
-
-    /// WebTransport 関連の設定 ID かどうか
-    pub fn is_webtransport(id: u64) -> bool {
-        matches!(
-            id,
-            0x2c7cf000 | 0x2b64 | 0x2b65 | 0x2b61 | 0x2b603742 | 0xc671706a | 0x14e9cd29
-        )
-    }
-}
-
-/// WebTransport 設定
+/// WebTransport 設定 (型付きフィールドのコレクション)
+///
+/// draft-ietf-webtrans-http3-02 / -07 / -14 / -15。
+/// 将来のドラフトで変更される可能性がある。
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Settings {
     /// WebTransport 有効化 (デフォルト: 0 = WebTransport 無効, 0 より大きければ有効)
     /// draft-ietf-webtrans-http3-15 Section 3.1, Section 9.2
     /// 将来のドラフトで変更される可能性がある
-    pub wt_enabled: u64,
+    pub wt_enabled: VarInt,
     /// 初期単方向ストリーム上限 (デフォルト: 0)
-    pub wt_initial_max_streams_uni: u64,
+    pub wt_initial_max_streams_uni: VarInt,
     /// 初期双方向ストリーム上限 (デフォルト: 0)
-    pub wt_initial_max_streams_bidi: u64,
+    pub wt_initial_max_streams_bidi: VarInt,
     /// 初期データ上限 (デフォルト: 0)
-    pub wt_initial_max_data: u64,
+    pub wt_initial_max_data: VarInt,
     /// WebTransport 有効化 (draft-02)
     pub enable_webtransport_draft02: Option<bool>,
     /// WebTransport 最大セッション数 (draft-07)
-    pub webtransport_max_sessions_draft07: Option<u64>,
+    pub webtransport_max_sessions_draft07: Option<VarInt>,
     /// WebTransport 最大セッション数 (draft-14)
     /// draft-14 Section 9.2
-    pub wt_max_sessions_draft14: Option<u64>,
+    pub wt_max_sessions_draft14: Option<VarInt>,
 }
 
 impl Default for Settings {
@@ -83,10 +45,10 @@ impl Settings {
     /// 新しい Settings を作成 (すべてデフォルト値)
     pub const fn new() -> Self {
         Self {
-            wt_enabled: 0,
-            wt_initial_max_streams_uni: 0,
-            wt_initial_max_streams_bidi: 0,
-            wt_initial_max_data: 0,
+            wt_enabled: VarInt::ZERO,
+            wt_initial_max_streams_uni: VarInt::ZERO,
+            wt_initial_max_streams_bidi: VarInt::ZERO,
+            wt_initial_max_data: VarInt::ZERO,
             enable_webtransport_draft02: None,
             webtransport_max_sessions_draft07: None,
             wt_max_sessions_draft14: None,
@@ -96,25 +58,25 @@ impl Settings {
     /// WebTransport 有効化を設定
     /// draft-ietf-webtrans-http3-15 Section 3.1, Section 9.2
     /// 将来のドラフトで変更される可能性がある
-    pub fn wt_enabled(mut self, value: u64) -> Self {
+    pub fn wt_enabled(mut self, value: VarInt) -> Self {
         self.wt_enabled = value;
         self
     }
 
     /// 初期単方向ストリーム上限を設定
-    pub fn wt_initial_max_streams_uni(mut self, max_streams: u64) -> Self {
+    pub fn wt_initial_max_streams_uni(mut self, max_streams: VarInt) -> Self {
         self.wt_initial_max_streams_uni = max_streams;
         self
     }
 
     /// 初期双方向ストリーム上限を設定
-    pub fn wt_initial_max_streams_bidi(mut self, max_streams: u64) -> Self {
+    pub fn wt_initial_max_streams_bidi(mut self, max_streams: VarInt) -> Self {
         self.wt_initial_max_streams_bidi = max_streams;
         self
     }
 
     /// 初期データ上限を設定
-    pub fn wt_initial_max_data(mut self, max_data: u64) -> Self {
+    pub fn wt_initial_max_data(mut self, max_data: VarInt) -> Self {
         self.wt_initial_max_data = max_data;
         self
     }
@@ -126,16 +88,80 @@ impl Settings {
     }
 
     /// WebTransport 最大セッション数 (draft-07) を設定
-    pub fn webtransport_max_sessions_draft07(mut self, max_sessions: u64) -> Self {
+    pub fn webtransport_max_sessions_draft07(mut self, max_sessions: VarInt) -> Self {
         self.webtransport_max_sessions_draft07 = Some(max_sessions);
         self
     }
 
     /// WebTransport 最大セッション数 (draft-14) を設定
     /// draft-14 Section 9.2
-    pub fn wt_max_sessions_draft14(mut self, max_sessions: u64) -> Self {
+    pub fn wt_max_sessions_draft14(mut self, max_sessions: VarInt) -> Self {
         self.wt_max_sessions_draft14 = Some(max_sessions);
         self
+    }
+
+    /// `Setting` のスライスから WebTransport 関連設定だけを取り出して構築する
+    ///
+    /// WebTransport 関連の variant が 1 つも含まれない場合は `None` を返す。
+    ///
+    /// 呼び出し側は [`crate::frame::SettingsPayload::add`] を経由して構築された
+    /// スライス (ID 重複なし) を渡す前提で、本関数は重複検査をしない。直接
+    /// `&[Setting]` を渡す内部呼び出しで万一同一 variant が複数現れた場合は
+    /// debug ビルドで panic させ、release ビルドは最後の値で上書きする
+    /// (本関数の不変条件破壊を `debug_assert!` で検出する)。
+    pub(crate) fn from_payload(settings: &[Setting]) -> Option<Self> {
+        let mut wt = Self::new();
+        let mut found = false;
+        let mut seen_wt_ids = std::collections::HashSet::new();
+        for setting in settings {
+            // 同一 WT variant の重複は呼び出し側 (`SettingsPayload::add`) が
+            // 弾いている前提だが、本関数の不変条件を debug ビルドで検証する。
+            match *setting {
+                Setting::WtEnabled(v) => {
+                    debug_assert!(seen_wt_ids.insert(setting.id()));
+                    wt.wt_enabled = v;
+                    found = true;
+                }
+                Setting::WtInitialMaxStreamsUni(v) => {
+                    debug_assert!(seen_wt_ids.insert(setting.id()));
+                    wt.wt_initial_max_streams_uni = v;
+                    found = true;
+                }
+                Setting::WtInitialMaxStreamsBidi(v) => {
+                    debug_assert!(seen_wt_ids.insert(setting.id()));
+                    wt.wt_initial_max_streams_bidi = v;
+                    found = true;
+                }
+                Setting::WtInitialMaxData(v) => {
+                    debug_assert!(seen_wt_ids.insert(setting.id()));
+                    wt.wt_initial_max_data = v;
+                    found = true;
+                }
+                Setting::EnableWebTransportDraft02(b) => {
+                    debug_assert!(seen_wt_ids.insert(setting.id()));
+                    wt.enable_webtransport_draft02 = Some(b);
+                    found = true;
+                }
+                Setting::WebTransportMaxSessionsDraft07(v) => {
+                    debug_assert!(seen_wt_ids.insert(setting.id()));
+                    wt.webtransport_max_sessions_draft07 = Some(v);
+                    found = true;
+                }
+                Setting::WtMaxSessionsDraft14(v) => {
+                    debug_assert!(seen_wt_ids.insert(setting.id()));
+                    wt.wt_max_sessions_draft14 = Some(v);
+                    found = true;
+                }
+                // 非 WebTransport variant および Unknown は無視
+                Setting::QpackMaxTableCapacity(_)
+                | Setting::MaxFieldSectionSize(_)
+                | Setting::QpackBlockedStreams(_)
+                | Setting::EnableConnectProtocol(_)
+                | Setting::H3Datagram(_)
+                | Setting::Unknown(_) => {}
+            }
+        }
+        found.then_some(wt)
     }
 
     /// SETTINGS からドラフトバージョンを検出する
@@ -161,16 +187,16 @@ impl Settings {
     /// draft-ietf-webtrans-http3-02 / -07 / -14 / -15
     /// 将来のドラフトで変更される可能性がある
     pub fn detect_draft_pattern(&self) -> Option<DraftVersion> {
-        if self.wt_enabled > 0 {
+        if self.wt_enabled.get() > 0 {
             return Some(DraftVersion::Draft15);
         }
         if self
             .webtransport_max_sessions_draft07
-            .is_some_and(|v| v > 0)
+            .is_some_and(|v| v.get() > 0)
         {
             return Some(DraftVersion::Draft07);
         }
-        if self.wt_max_sessions_draft14.is_some_and(|v| v > 0) {
+        if self.wt_max_sessions_draft14.is_some_and(|v| v.get() > 0) {
             return Some(DraftVersion::Draft14);
         }
         if self.enable_webtransport_draft02 == Some(true) {
@@ -184,12 +210,12 @@ impl Settings {
     /// draft-02/07/14/15 のいずれかで有効になっていれば true。
     /// 将来のドラフトで変更される可能性がある
     pub fn is_enabled(&self) -> bool {
-        self.wt_enabled > 0
+        self.wt_enabled.get() > 0
             || self.enable_webtransport_draft02 == Some(true)
             || self
                 .webtransport_max_sessions_draft07
-                .is_some_and(|v| v > 0)
-            || self.wt_max_sessions_draft14.is_some_and(|v| v > 0)
+                .is_some_and(|v| v.get() > 0)
+            || self.wt_max_sessions_draft14.is_some_and(|v| v.get() > 0)
     }
 
     /// フロー制御が有効かどうか
@@ -203,17 +229,10 @@ impl Settings {
     /// draft-ietf-webtrans-http3-14 Section 5.1, draft-ietf-webtrans-http3-15 Section 5.1
     /// 将来のドラフトで変更される可能性がある
     pub fn declares_flow_control(&self) -> bool {
-        self.wt_max_sessions_draft14.is_some_and(|v| v > 1)
-            || self.wt_initial_max_streams_uni != 0
-            || self.wt_initial_max_streams_bidi != 0
-            || self.wt_initial_max_data != 0
-    }
-
-    /// フロー制御を有効として扱うかどうか
-    ///
-    /// 互換性のためにローカル宣言判定を返す。
-    pub fn flow_control_enabled(&self) -> bool {
-        self.declares_flow_control()
+        self.wt_max_sessions_draft14.is_some_and(|v| v.get() > 1)
+            || self.wt_initial_max_streams_uni.get() != 0
+            || self.wt_initial_max_streams_bidi.get() != 0
+            || self.wt_initial_max_data.get() != 0
     }
 
     /// ピアとのネゴシエーション結果としてフロー制御が有効かどうか
@@ -241,104 +260,34 @@ impl Settings {
         match self.detect_draft_pattern() {
             Some(DraftVersion::Draft14) => true,
             Some(DraftVersion::Draft07) => {
-                self.wt_initial_max_streams_uni != 0
-                    || self.wt_initial_max_streams_bidi != 0
-                    || self.wt_initial_max_data != 0
+                self.wt_initial_max_streams_uni.get() != 0
+                    || self.wt_initial_max_streams_bidi.get() != 0
+                    || self.wt_initial_max_data.get() != 0
             }
             _ => false,
         }
     }
 
-    /// 複数セッションの同時使用が許可されるかどうか
-    ///
-    /// フロー制御が有効でない場合、エンドポイントは同時に 1 セッションのみ使用可能 (MUST NOT)。
-    /// draft-ietf-webtrans-http3-15 Section 5.2
-    /// 将来のドラフトで変更される可能性がある
-    pub fn allows_multiple_sessions_with_peer(&self, peer: &Self) -> bool {
-        self.flow_control_enabled_with_peer(peer)
-    }
-
-    /// SettingsPayload から WebTransport Settings を作成
-    ///
-    /// WebTransport 関連の設定 ID のみをパースする。
-    /// 1 つも WebTransport 関連 ID が含まれない場合は None を返す。
-    ///
-    /// `SETTINGS_ENABLE_WEBTRANSPORT_DRAFT02` (0x2b603742) はブール設定であり、
-    /// 値が 0 または 1 以外の場合は `H3_SETTINGS_ERROR` を返す。
-    /// draft-ietf-webtrans-http3-02 由来。将来変更される可能性がある。
-    pub fn from_payload(
-        payload: &crate::frame::SettingsPayload,
-    ) -> Result<Option<Self>, crate::error::Error> {
-        let mut settings = Self::new();
-        let mut found = false;
-        for (id, value) in &payload.entries {
-            match *id {
-                0x2c7cf000 => {
-                    settings.wt_enabled = *value;
-                    found = true;
-                }
-                0x2b64 => {
-                    settings.wt_initial_max_streams_uni = *value;
-                    found = true;
-                }
-                0x2b65 => {
-                    settings.wt_initial_max_streams_bidi = *value;
-                    found = true;
-                }
-                0x2b61 => {
-                    settings.wt_initial_max_data = *value;
-                    found = true;
-                }
-                // SETTINGS_ENABLE_WEBTRANSPORT_DRAFT02: ブール設定
-                // 値は 0 または 1 のみ
-                // (draft-ietf-webtrans-http3-02 由来、将来変更される可能性がある)
-                0x2b603742 => {
-                    if *value > 1 {
-                        return Err(crate::error::Error::ConnectionError(
-                            crate::error::ErrorCode::SettingsError,
-                        ));
-                    }
-                    settings.enable_webtransport_draft02 = Some(*value == 1);
-                    found = true;
-                }
-                0xc671706a => {
-                    settings.webtransport_max_sessions_draft07 = Some(*value);
-                    found = true;
-                }
-                0x14e9cd29 => {
-                    settings.wt_max_sessions_draft14 = Some(*value);
-                    found = true;
-                }
-                _ => {} // H3 設定や不明な ID は無視
-            }
-        }
-        Ok(found.then_some(settings))
-    }
-
     /// 設定エントリのイテレータを返す
     ///
-    /// 0 以外の値を持つ設定のみを返す。
-    pub fn iter(&self) -> impl Iterator<Item = (u64, u64)> + '_ {
+    /// 値が 0 / `None` の WebTransport 設定はエントリに含めない。
+    pub fn iter(&self) -> impl Iterator<Item = Setting> + '_ {
         let entries = [
-            (self.wt_enabled > 0).then_some((SettingsId::WtEnabled as u64, self.wt_enabled)),
-            (self.wt_initial_max_streams_uni > 0).then_some((
-                SettingsId::WtInitialMaxStreamsUni as u64,
-                self.wt_initial_max_streams_uni,
-            )),
-            (self.wt_initial_max_streams_bidi > 0).then_some((
-                SettingsId::WtInitialMaxStreamsBidi as u64,
-                self.wt_initial_max_streams_bidi,
-            )),
-            (self.wt_initial_max_data > 0).then_some((
-                SettingsId::WtInitialMaxData as u64,
-                self.wt_initial_max_data,
-            )),
+            (self.wt_enabled != VarInt::ZERO).then_some(Setting::WtEnabled(self.wt_enabled)),
+            (self.wt_initial_max_streams_uni != VarInt::ZERO).then_some(
+                Setting::WtInitialMaxStreamsUni(self.wt_initial_max_streams_uni),
+            ),
+            (self.wt_initial_max_streams_bidi != VarInt::ZERO).then_some(
+                Setting::WtInitialMaxStreamsBidi(self.wt_initial_max_streams_bidi),
+            ),
+            (self.wt_initial_max_data != VarInt::ZERO)
+                .then_some(Setting::WtInitialMaxData(self.wt_initial_max_data)),
             self.enable_webtransport_draft02
-                .map(|v| (SettingsId::EnableWebTransportDraft02 as u64, u64::from(v))),
+                .map(Setting::EnableWebTransportDraft02),
             self.webtransport_max_sessions_draft07
-                .map(|v| (SettingsId::WebTransportMaxSessionsDraft07 as u64, v)),
+                .map(Setting::WebTransportMaxSessionsDraft07),
             self.wt_max_sessions_draft14
-                .map(|v| (SettingsId::WtMaxSessionsDraft14 as u64, v)),
+                .map(Setting::WtMaxSessionsDraft14),
         ];
         entries.into_iter().flatten()
     }
@@ -348,77 +297,43 @@ impl Settings {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_settings_id_from_id() {
-        assert_eq!(SettingsId::from_id(0x2c7cf000), Some(SettingsId::WtEnabled));
-        assert_eq!(
-            SettingsId::from_id(0x2b64),
-            Some(SettingsId::WtInitialMaxStreamsUni)
-        );
-        assert_eq!(
-            SettingsId::from_id(0x2b65),
-            Some(SettingsId::WtInitialMaxStreamsBidi)
-        );
-        assert_eq!(
-            SettingsId::from_id(0x2b61),
-            Some(SettingsId::WtInitialMaxData)
-        );
-        assert_eq!(
-            SettingsId::from_id(0x2b603742),
-            Some(SettingsId::EnableWebTransportDraft02)
-        );
-        assert_eq!(
-            SettingsId::from_id(0xc671706a),
-            Some(SettingsId::WebTransportMaxSessionsDraft07)
-        );
-        assert_eq!(SettingsId::from_id(0x99), None);
-    }
-
-    #[test]
-    fn test_settings_id_is_webtransport() {
-        assert!(SettingsId::is_webtransport(0x2c7cf000));
-        assert!(SettingsId::is_webtransport(0x2b64));
-        assert!(SettingsId::is_webtransport(0x2b65));
-        assert!(SettingsId::is_webtransport(0x2b61));
-        assert!(SettingsId::is_webtransport(0x2b603742));
-        assert!(SettingsId::is_webtransport(0xc671706a));
-        assert!(!SettingsId::is_webtransport(0x01));
-        assert!(!SettingsId::is_webtransport(0x99));
+    fn v(n: u64) -> VarInt {
+        VarInt::new(n).unwrap()
     }
 
     #[test]
     fn test_settings_default() {
         let settings = Settings::default();
-        assert_eq!(settings.wt_enabled, 0);
+        assert_eq!(settings.wt_enabled, VarInt::ZERO);
         assert!(!settings.is_enabled());
-        assert!(!settings.flow_control_enabled());
+        assert!(!settings.declares_flow_control());
     }
 
     #[test]
     fn test_settings_builder() {
         let settings = Settings::new()
-            .wt_enabled(1)
-            .wt_initial_max_streams_uni(100)
-            .wt_initial_max_streams_bidi(50)
-            .wt_initial_max_data(1024 * 1024);
+            .wt_enabled(v(1))
+            .wt_initial_max_streams_uni(v(100))
+            .wt_initial_max_streams_bidi(v(50))
+            .wt_initial_max_data(v(1024 * 1024));
 
-        assert_eq!(settings.wt_enabled, 1);
-        assert_eq!(settings.wt_initial_max_streams_uni, 100);
-        assert_eq!(settings.wt_initial_max_streams_bidi, 50);
-        assert_eq!(settings.wt_initial_max_data, 1024 * 1024);
+        assert_eq!(settings.wt_enabled, v(1));
+        assert_eq!(settings.wt_initial_max_streams_uni, v(100));
+        assert_eq!(settings.wt_initial_max_streams_bidi, v(50));
+        assert_eq!(settings.wt_initial_max_data, v(1024 * 1024));
         assert!(settings.is_enabled());
-        assert!(settings.flow_control_enabled());
+        assert!(settings.declares_flow_control());
     }
 
     #[test]
     fn test_settings_draft02_07() {
         let settings = Settings::new()
             .enable_webtransport_draft02(true)
-            .webtransport_max_sessions_draft07(5);
+            .webtransport_max_sessions_draft07(v(5));
 
         assert!(settings.is_enabled());
         assert_eq!(settings.enable_webtransport_draft02, Some(true));
-        assert_eq!(settings.webtransport_max_sessions_draft07, Some(5));
+        assert_eq!(settings.webtransport_max_sessions_draft07, Some(v(5)));
     }
 
     #[test]
@@ -432,109 +347,122 @@ mod tests {
 
     #[test]
     fn test_is_enabled_draft07() {
-        let settings = Settings::new().webtransport_max_sessions_draft07(1);
+        let settings = Settings::new().webtransport_max_sessions_draft07(v(1));
         assert!(settings.is_enabled());
 
-        let settings = Settings::new().webtransport_max_sessions_draft07(0);
+        let settings = Settings::new().webtransport_max_sessions_draft07(v(0));
         assert!(!settings.is_enabled());
     }
 
     #[test]
     fn test_flow_control_enabled() {
         // wt_enabled のみではフロー制御無効 (draft-15: INITIAL_MAX_* が必要)
-        let settings = Settings::new().wt_enabled(1);
-        assert!(!settings.flow_control_enabled());
+        let settings = Settings::new().wt_enabled(v(1));
+        assert!(!settings.declares_flow_control());
 
-        let settings = Settings::new().wt_enabled(2);
-        assert!(!settings.flow_control_enabled());
+        let settings = Settings::new().wt_enabled(v(2));
+        assert!(!settings.declares_flow_control());
 
         // INITIAL_MAX_* が非ゼロならフロー制御有効
-        let settings = Settings::new().wt_enabled(1).wt_initial_max_streams_uni(10);
-        assert!(settings.flow_control_enabled());
+        let settings = Settings::new()
+            .wt_enabled(v(1))
+            .wt_initial_max_streams_uni(v(10));
+        assert!(settings.declares_flow_control());
 
-        let settings = Settings::new().wt_enabled(1).wt_initial_max_streams_bidi(5);
-        assert!(settings.flow_control_enabled());
+        let settings = Settings::new()
+            .wt_enabled(v(1))
+            .wt_initial_max_streams_bidi(v(5));
+        assert!(settings.declares_flow_control());
 
-        let settings = Settings::new().wt_enabled(1).wt_initial_max_data(1024);
-        assert!(settings.flow_control_enabled());
+        let settings = Settings::new()
+            .wt_enabled(v(1))
+            .wt_initial_max_data(v(1024));
+        assert!(settings.declares_flow_control());
     }
 
     #[test]
     fn test_flow_control_enabled_with_peer() {
-        let local = Settings::new().wt_initial_max_streams_uni(10);
-        let peer = Settings::new().wt_enabled(1);
+        let local = Settings::new().wt_initial_max_streams_uni(v(10));
+        let peer = Settings::new().wt_enabled(v(1));
         assert!(!local.flow_control_enabled_with_peer(&peer));
 
-        let peer = Settings::new().wt_initial_max_data(1);
+        let peer = Settings::new().wt_initial_max_data(v(1));
         assert!(local.flow_control_enabled_with_peer(&peer));
     }
 
     #[test]
     fn test_settings_iter() {
-        let settings = Settings::new().wt_enabled(1).wt_initial_max_data(4096);
+        let settings = Settings::new()
+            .wt_enabled(v(1))
+            .wt_initial_max_data(v(4096));
 
         let entries: Vec<_> = settings.iter().collect();
         assert_eq!(entries.len(), 2);
-        assert!(entries.contains(&(0x2c7cf000, 1)));
-        assert!(entries.contains(&(0x2b61, 4096)));
+        assert!(entries.contains(&Setting::WtEnabled(v(1))));
+        assert!(entries.contains(&Setting::WtInitialMaxData(v(4096))));
     }
 
     #[test]
     fn test_settings_iter_with_draft02_07() {
         let settings = Settings::new()
-            .wt_enabled(1)
+            .wt_enabled(v(1))
             .enable_webtransport_draft02(true)
-            .webtransport_max_sessions_draft07(3);
+            .webtransport_max_sessions_draft07(v(3));
 
         let entries: Vec<_> = settings.iter().collect();
         assert_eq!(entries.len(), 3);
-        assert!(entries.contains(&(0x2c7cf000, 1)));
-        assert!(entries.contains(&(0x2b603742, 1)));
-        assert!(entries.contains(&(0xc671706a, 3)));
+        assert!(entries.contains(&Setting::WtEnabled(v(1))));
+        assert!(entries.contains(&Setting::EnableWebTransportDraft02(true)));
+        assert!(entries.contains(&Setting::WebTransportMaxSessionsDraft07(v(3))));
     }
 
     #[test]
-    fn test_from_payload() {
-        let mut payload = crate::frame::SettingsPayload::new();
-        payload.add(0x2c7cf000, 1);
-        payload.add(0x2b64, 100);
-        payload.add(0x2b65, 50);
-        payload.add(0x2b61, 1048576);
-        payload.add(0x2b603742, 1);
-        payload.add(0xc671706a, 3);
-
-        let settings = Settings::from_payload(&payload).unwrap().unwrap();
-        assert_eq!(settings.wt_enabled, 1);
-        assert_eq!(settings.wt_initial_max_streams_uni, 100);
-        assert_eq!(settings.wt_initial_max_streams_bidi, 50);
-        assert_eq!(settings.wt_initial_max_data, 1048576);
-        assert_eq!(settings.enable_webtransport_draft02, Some(true));
-        assert_eq!(settings.webtransport_max_sessions_draft07, Some(3));
+    fn test_from_payload_wt_setting() {
+        // WebTransport variant のみ反映され、非 WT / Unknown は無視されることを検証
+        let unknown = Setting::from_wire(v(0xdead), v(1)).unwrap();
+        let entries = [
+            Setting::WtEnabled(v(1)),
+            Setting::WtInitialMaxStreamsUni(v(100)),
+            Setting::WtInitialMaxStreamsBidi(v(50)),
+            Setting::WtInitialMaxData(v(1024)),
+            Setting::EnableWebTransportDraft02(true),
+            Setting::WebTransportMaxSessionsDraft07(v(3)),
+            Setting::WtMaxSessionsDraft14(v(2)),
+            Setting::H3Datagram(true), // 非 WT、無視される
+            unknown,                   // Unknown、無視される
+        ];
+        let wt = Settings::from_payload(&entries).unwrap();
+        assert_eq!(wt.wt_enabled, v(1));
+        assert_eq!(wt.wt_initial_max_streams_uni, v(100));
+        assert_eq!(wt.wt_initial_max_streams_bidi, v(50));
+        assert_eq!(wt.wt_initial_max_data, v(1024));
+        assert_eq!(wt.enable_webtransport_draft02, Some(true));
+        assert_eq!(wt.webtransport_max_sessions_draft07, Some(v(3)));
+        assert_eq!(wt.wt_max_sessions_draft14, Some(v(2)));
     }
 
     #[test]
-    fn test_from_payload_none_when_no_wt_entries() {
-        let mut payload = crate::frame::SettingsPayload::new();
-        payload.add(0x01, 4096); // QPACK_MAX_TABLE_CAPACITY (H3 設定)
-
-        assert!(Settings::from_payload(&payload).unwrap().is_none());
+    fn test_from_payload_returns_none_without_wt_entries() {
+        // WT variant が 1 つも含まれない場合は None
+        let entries = [Setting::H3Datagram(true)];
+        assert!(Settings::from_payload(&entries).is_none());
     }
 
     #[test]
     fn test_detect_draft_pattern_draft15() {
-        let settings = Settings::new().wt_enabled(1);
+        let settings = Settings::new().wt_enabled(v(1));
         assert_eq!(settings.detect_draft_pattern(), Some(DraftVersion::Draft15));
     }
 
     #[test]
     fn test_detect_draft_pattern_draft14() {
-        let settings = Settings::new().wt_max_sessions_draft14(1);
+        let settings = Settings::new().wt_max_sessions_draft14(v(1));
         assert_eq!(settings.detect_draft_pattern(), Some(DraftVersion::Draft14));
     }
 
     #[test]
     fn test_detect_draft_pattern_draft07() {
-        let settings = Settings::new().webtransport_max_sessions_draft07(1);
+        let settings = Settings::new().webtransport_max_sessions_draft07(v(1));
         assert_eq!(settings.detect_draft_pattern(), Some(DraftVersion::Draft07));
     }
 
@@ -554,7 +482,7 @@ mod tests {
         assert_eq!(settings.detect_draft_pattern(), None);
 
         // draft-14 が 0 の場合も None
-        let settings = Settings::new().wt_max_sessions_draft14(0);
+        let settings = Settings::new().wt_max_sessions_draft14(v(0));
         assert_eq!(settings.detect_draft_pattern(), None);
     }
 
@@ -563,15 +491,15 @@ mod tests {
         // draft-07 と draft-14 を両方送る場合は SETTINGS ネゴシエーションとしては
         // draft-07 を優先する (Safari が draft-14 固有の応答 SETTINGS を拒否するため)
         let settings = Settings::new()
-            .webtransport_max_sessions_draft07(1)
-            .wt_max_sessions_draft14(1);
+            .webtransport_max_sessions_draft07(v(1))
+            .wt_max_sessions_draft14(v(1));
         assert_eq!(settings.detect_draft_pattern(), Some(DraftVersion::Draft07));
 
         // draft-15 が最優先
         let settings = Settings::new()
-            .wt_enabled(1)
-            .wt_max_sessions_draft14(1)
-            .webtransport_max_sessions_draft07(1);
+            .wt_enabled(v(1))
+            .wt_max_sessions_draft14(v(1))
+            .webtransport_max_sessions_draft07(v(1));
         assert_eq!(settings.detect_draft_pattern(), Some(DraftVersion::Draft15));
     }
 
@@ -582,10 +510,10 @@ mod tests {
         // - draft-15 系 ID の SETTINGS_WT_INITIAL_MAX_*
         // draft 自体は draft-07 として扱う。
         let settings = Settings::new()
-            .webtransport_max_sessions_draft07(1)
-            .wt_initial_max_data(8388608)
-            .wt_initial_max_streams_uni(100)
-            .wt_initial_max_streams_bidi(100);
+            .webtransport_max_sessions_draft07(v(1))
+            .wt_initial_max_data(v(8_388_608))
+            .wt_initial_max_streams_uni(v(100))
+            .wt_initial_max_streams_bidi(v(100));
         assert_eq!(settings.detect_draft_pattern(), Some(DraftVersion::Draft07));
     }
 
@@ -596,47 +524,47 @@ mod tests {
         // SETTINGS ネゴシエーションとしては draft-07 を優先する。
         // draft-14 固有のカプセルベースフロー制御はセッション確立後に別途扱う。
         let settings = Settings::new()
-            .webtransport_max_sessions_draft07(1)
-            .wt_max_sessions_draft14(1)
-            .wt_initial_max_data(8388608)
-            .wt_initial_max_streams_uni(100)
-            .wt_initial_max_streams_bidi(100);
+            .webtransport_max_sessions_draft07(v(1))
+            .wt_max_sessions_draft14(v(1))
+            .wt_initial_max_data(v(8_388_608))
+            .wt_initial_max_streams_uni(v(100))
+            .wt_initial_max_streams_bidi(v(100));
         assert_eq!(settings.detect_draft_pattern(), Some(DraftVersion::Draft07));
     }
 
     #[test]
     fn test_declares_flow_control_draft14_max_sessions() {
         // draft-14: WT_MAX_SESSIONS > 1 でフロー制御宣言
-        let settings = Settings::new().wt_max_sessions_draft14(2);
+        let settings = Settings::new().wt_max_sessions_draft14(v(2));
         assert!(settings.declares_flow_control());
 
         // WT_MAX_SESSIONS = 1 ではフロー制御宣言にならない
-        let settings = Settings::new().wt_max_sessions_draft14(1);
+        let settings = Settings::new().wt_max_sessions_draft14(v(1));
         assert!(!settings.declares_flow_control());
     }
 
     #[test]
     fn test_requires_initial_capsule_flow_control_compat_safari_observed() {
         let settings = Settings::new()
-            .webtransport_max_sessions_draft07(1)
-            .wt_initial_max_streams_uni(100)
-            .wt_initial_max_streams_bidi(100)
-            .wt_initial_max_data(8 * 1024 * 1024);
+            .webtransport_max_sessions_draft07(v(1))
+            .wt_initial_max_streams_uni(v(100))
+            .wt_initial_max_streams_bidi(v(100))
+            .wt_initial_max_data(v(8 * 1024 * 1024));
         assert!(settings.requires_initial_capsule_flow_control_compat());
     }
 
     #[test]
     fn test_requires_initial_capsule_flow_control_compat_draft07_plain() {
-        let settings = Settings::new().webtransport_max_sessions_draft07(1);
+        let settings = Settings::new().webtransport_max_sessions_draft07(v(1));
         assert!(!settings.requires_initial_capsule_flow_control_compat());
     }
 
     #[test]
     fn test_is_enabled_draft14() {
-        let settings = Settings::new().wt_max_sessions_draft14(1);
+        let settings = Settings::new().wt_max_sessions_draft14(v(1));
         assert!(settings.is_enabled());
 
-        let settings = Settings::new().wt_max_sessions_draft14(0);
+        let settings = Settings::new().wt_max_sessions_draft14(v(0));
         assert!(!settings.is_enabled());
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,6 +1,10 @@
 //! 統合テスト: クライアント・サーバー間の通信シミュレーション
 
-use shiguredo_http3::{ClientConnection, Event, Header, ServerConnection, Settings};
+use shiguredo_http3::{ClientConnection, Event, Header, ServerConnection, Settings, VarInt};
+
+fn vi(value: u64) -> VarInt {
+    VarInt::new(value).unwrap()
+}
 
 /// クライアントからサーバーへのリクエスト・レスポンス交換をシミュレート
 #[test]
@@ -247,16 +251,16 @@ fn test_multiple_requests() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn test_custom_settings() {
     let settings = Settings::new()
-        .max_field_section_size(8192)
-        .qpack_max_table_capacity(4096)
-        .qpack_blocked_streams(100);
+        .max_field_section_size(vi(8192))
+        .qpack_max_table_capacity(vi(4096))
+        .qpack_blocked_streams(vi(100));
 
     let mut client = ClientConnection::new(settings);
     client.set_control_stream_id(2).unwrap();
 
     // ローカル設定を確認
     let local = client.local_settings();
-    assert_eq!(local.max_field_section_size, Some(8192));
-    assert_eq!(local.qpack_max_table_capacity, Some(4096));
-    assert_eq!(local.qpack_blocked_streams, Some(100));
+    assert_eq!(local.max_field_section_size, Some(vi(8192)));
+    assert_eq!(local.qpack_max_table_capacity, Some(vi(4096)));
+    assert_eq!(local.qpack_blocked_streams, Some(vi(100)));
 }

--- a/tests/test_webtransport_draft_connect.rs
+++ b/tests/test_webtransport_draft_connect.rs
@@ -11,7 +11,13 @@
 
 use shiguredo_http3::qpack::Encoder;
 use shiguredo_http3::webtransport::DraftVersion;
-use shiguredo_http3::{Error, ErrorCode, Event, Header, ServerConnection, Settings, webtransport};
+use shiguredo_http3::{
+    Error, ErrorCode, Event, Header, ServerConnection, Settings, VarInt, webtransport,
+};
+
+fn vi(value: u64) -> VarInt {
+    VarInt::new(value).unwrap()
+}
 
 // =========================================================================
 // ヘルパー関数
@@ -60,7 +66,7 @@ fn build_draft02_client_ctrl() -> Vec<u8> {
 /// 制御ストリームデータを返す
 /// Safari と同じパターン: ENABLE_CONNECT_PROTOCOL なし
 fn build_draft07_client_ctrl() -> Vec<u8> {
-    let wt = webtransport::Settings::new().webtransport_max_sessions_draft07(1);
+    let wt = webtransport::Settings::new().webtransport_max_sessions_draft07(vi(1));
     let settings = Settings {
         enable_connect_protocol: None,
         ..Settings::new()
@@ -78,10 +84,10 @@ fn build_draft07_client_ctrl() -> Vec<u8> {
 /// ENABLE_CONNECT_PROTOCOL あり
 fn build_draft14_client_ctrl_with_ecp() -> Vec<u8> {
     let wt = webtransport::Settings::new()
-        .wt_max_sessions_draft14(1)
-        .wt_initial_max_streams_uni(100)
-        .wt_initial_max_streams_bidi(100)
-        .wt_initial_max_data(8 * 1024 * 1024);
+        .wt_max_sessions_draft14(vi(1))
+        .wt_initial_max_streams_uni(vi(100))
+        .wt_initial_max_streams_bidi(vi(100))
+        .wt_initial_max_data(vi(8 * 1024 * 1024));
     let settings = Settings::new()
         .h3_datagram(true)
         .enable_connect_protocol(true)
@@ -95,10 +101,10 @@ fn build_draft14_client_ctrl_with_ecp() -> Vec<u8> {
 /// draft-14 クライアントの SETTINGS (ENABLE_CONNECT_PROTOCOL なし)
 fn build_draft14_client_ctrl_without_ecp() -> Vec<u8> {
     let wt = webtransport::Settings::new()
-        .wt_max_sessions_draft14(1)
-        .wt_initial_max_streams_uni(100)
-        .wt_initial_max_streams_bidi(100)
-        .wt_initial_max_data(8 * 1024 * 1024);
+        .wt_max_sessions_draft14(vi(1))
+        .wt_initial_max_streams_uni(vi(100))
+        .wt_initial_max_streams_bidi(vi(100))
+        .wt_initial_max_data(vi(8 * 1024 * 1024));
     let settings = Settings {
         enable_connect_protocol: None,
         ..Settings::new()
@@ -113,7 +119,7 @@ fn build_draft14_client_ctrl_without_ecp() -> Vec<u8> {
 
 /// draft-15 クライアントの SETTINGS (ENABLE_CONNECT_PROTOCOL あり)
 fn build_draft15_client_ctrl_with_ecp() -> Vec<u8> {
-    let wt = webtransport::Settings::new().wt_enabled(1);
+    let wt = webtransport::Settings::new().wt_enabled(vi(1));
     let settings = Settings::new()
         .h3_datagram(true)
         .enable_webtransport_server(wt);
@@ -125,7 +131,7 @@ fn build_draft15_client_ctrl_with_ecp() -> Vec<u8> {
 
 /// draft-15 クライアントの SETTINGS (ENABLE_CONNECT_PROTOCOL なし)
 fn build_draft15_client_ctrl_without_ecp() -> Vec<u8> {
-    let wt = webtransport::Settings::new().wt_enabled(1);
+    let wt = webtransport::Settings::new().wt_enabled(vi(1));
     let settings = Settings {
         enable_connect_protocol: None,
         ..Settings::new()
@@ -141,10 +147,10 @@ fn build_draft15_client_ctrl_without_ecp() -> Vec<u8> {
 /// 全 draft 対応のサーバーを構築する
 fn setup_server(reset_stream_at: bool) -> ServerConnection {
     let wt = webtransport::Settings::new()
-        .wt_enabled(1)
+        .wt_enabled(vi(1))
         .enable_webtransport_draft02(true)
-        .webtransport_max_sessions_draft07(100)
-        .wt_max_sessions_draft14(100);
+        .webtransport_max_sessions_draft07(vi(100))
+        .wt_max_sessions_draft14(vi(100));
     let settings = Settings::new().enable_webtransport_server(wt);
     let mut server = ServerConnection::new(settings);
     server.set_control_stream_id(3).unwrap();
@@ -277,11 +283,11 @@ mod draft07 {
         // 応答 SETTINGS を拒否するため)。draft-14 固有のカプセルベースフロー制御は
         // セッション確立後に別途扱う。
         let wt = webtransport::Settings::new()
-            .webtransport_max_sessions_draft07(1)
-            .wt_max_sessions_draft14(1)
-            .wt_initial_max_data(8 * 1024 * 1024)
-            .wt_initial_max_streams_uni(100)
-            .wt_initial_max_streams_bidi(100);
+            .webtransport_max_sessions_draft07(vi(1))
+            .wt_max_sessions_draft14(vi(1))
+            .wt_initial_max_data(vi(8 * 1024 * 1024))
+            .wt_initial_max_streams_uni(vi(100))
+            .wt_initial_max_streams_bidi(vi(100));
         let settings = Settings {
             enable_connect_protocol: None,
             ..Settings::new()
@@ -479,7 +485,7 @@ mod common {
     #[test]
     fn connect_rejected_when_h3_datagram_disabled() {
         // H3_DATAGRAM が無効なクライアントからの CONNECT は全 draft で拒否
-        let wt = webtransport::Settings::new().webtransport_max_sessions_draft07(1);
+        let wt = webtransport::Settings::new().webtransport_max_sessions_draft07(vi(1));
         let settings = Settings {
             enable_connect_protocol: None,
             h3_datagram: Some(false),
@@ -551,7 +557,7 @@ mod common {
     #[test]
     fn connect_rejected_without_transport_verified() {
         // wt_transport_verified が false の場合は拒否
-        let wt = webtransport::Settings::new().webtransport_max_sessions_draft07(1);
+        let wt = webtransport::Settings::new().webtransport_max_sessions_draft07(vi(1));
         let settings = Settings::new().enable_webtransport_server(wt);
         let mut server = ServerConnection::new(settings);
         server.set_control_stream_id(3).unwrap();
@@ -610,7 +616,7 @@ mod no_flow_control_single_session {
 
     /// FC を宣言しない (= initial_max_* を持たない) draft-15 クライアントを作る
     fn build_draft15_client_no_fc() -> shiguredo_http3::ClientConnection {
-        let wt = webtransport::Settings::new().wt_enabled(1);
+        let wt = webtransport::Settings::new().wt_enabled(vi(1));
         let settings = Settings::new()
             .h3_datagram(true)
             .enable_webtransport_server(wt);
@@ -654,7 +660,7 @@ mod no_flow_control_single_session {
         let mut client = build_draft15_client_no_fc();
 
         // サーバー側 SETTINGS を構築 (FC 無効: wt_initial_max_* を持たない)
-        let server_wt = webtransport::Settings::new().wt_enabled(1);
+        let server_wt = webtransport::Settings::new().wt_enabled(vi(1));
         let server_settings = Settings::new()
             .h3_datagram(true)
             .enable_connect_protocol(true)
@@ -730,10 +736,10 @@ mod wt_protocol_without_available_protocols {
     fn client_rejects_wt_protocol_when_no_available_protocols() {
         // クライアントを構築
         let wt = webtransport::Settings::new()
-            .wt_enabled(1)
-            .wt_initial_max_streams_uni(100)
-            .wt_initial_max_streams_bidi(100)
-            .wt_initial_max_data(8 * 1024 * 1024);
+            .wt_enabled(vi(1))
+            .wt_initial_max_streams_uni(vi(100))
+            .wt_initial_max_streams_bidi(vi(100))
+            .wt_initial_max_data(vi(8 * 1024 * 1024));
         let settings = Settings::new()
             .h3_datagram(true)
             .enable_webtransport_server(wt);
@@ -746,10 +752,10 @@ mod wt_protocol_without_available_protocols {
 
         // サーバーの SETTINGS を構築して feed
         let server_wt = webtransport::Settings::new()
-            .wt_enabled(1)
-            .wt_initial_max_streams_uni(100)
-            .wt_initial_max_streams_bidi(100)
-            .wt_initial_max_data(8 * 1024 * 1024);
+            .wt_enabled(vi(1))
+            .wt_initial_max_streams_uni(vi(100))
+            .wt_initial_max_streams_bidi(vi(100))
+            .wt_initial_max_data(vi(8 * 1024 * 1024));
         let server_settings = Settings::new()
             .h3_datagram(true)
             .enable_connect_protocol(true)
@@ -875,10 +881,10 @@ mod protocol_draft_alignment {
         // クライアントが draft-15 の peer に旧値 "webtransport" を送ろうとした場合、
         // send_request は ConnectionError(InternalError) を返す
         let server_wt = webtransport::Settings::new()
-            .wt_enabled(1)
-            .wt_initial_max_streams_uni(100)
-            .wt_initial_max_streams_bidi(100)
-            .wt_initial_max_data(8 * 1024 * 1024);
+            .wt_enabled(vi(1))
+            .wt_initial_max_streams_uni(vi(100))
+            .wt_initial_max_streams_bidi(vi(100))
+            .wt_initial_max_data(vi(8 * 1024 * 1024));
         let server_settings = Settings::new()
             .h3_datagram(true)
             .enable_connect_protocol(true)
@@ -887,7 +893,7 @@ mod protocol_draft_alignment {
         server.set_control_stream_id(3).unwrap();
         let (server_ctrl, _) = server.take_stream_data(3).unwrap();
 
-        let client_wt = webtransport::Settings::new().wt_enabled(1);
+        let client_wt = webtransport::Settings::new().wt_enabled(vi(1));
         let client_settings = Settings::new()
             .h3_datagram(true)
             .enable_webtransport_server(client_wt);


### PR DESCRIPTION
## 概要

SETTINGS パラメータの ID と値の構築時検査を `Setting` enum + `SettingError` で型強制し、不正値がコード上で組み立てられない不変条件を確立する。

## 変更内容

### 新規 API

- `Setting` enum (`#[non_exhaustive]`): 既知 SETTINGS パラメータ (H3 5 種類 + WebTransport 7 種類) と `Unknown(UnknownSetting)` を一体表現
- `UnknownSetting`: フィールド private な newtype で `Setting::Unknown` の構築経路を `Setting::from_wire` 経由に限定
- `SettingError` (`#[non_exhaustive]`): `Http2OnlyId` / `ReservedId` / `InvalidBooleanValue` / `DuplicateId` を構造化

### 構築時検査の集約

- `Setting::from_wire(VarInt, VarInt) -> Result<Self, SettingError>` に値域検査 (HTTP/2 専用 ID / 予約 ID / bool 値域外) を集約
- `SettingsPayload::add(setting: Setting) -> Result<(), SettingError>` で重複 ID を構築時に弾く (RFC 9114 §7.2.4 MUST NOT)
- decoder のエラー検査ロジックを `Setting::from_wire` + `SettingsPayload::add` に統合

### VarInt 化

- `Settings` / `webtransport::Settings` の値フィールドを `u64` → `VarInt`
- `ServerSettingsParams` のフィールドを `VarInt` 化し、ビルダーの `expect` panic 経路を解消
- `Settings::from_limits` を `Result<Self, VarIntError>` 化し、`Limits` の VarInt 範囲外で panic させない

### 後方互換性

- `Error` / `FrameDecodeError` に `#[non_exhaustive]` を付与
- `settings::SettingsId` / `webtransport::SettingsId` を削除し `Setting` enum に統合 (破壊的)
- `SettingsPayload.entries: Vec<(u64, u64)>` (pub) → `Vec<Setting>` (private) (破壊的)
- `webtransport::Settings::from_payload` を `pub` → `pub(crate)` (破壊的)
- `webtransport::Settings::flow_control_enabled` / `allows_multiple_sessions_with_peer` を削除 (死にコード)
- `FrameDecodeError::InvalidSettingsId(u64)` → `InvalidSetting(SettingError)` (破壊的)

### テスト

- decoder のエラーパス単体テスト 3 件追加 (ReservedId / InvalidBooleanValue 0x08, 0x33)
- `Settings::from_limits` の VarInt 範囲外検出を 3 フィールド個別に検証
- `SettingsPayload::add` の重複検出 PBT (variant 横断)
- `Setting::from_wire` ↔ `as_wire` ラウンドトリップ PBT を VarInt 全域でカバー
- fuzz target を改善し `Setting::from_wire` の panic 安全性も検証
- HTTP/2 専用 / bool 不正値の PBT は単体テストと役割重複していたため削除

## 完了条件

- [x] `Setting` / `SettingError` / `UnknownSetting` 新設
- [x] `SettingsId` (両方) を削除
- [x] `Setting::from_wire` / `as_wire` ラウンドトリップ
- [x] `SettingsPayload::add` の Result 化 + 重複検出集約
- [x] `Settings::from_limits` の Result 化
- [x] `ServerSettingsParams` の VarInt 化
- [x] `Error` / `FrameDecodeError` に `#[non_exhaustive]` 付与
- [x] 死にコード削除 (`flow_control_enabled` / `allows_multiple_sessions_with_peer`)
- [x] `webtransport::Settings::from_payload(&[Setting])` 復活
- [x] 全テスト・PBT・fuzz 通過 (841 件 passed)
- [x] 仕様引用節番号の補正 (RFC 9114 §7.2.4 / §11.2.2 / RFC 9220 §3 / draft-02 §3.2)

## レビュー周回

3 周の `/review-diff-code` を経て致命的 0 / 重要 0 に到達。

## 関連 issue

- issues/closed/0086-change-settings-construct-time-validation.md