### PR TITLE
0087 Frame ペイロードを構築時検査型に変更する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,19 @@
 - [ADD] `SettingError` を新設し、`Setting::from_wire` / `SettingsPayload::add` の検査エラー
   (HTTP/2 専用 ID / 予約 ID / bool 値域外 / 重複 ID) を構造化エラーで通知する (`#[non_exhaustive]`)
   - @voluntas
+- [ADD] `GoawayPayload::from_static` を `const fn` で追加し、不正リテラルの GOAWAY ID
+  (RFC 9000 Section 16 の VarInt 範囲外) をコンパイル時 panic として検出可能にする
+  - @voluntas
+- [ADD] `frame::DataPayload` / `frame::HeadersPayload` にアクセサ
+  (`data` / `into_data` / `encoded_field_section` / `into_encoded_field_section` /
+  `len` / `is_empty`) を追加し、フィールド private 化後も所有権付きで取り出せるようにする
+  - @voluntas
+- [ADD] `frame::UnknownFrame` / `frame::UnknownFrameError` を新設し、`Frame::Unknown` のフィールドを
+  private 化することで既知の HTTP/3 フレームタイプ (DATA / HEADERS / CANCEL_PUSH / SETTINGS /
+  PUSH_PROMISE / GOAWAY / MAX_PUSH_ID) や HTTP/2 専用 ID (RFC 9114 Section 11.2.1 Table 2 で
+  Reserved 登録、Section 7.2.8 で受信時 H3_FRAME_UNEXPECTED: 0x02 / 0x06 / 0x08 / 0x09) を
+  `Unknown` で偽装できない不変条件を保証する
+  - @voluntas
 - [CHANGE] `varint::encode` / `varint::encode_into_vec` / `varint::decode` のシグネチャを `VarInt` を扱う形に変更する
   - @voluntas
 - [CHANGE] `varint::MAX_VALUE` / `varint::encoded_len(u64)` / `varint::try_encoded_len` / `varint::try_encode_into_vec` / `varint::EncodeError::ValueTooLarge` を削除する (`VarInt` 型が値域を保証するため)
@@ -101,6 +114,31 @@
 - [CHANGE] `webtransport::Settings::flow_control_enabled` と
   `webtransport::Settings::allows_multiple_sessions_with_peer` を削除する
   (それぞれ `declares_flow_control` / `flow_control_enabled_with_peer` への単純委譲だった)
+  - @voluntas
+- [CHANGE] `frame::DataPayload` / `frame::HeadersPayload` / `frame::GoawayPayload` の
+  全フィールドを private 化する。アクセサ経由でのみ参照可能にすることで構築後の改ざんを防ぐ
+  - @voluntas
+- [CHANGE] `frame::Frame::Unknown` を struct variant から tuple variant
+  (`Unknown(UnknownFrame)`) に変更し、フィールドを private 化する
+  - @voluntas
+- [CHANGE] `frame::GoawayPayload.id` / `frame::Frame::MaxPushId` /
+  `frame::UnknownFrame::frame_type` / `frame::Frame::frame_type()` の型を `u64` から
+  `VarInt` に変更し、RFC 9000 Section 16 の値域を型レベルで担保する。
+  `frame::GoawayPayload::new(id: VarInt)` のシグネチャも変更する
+  - @voluntas
+- [CHANGE] `frame::FrameHeader.frame_type` / `payload_len` の型を `u64` から `VarInt` に
+  変更してフィールドを private 化し、`frame_type()` / `payload_len()` / `header_len()` の
+  アクセサを提供する。`total_len()` の戻り値型を `usize` から `Option<usize>` に変更し、
+  32bit プラットフォームで `payload_len` が `usize` を超える場合に `None` を返す
+  - @voluntas
+- [CHANGE] `frame::encode_frame_header` のシグネチャを `(buf, frame_type: VarInt, payload_len: VarInt)`
+  に変更し、`u64` 受けに伴う値域検査経路を削除する
+  - @voluntas
+- [CHANGE] `event::Event::GoawayReceived.id` の型を `u64` から `VarInt` に変更する
+  - @voluntas
+- [CHANGE] `Connection::send_goaway` / `ClientConnection::send_goaway` /
+  `ServerConnection::send_goaway` の引数型を `u64` から `VarInt` に変更し、
+  ローカル API 利用時の値域違反を型レベルで排除する
   - @voluntas
 
 ### misc

--- a/issues/closed/0087-change-frame-construct-time-validation.md
+++ b/issues/closed/0087-change-frame-construct-time-validation.md
@@ -1,7 +1,9 @@
 # 0087: 各 Frame ペイロードを構築時検査型に変更する
 
 Created: 2026-05-23
+Completed: 2026-05-24
 Model: Opus 4.7
+Branch: feature/change-frame-construct-time-validation
 
 ## 概要
 
@@ -291,3 +293,84 @@ const BAD: GoawayPayload = GoawayPayload::from_static(1u64 << 62);
 
 - [[0067-bug-fix-goaway-monotonic-decrease]] (GOAWAY 単調減少 — 接続状態依存のためランタイム検査)
 - [[0088-add-trybuild-and-pbt-construct-time-validation]] (`from_static` の compile_fail テスト)
+
+## 解決方法
+
+### Frame ペイロードの private 化とアクセサ追加
+
+- `DataPayload` / `HeadersPayload` / `GoawayPayload` の全フィールドを private 化
+  し、`data()` / `into_data()` / `encoded_field_section()` /
+  `into_encoded_field_section()` / `id()` / `len()` / `is_empty()` のアクセサを
+  提供する
+- 構築後の改ざんを防止し、利用者は所有権付き取り出しを `into_*` 経由で行う
+
+### VarInt 型化 (RFC 9000 Section 16 の値域を型レベルで担保)
+
+- `GoawayPayload.id` / `Frame::MaxPushId` / `Frame::frame_type()` の型を
+  `u64` から `VarInt` に変更
+- `FrameHeader.frame_type` / `payload_len` の型を `VarInt` に変更し、
+  フィールドを private 化、`frame_type()` / `payload_len()` / `header_len()`
+  アクセサを提供
+- `FrameHeader::total_len()` を `Option<usize>` 化し、32bit プラットフォームで
+  `payload_len` が `usize` を超える silent truncation を防止
+- `Event::GoawayReceived.id` / `Connection::send_goaway` /
+  `ClientConnection::send_goaway` / `ServerConnection::send_goaway` の
+  引数型を `VarInt` に変更
+- `frame::encode_frame_header` の引数を `(buf, frame_type: VarInt, payload_len: VarInt)`
+  に変更
+
+### Frame::Unknown を newtype 化し既知タイプ偽装を防止
+
+- `Frame::Unknown { frame_type, payload }` を `Frame::Unknown(UnknownFrame)`
+  tuple variant に変更
+- `UnknownFrame::new(frame_type, payload) -> Result<Self, UnknownFrameError>`
+  で構築時に以下を弾く:
+  - 既知の HTTP/3 フレームタイプ (RFC 9114 Section 7.2: DATA / HEADERS /
+    CANCEL_PUSH / SETTINGS / PUSH_PROMISE / GOAWAY / MAX_PUSH_ID)
+  - HTTP/2 専用 ID (RFC 9114 Section 11.2.1 Table 2 で Reserved 登録、
+    Section 7.2.8 で受信時 H3_FRAME_UNEXPECTED: 0x02 / 0x06 / 0x08 / 0x09)
+- `UnknownFrameError` を `#[non_exhaustive]` で公開、各 variant にも
+  `#[non_exhaustive]` 付与
+- decoder は `UnknownFrame::new(...).expect(...)` 経由で構築 (match の
+  `None` arm に達するのは既知/HTTP2 専用を除外した後のため `Ok` 確実)
+
+### GoawayPayload::from_static (const fn)
+
+- 不正リテラルの GOAWAY ID をコンパイル時 panic として検出可能にする
+- ロール依存の制約 (`4 の倍数` / push ID `0` のみ) は `Connection::send_goaway`
+  のランタイム検査で別途行う
+
+### FrameHeader::from_validated_parts と非最小 VarInt エンコード対応
+
+- decoder で `varint::decode` の消費長 (`type_len + len_len`) を保持し
+  `FrameHeader::from_validated_parts(frame_type, payload_len, header_len)` で
+  wire 上の実バイト長を渡す
+- RFC 9000 Section 16 は非最小 VarInt エンコードを許容する (frame type 例外は
+  QUIC layer のみで HTTP/3 frame type には適用されない) ため、値からの最小長
+  (`encoded_len()` の合計) と一致しない場合がある
+- `debug_assert!` で下限 (最小エンコード長) と上限 (16 バイト) のみ検査
+
+### CHANGES.md 更新
+
+- `[ADD]` 3 件 (GoawayPayload::from_static / DataPayload・HeadersPayload
+  アクセサ / UnknownFrame・UnknownFrameError)
+- `[CHANGE]` 8 件 (private 化、Unknown tuple variant 化、VarInt 化、
+  FrameHeader 型変更、encode_frame_header シグネチャ、GoawayReceived 型変更、
+  send_goaway 引数型変更)
+
+### 受け入れ条件との対応
+
+- `DataPayload::from_validated_parts` は実装時に削除 (`new` と完全同一で意味なし)
+- `GoawayPayload::from_validated_parts` も同様に削除 (`new(VarInt)` で型レベル保証)
+- `UnknownFrame::from_validated_parts` も削除し decoder は `UnknownFrame::new(...).expect(...)`
+- `encode_max_push_id_frame` は `encode_frame` の match arm から呼ばれるため残置
+  (送信 API は提供しないが decode → re-encode のループバックで使用)
+
+### テスト
+
+- 単体テスト: `UnknownFrame::new` の既知タイプ拒否 (全 7 種類) / HTTP/2 専用拒否
+  (全 4 種類) / Reserved Frame Type 受理 (0x21)
+- 単体テスト: 非最小 VarInt エンコードの decoder ラウンドトリップ
+- 統合テスト: GOAWAY 単調減少 (同値再送 OK / 減少 OK / 増加 NG)
+- PBT: `prop_unknown_frame_preserved` を `prop_filter` で全 VarInt 範囲から
+  既知 / HTTP/2 専用を除外する形に拡張

--- a/pbt/tests/prop_capsule.rs
+++ b/pbt/tests/prop_capsule.rs
@@ -117,7 +117,7 @@ proptest! {
         // DATA フレームからペイロードを取り出す
         match frame {
             shiguredo_http3::Frame::Data(payload) => {
-                let (decoded, cap_consumed) = Capsule::decode(&payload.data)
+                let (decoded, cap_consumed) = Capsule::decode(payload.data())
                     .expect("Capsule::decode should not error")
                     .expect("Capsule::decode should not be incomplete");
                 prop_assert_eq!(
@@ -125,7 +125,7 @@ proptest! {
                     "カプセルがラウンドトリップで変化した"
                 );
                 prop_assert_eq!(
-                    cap_consumed, payload.data.len(),
+                    cap_consumed, payload.len(),
                     "カプセル消費バイト数が不一致"
                 );
             }

--- a/pbt/tests/prop_frame.rs
+++ b/pbt/tests/prop_frame.rs
@@ -1,9 +1,10 @@
 //! Property-Based Testing for HTTP/3 Frames (RFC 9114)
 
 use proptest::prelude::*;
+use shiguredo_http3::VarInt;
 use shiguredo_http3::frame::{
-    DataPayload, Frame, FrameType, GoawayPayload, HeadersPayload, SettingsPayload, decode_frame,
-    encode_frame, encoded_frame_len,
+    DataPayload, Frame, FrameType, GoawayPayload, HeadersPayload, SettingsPayload, UnknownFrame,
+    decode_frame, encode_frame, encoded_frame_len,
 };
 
 prop_compose! {
@@ -142,9 +143,7 @@ proptest! {
     /// Property: DATA フレームのエンコード/デコードラウンドトリップ
     #[test]
     fn prop_data_frame_roundtrip(payload in valid_payload()) {
-        let frame = Frame::Data(DataPayload {
-            data: payload.clone(),
-        });
+        let frame = Frame::Data(DataPayload::new(payload.clone()));
 
         let mut buf = vec![0u8; encoded_frame_len(&frame).unwrap()];
         let encoded_len = encode_frame(&mut buf, &frame).unwrap();
@@ -155,7 +154,7 @@ proptest! {
 
         if let Frame::Data(data) = decoded {
             prop_assert_eq!(
-                data.data, payload,
+                data.data(), payload.as_slice(),
                 "DATA payload mismatch"
             );
         } else {
@@ -166,9 +165,7 @@ proptest! {
     /// Property: DATA フレームの長さはペイロード長と一致
     #[test]
     fn prop_data_frame_length_matches_payload(payload in valid_payload()) {
-        let frame = Frame::Data(DataPayload {
-            data: payload.clone(),
-        });
+        let frame = Frame::Data(DataPayload::new(payload.clone()));
 
         // FrameType::Data は 0x00 (1 バイト VarInt) で構築不能ではないため、
         // ランタイム値の `VarInt::new` を使って整合性を取る (const 文脈ではないので
@@ -198,9 +195,7 @@ proptest! {
     /// Property: HEADERS フレームのエンコード/デコードラウンドトリップ
     #[test]
     fn prop_headers_frame_roundtrip(encoded_block in valid_encoded_headers()) {
-        let frame = Frame::Headers(HeadersPayload {
-            encoded_field_section: encoded_block.clone(),
-        });
+        let frame = Frame::Headers(HeadersPayload::new(encoded_block.clone()));
 
         let mut buf = vec![0u8; encoded_frame_len(&frame).unwrap()];
         let encoded_len = encode_frame(&mut buf, &frame).unwrap();
@@ -211,7 +206,7 @@ proptest! {
 
         if let Frame::Headers(headers) = decoded {
             prop_assert_eq!(
-                headers.encoded_field_section, encoded_block,
+                headers.encoded_field_section(), encoded_block.as_slice(),
                 "HEADERS encoded block mismatch"
             );
         } else {
@@ -280,7 +275,8 @@ proptest! {
     /// Property: GOAWAY フレームのエンコード/デコードラウンドトリップ
     #[test]
     fn prop_goaway_frame_roundtrip(id in valid_goaway_id()) {
-        let frame = Frame::Goaway(GoawayPayload { id });
+        let id = VarInt::new(id).unwrap();
+        let frame = Frame::Goaway(GoawayPayload::new(id));
 
         let mut buf = vec![0u8; encoded_frame_len(&frame).unwrap()];
         let encoded_len = encode_frame(&mut buf, &frame).unwrap();
@@ -291,7 +287,7 @@ proptest! {
 
         if let Frame::Goaway(goaway) = decoded {
             prop_assert_eq!(
-                goaway.id, id,
+                goaway.id(), id,
                 "GOAWAY id mismatch"
             );
         } else {
@@ -306,15 +302,21 @@ proptest! {
 
 proptest! {
     /// Property: 未知のフレームタイプはペイロードとともに保存される
+    ///
+    /// VarInt 全領域 (0..=2^62-1, RFC 9000 Section 16) から既知タイプと
+    /// HTTP/2 専用 ID (RFC 9114 Section 7.2 / Section 11.2.1 Table 2) を除いて生成する。
     #[test]
     fn prop_unknown_frame_preserved(
-        unknown_type in (0x100u64..0x1000), // 未知の範囲
+        unknown_type in (0u64..(1u64 << 62)).prop_filter(
+            "既知 / HTTP/2 専用フレームタイプを除外",
+            |t| FrameType::from_type(*t).is_none() && !FrameType::is_http2_only(*t),
+        ),
         payload in valid_payload(),
     ) {
-        let frame = Frame::Unknown {
-            frame_type: unknown_type,
-            payload: payload.clone(),
-        };
+        let frame_type = VarInt::new(unknown_type).unwrap();
+        let unknown = UnknownFrame::new(frame_type, payload.clone())
+            .expect("生成範囲は既知タイプでも HTTP/2 専用でもない");
+        let frame = Frame::Unknown(unknown);
 
         let mut buf = vec![0u8; encoded_frame_len(&frame).unwrap()];
         let encoded_len = encode_frame(&mut buf, &frame).unwrap();
@@ -323,9 +325,9 @@ proptest! {
 
         prop_assert_eq!(encoded_len, decoded_len);
 
-        if let Frame::Unknown { frame_type, payload: decoded_payload } = decoded {
-            prop_assert_eq!(frame_type, unknown_type);
-            prop_assert_eq!(decoded_payload, payload);
+        if let Frame::Unknown(decoded_unknown) = decoded {
+            prop_assert_eq!(decoded_unknown.frame_type(), frame_type);
+            prop_assert_eq!(decoded_unknown.payload(), payload.as_slice());
         } else {
             prop_assert!(false, "Expected Unknown frame");
         }
@@ -340,7 +342,7 @@ proptest! {
     /// Property: encoded_frame_len は常に実際のエンコード長と一致
     #[test]
     fn prop_encoded_frame_len_accurate(payload in valid_payload()) {
-        let frame = Frame::Data(DataPayload { data: payload });
+        let frame = Frame::Data(DataPayload::new(payload));
 
         let predicted_len = encoded_frame_len(&frame).unwrap();
         let mut buf = vec![0u8; predicted_len + 100]; // 余裕を持たせる

--- a/src/connection/client.rs
+++ b/src/connection/client.rs
@@ -4,6 +4,7 @@ use crate::error::Error;
 use crate::event::Event;
 use crate::qpack::Header;
 use crate::settings::Settings;
+use crate::varint::VarInt;
 
 use super::{Connection, H3InitData, Role};
 
@@ -110,7 +111,7 @@ impl ClientConnection {
     }
 
     /// GOAWAY を送信
-    pub fn send_goaway(&mut self, id: u64) -> Result<(), crate::error::Error> {
+    pub fn send_goaway(&mut self, id: VarInt) -> Result<(), Error> {
         self.inner.send_goaway(id)
     }
 

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -513,14 +513,14 @@ pub struct Connection {
     /// サーバー受信なら push ID。WT / request stream の新規拒否判定に
     /// 使えるのはクライアント受信時のみ。
     /// (RFC 9114 Section 5.2)
-    peer_goaway_last_id: Option<u64>,
+    peer_goaway_last_id: Option<VarInt>,
     /// 最後に送信した GOAWAY の ID (段階的送信のために単調減少を検証する)
-    last_sent_goaway_id: Option<u64>,
+    last_sent_goaway_id: Option<VarInt>,
     /// クライアントから受信した MAX_PUSH_ID の最新値
     ///
     /// サーバープッシュ自体はサポートしないが、RFC 9114 Section 7.2.7 で定義された
     /// 単調増加制約だけは検証する (後退は H3_ID_ERROR)。
-    max_push_id: Option<u64>,
+    max_push_id: Option<VarInt>,
     /// 送信待ちストリーム ID
     writable_streams: VecDeque<u64>,
     /// QPACK ブロック中のストリームを ricnt (Required Insert Count) 順でソートする
@@ -736,7 +736,7 @@ impl Connection {
     /// (RFC 9114 Section 5.2 / 7.2.6, draft-ietf-webtrans-http3-15 Section 4.7)
     fn peer_goaway_request_boundary(&self) -> Option<u64> {
         if self.role == Role::Client {
-            self.peer_goaway_last_id
+            self.peer_goaway_last_id.map(|v| v.get())
         } else {
             None
         }
@@ -851,7 +851,7 @@ impl Connection {
             if self.role == Role::Client {
                 // 破棄 (ストリームと異なりデータグラムは RESET 不要)
             } else if let Some(last_id) = self.last_sent_goaway_id
-                && session_id >= last_id
+                && session_id >= last_id.get()
             {
                 // サーバーが GOAWAY を送信済みの場合、その境界以降の session_id に
                 // 対する新規 WebTransport セッションは受け入れない
@@ -2058,7 +2058,6 @@ impl Connection {
     /// 0 を返す (CONNECT stream や非 WT ストリーム)。将来のドラフトで stream
     /// header フォーマットが変更される可能性がある。
     pub fn wt_stream_header_len(&self, stream_id: u64) -> u64 {
-        use crate::varint::VarInt;
         use crate::webtransport::stream::{BIDIRECTIONAL_SIGNAL_VALUE, UNIDIRECTIONAL_STREAM_TYPE};
         // signal value / stream type は WebTransport プロトコルの定数なので const 文脈で
         // VarInt 構築できる (`from_static` でコンパイル時検査)。
@@ -2141,7 +2140,7 @@ impl Connection {
             // (draft-ietf-webtrans-http3-15 Section 4.7)。
             // nghttp3 lib/nghttp3_conn.c L3654 と整合。
             if let Some(last_id) = self.last_sent_goaway_id
-                && session_id >= last_id
+                && session_id >= last_id.get()
             {
                 return Err(());
             }
@@ -2520,12 +2519,13 @@ impl Connection {
                     });
                 }
                 crate::frame::Frame::Goaway(payload) => {
+                    let goaway_id = payload.id();
                     // クライアントが受信する GOAWAY の stream ID は
                     // client-initiated bidirectional stream ID でなければならない
                     // (RFC 9114 Section 7.2.6)
                     if self.role == Role::Client {
                         // client-initiated bidi stream ID は 4 の倍数 (0, 4, 8, ...)
-                        if payload.id % 4 != 0 {
+                        if goaway_id.get() % 4 != 0 {
                             return Err(Error::ConnectionError(ErrorCode::IdError));
                         }
                     }
@@ -2533,15 +2533,15 @@ impl Connection {
                     // 複数 GOAWAY の単調減少チェック (RFC 9114 Section 5.2)
                     // 値の意味はロール依存だが、単調減少制約はどちらの方向でも成立する
                     if let Some(prev_id) = self.peer_goaway_last_id
-                        && payload.id > prev_id
+                        && goaway_id > prev_id
                     {
                         return Err(Error::ConnectionError(ErrorCode::IdError));
                     }
 
                     self.peer_goaway_received = true;
-                    self.peer_goaway_last_id = Some(payload.id);
+                    self.peer_goaway_last_id = Some(goaway_id);
                     self.events
-                        .push_back(Event::GoawayReceived { id: payload.id });
+                        .push_back(Event::GoawayReceived { id: goaway_id });
 
                     // WT draining 伝播はクライアント受信時のみ行う
                     //
@@ -2556,7 +2556,7 @@ impl Connection {
                             .wt_sessions
                             .iter()
                             .filter(|(sid, session)| {
-                                **sid >= payload.id
+                                **sid >= goaway_id.get()
                                     && (session.state == WtSessionState::Established
                                         || session.state == WtSessionState::Pending)
                             })
@@ -3727,20 +3727,24 @@ impl Connection {
     ///
     /// クライアントの場合: id は push ID でなければならない。
     /// サーバープッシュ未対応のため、現在は 0 のみ許可する。
-    pub fn send_goaway(&mut self, id: u64) -> Result<(), Error> {
+    ///
+    /// 同一 ID の再送は許可される (RFC 9114 Section 5.2: "MUST NOT increase the value")。
+    /// 既に送信済みの値より大きい ID を渡すと `IdError` を返す。
+    pub fn send_goaway(&mut self, id: VarInt) -> Result<(), Error> {
         // GOAWAY ID の型検証 (RFC 9114 Section 5.2)
+        let id_u64 = id.get();
         match self.role {
             Role::Server => {
                 // サーバー → クライアント: client-initiated bidirectional stream ID
                 // client-initiated bidi stream ID は 4 の倍数 (0, 4, 8, ...)
-                if !id.is_multiple_of(4) {
+                if !id_u64.is_multiple_of(4) {
                     return Err(Error::ConnectionError(ErrorCode::IdError));
                 }
             }
             Role::Client => {
                 // クライアント → サーバー: push ID
                 // サーバープッシュ未対応のため 0 のみ許可
-                if id != 0 {
+                if id_u64 != 0 {
                     return Err(Error::ConnectionError(ErrorCode::IdError));
                 }
             }
@@ -5749,7 +5753,7 @@ mod tests {
         // セッション確立まで進めず Pending のままで GOAWAY を受信させる
 
         // サーバーが GOAWAY を送信
-        server.send_goaway(stream_id).unwrap();
+        server.send_goaway(VarInt::new(stream_id).unwrap()).unwrap();
         let (ctrl_data, _) = server.take_stream_data(3).unwrap();
         client.feed_stream(3, &ctrl_data, false).unwrap();
 

--- a/src/connection/server.rs
+++ b/src/connection/server.rs
@@ -4,6 +4,7 @@ use crate::error::Error;
 use crate::event::Event;
 use crate::qpack::Header;
 use crate::settings::Settings;
+use crate::varint::VarInt;
 
 use super::{Connection, H3InitData, Role};
 
@@ -114,7 +115,7 @@ impl ServerConnection {
     }
 
     /// GOAWAY を送信
-    pub fn send_goaway(&mut self, id: u64) -> Result<(), crate::error::Error> {
+    pub fn send_goaway(&mut self, id: VarInt) -> Result<(), Error> {
         self.inner.send_goaway(id)
     }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -2,6 +2,8 @@
 //!
 //! Connection から返されるイベントを定義。
 
+use crate::varint::VarInt;
+
 /// WebTransport セッション終了時にリセットすべきストリームの情報
 ///
 /// (draft-ietf-webtrans-http3-15 Section 6 / Section 4.4 / Section 5.4)
@@ -77,8 +79,11 @@ pub enum Event {
     },
     /// GOAWAY 受信
     GoawayReceived {
-        /// GOAWAY で指定された ID
-        id: u64,
+        /// GOAWAY で指定された ID (RFC 9000 Section 16 の VarInt)
+        ///
+        /// ロール依存: クライアント受信なら request stream ID、
+        /// サーバー受信なら push ID。
+        id: VarInt,
     },
     /// WebTransport 双方向ストリーム開始
     /// (draft-ietf-webtrans-http3-15 Section 4.3)

--- a/src/frame/decoder.rs
+++ b/src/frame/decoder.rs
@@ -2,25 +2,75 @@
 
 use crate::error::FrameDecodeError;
 use crate::settings::Setting;
-use crate::varint;
+use crate::varint::{self, VarInt};
 
-use super::{DataPayload, Frame, FrameType, GoawayPayload, HeadersPayload, SettingsPayload};
+use super::{
+    DataPayload, Frame, FrameType, GoawayPayload, HeadersPayload, SettingsPayload, UnknownFrame,
+};
 
-/// フレームヘッダー
+/// フレームヘッダー (RFC 9114 Section 7.1)
+///
+/// `frame_type` / `payload_len` は wire 上 VarInt のため
+/// [`VarInt`] 型で保持し RFC 9000 Section 16 の値域を型レベルで担保する。
+/// `header_len` は decoder が受信した wire 上の実バイト長を保持する。
+/// RFC 9000 Section 16 は最小エンコード必須ではない (frame type 例外は §12.4 の
+/// QUIC frame type のみで HTTP/3 frame type には適用されない) ため、
+/// `frame_type.encoded_len() + payload_len.encoded_len()` (値からの最小長)
+/// と一致するとは限らない。
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FrameHeader {
     /// フレームタイプ
-    pub frame_type: u64,
+    frame_type: VarInt,
     /// ペイロード長
-    pub payload_len: u64,
-    /// ヘッダーのバイト長
-    pub header_len: usize,
+    payload_len: VarInt,
+    /// ヘッダーのバイト長 (wire 上の実バイト長: type と length の VarInt 消費長の和)
+    header_len: usize,
 }
 
 impl FrameHeader {
+    /// 検証済みの値から構築する (crate 内部専用、decoder が使用)
+    ///
+    /// `frame_type` / `payload_len` は型レベルで VarInt 範囲が保証されており、
+    /// `header_len` は呼び出し側が wire 上の実バイト消費長を渡す責務を負う
+    /// (`varint::decode` の返す `consumed` の和)。本検証では下限 (= 最小エンコード長)
+    /// と上限 (= 16 バイト、VarInt 2 つ分の最大エンコード長) のみを debug_assert する。
+    pub(crate) const fn from_validated_parts(
+        frame_type: VarInt,
+        payload_len: VarInt,
+        header_len: usize,
+    ) -> Self {
+        debug_assert!(header_len >= frame_type.encoded_len() + payload_len.encoded_len());
+        debug_assert!(header_len <= 16);
+        Self {
+            frame_type,
+            payload_len,
+            header_len,
+        }
+    }
+
+    /// フレームタイプを取得
+    pub const fn frame_type(&self) -> VarInt {
+        self.frame_type
+    }
+
+    /// ペイロード長を取得
+    pub const fn payload_len(&self) -> VarInt {
+        self.payload_len
+    }
+
+    /// ヘッダーのバイト長を取得
+    pub const fn header_len(&self) -> usize {
+        self.header_len
+    }
+
     /// フレーム全体のバイト長
-    pub fn total_len(&self) -> usize {
-        self.header_len + self.payload_len as usize
+    ///
+    /// `payload_len` は最大 `2^62 - 1` (RFC 9000 Section 16) のため、
+    /// 32bit プラットフォームでは `usize` に収まらない可能性がある。
+    /// その場合は [`None`] を返し、呼び出し側でエラー扱いする。
+    pub fn total_len(&self) -> Option<usize> {
+        let payload = usize::try_from(self.payload_len.get()).ok()?;
+        self.header_len.checked_add(payload)
     }
 }
 
@@ -47,11 +97,13 @@ pub fn decode_frame_header(buf: &[u8]) -> Result<FrameHeader, FrameDecodeError> 
         return Err(FrameDecodeError::Http2Frame(frame_type.get()));
     }
 
-    Ok(FrameHeader {
-        frame_type: frame_type.get(),
-        payload_len: payload_len.get(),
-        header_len: type_len + len_len,
-    })
+    // wire 上の実バイト長を保持する (RFC 9000 Section 16 は最小エンコード必須でない
+    // ため、type_len + len_len は VarInt 値から計算した最小長と一致するとは限らない)
+    Ok(FrameHeader::from_validated_parts(
+        frame_type,
+        payload_len,
+        type_len + len_len,
+    ))
 }
 
 /// フレームをデコードする
@@ -60,16 +112,18 @@ pub fn decode_frame_header(buf: &[u8]) -> Result<FrameHeader, FrameDecodeError> 
 pub fn decode_frame(buf: &[u8]) -> Result<(Frame, usize), FrameDecodeError> {
     let header = decode_frame_header(buf)?;
 
-    let total_len = header.total_len();
+    // 32bit プラットフォームで payload_len が usize を超える場合は InvalidLength
+    let total_len = header.total_len().ok_or(FrameDecodeError::InvalidLength)?;
     if buf.len() < total_len {
         return Err(FrameDecodeError::BufferTooShort);
     }
 
-    let payload = &buf[header.header_len..total_len];
+    let payload = &buf[header.header_len()..total_len];
+    let frame_type_u64 = header.frame_type().get();
 
-    let frame = match FrameType::from_type(header.frame_type) {
-        Some(FrameType::Data) => decode_data_frame(payload)?,
-        Some(FrameType::Headers) => decode_headers_frame(payload)?,
+    let frame = match FrameType::from_type(frame_type_u64) {
+        Some(FrameType::Data) => Frame::Data(DataPayload::new(payload.to_vec())),
+        Some(FrameType::Headers) => Frame::Headers(HeadersPayload::new(payload.to_vec())),
         Some(FrameType::Settings) => decode_settings_frame(payload)?,
         Some(FrameType::Goaway) => decode_goaway_frame(payload)?,
         Some(FrameType::MaxPushId) => decode_max_push_id_frame(payload)?,
@@ -84,23 +138,15 @@ pub fn decode_frame(buf: &[u8]) -> Result<(Frame, usize), FrameDecodeError> {
             // 問わず H3_FRAME_UNEXPECTED で拒否する。
             // MAX_PUSH_ID は control stream 上で正当に受信されうるため別経路で扱う
             // (Section 7.2.7)。
-            return Err(FrameDecodeError::ServerPushNotSupported(header.frame_type));
+            return Err(FrameDecodeError::ServerPushNotSupported(frame_type_u64));
         }
-        None => Frame::Unknown {
-            frame_type: header.frame_type,
-            payload: payload.to_vec(),
-        },
+        None => Frame::Unknown(
+            UnknownFrame::new(header.frame_type(), payload.to_vec())
+                .expect("None arm receives only unknown non-HTTP/2 frame types"),
+        ),
     };
 
     Ok((frame, total_len))
-}
-
-fn decode_data_frame(payload: &[u8]) -> Result<Frame, FrameDecodeError> {
-    Ok(Frame::Data(DataPayload::new(payload.to_vec())))
-}
-
-fn decode_headers_frame(payload: &[u8]) -> Result<Frame, FrameDecodeError> {
-    Ok(Frame::Headers(HeadersPayload::new(payload.to_vec())))
 }
 
 fn decode_settings_frame(payload: &[u8]) -> Result<Frame, FrameDecodeError> {
@@ -131,7 +177,7 @@ fn decode_goaway_frame(payload: &[u8]) -> Result<Frame, FrameDecodeError> {
     if consumed != payload.len() {
         return Err(FrameDecodeError::InvalidLength);
     }
-    Ok(Frame::Goaway(GoawayPayload::new(id.get())))
+    Ok(Frame::Goaway(GoawayPayload::new(id)))
 }
 
 fn decode_max_push_id_frame(payload: &[u8]) -> Result<Frame, FrameDecodeError> {
@@ -140,7 +186,7 @@ fn decode_max_push_id_frame(payload: &[u8]) -> Result<Frame, FrameDecodeError> {
     if consumed != payload.len() {
         return Err(FrameDecodeError::InvalidLength);
     }
-    Ok(Frame::MaxPushId(id.get()))
+    Ok(Frame::MaxPushId(id))
 }
 
 #[cfg(test)]
@@ -152,15 +198,15 @@ mod tests {
         // Type=0 (DATA), Length=5
         let buf = [0x00, 0x05];
         let header = decode_frame_header(&buf).unwrap();
-        assert_eq!(header.frame_type, 0);
-        assert_eq!(header.payload_len, 5);
-        assert_eq!(header.header_len, 2);
+        assert_eq!(header.frame_type().get(), 0);
+        assert_eq!(header.payload_len().get(), 5);
+        assert_eq!(header.header_len(), 2);
 
         // Type=4 (SETTINGS), Length=10
         let buf = [0x04, 0x0a];
         let header = decode_frame_header(&buf).unwrap();
-        assert_eq!(header.frame_type, 4);
-        assert_eq!(header.payload_len, 10);
+        assert_eq!(header.frame_type().get(), 4);
+        assert_eq!(header.payload_len().get(), 10);
     }
 
     #[test]
@@ -205,12 +251,31 @@ mod tests {
 
     #[test]
     fn test_frame_header_total_len() {
-        let header = FrameHeader {
-            frame_type: 0,
-            payload_len: 100,
-            header_len: 2,
-        };
-        assert_eq!(header.total_len(), 102);
+        // frame_type 0 (1 バイト VarInt) + payload_len 50 (1 バイト VarInt) + payload 50
+        let header =
+            FrameHeader::from_validated_parts(VarInt::from_static(0), VarInt::from_static(50), 2);
+        assert_eq!(header.header_len(), 2);
+        assert_eq!(header.total_len(), Some(52));
+    }
+
+    #[test]
+    fn test_decode_frame_handles_non_minimal_varint_encoding() {
+        // RFC 9000 Section 16: 最小エンコード必須ではない (frame type 例外は QUIC layer のみ)。
+        // wire 上で type=0 を 2 バイト (0x40 0x00)、payload_len=3 を 1 バイト (0x03) で
+        // エンコードしたフレーム + payload 3 バイトを decode できることを確認する。
+        let buf = [0x40, 0x00, 0x03, 0xaa, 0xbb, 0xcc];
+        let header = decode_frame_header(&buf).unwrap();
+        assert_eq!(header.frame_type().get(), 0); // DATA
+        assert_eq!(header.payload_len().get(), 3);
+        assert_eq!(header.header_len(), 3); // 2 バイト + 1 バイト
+        assert_eq!(header.total_len(), Some(6));
+
+        let (frame, consumed) = decode_frame(&buf).unwrap();
+        assert_eq!(consumed, 6);
+        match frame {
+            Frame::Data(p) => assert_eq!(p.data(), &[0xaa, 0xbb, 0xcc][..]),
+            other => panic!("expected DATA, got {other:?}"),
+        }
     }
 
     #[test]
@@ -304,6 +369,6 @@ mod tests {
         // 受信できなければならない (RFC 9114 Section 7.2.7)。デコード自体は成功する。
         let buf = [0x0d, 0x01, 0x05];
         let result = decode_frame(&buf).unwrap();
-        assert_eq!(result, (Frame::MaxPushId(5), 3));
+        assert_eq!(result, (Frame::MaxPushId(VarInt::from_static(5)), 3));
     }
 }

--- a/src/frame/encoder.rs
+++ b/src/frame/encoder.rs
@@ -2,17 +2,20 @@
 
 use crate::varint::{self, VarInt};
 
-use super::{DataPayload, Frame, FrameType, GoawayPayload, HeadersPayload, SettingsPayload};
+use super::{
+    DataPayload, Frame, FrameType, GoawayPayload, HeadersPayload, SettingsPayload, UnknownFrame,
+};
 
 /// フレームヘッダーをエンコードする
 ///
 /// 成功時はエンコードしたバイト数を返す。
-/// `frame_type` または `payload_len` が VarInt 範囲 (RFC 9000 Section 16) を
-/// 超える場合は `None` を返す。
-pub fn encode_frame_header(buf: &mut [u8], frame_type: u64, payload_len: u64) -> Option<usize> {
-    let frame_type = VarInt::new(frame_type).ok()?;
-    let payload_len = VarInt::new(payload_len).ok()?;
-
+/// 引数は [`VarInt`] 型のため値域は型レベルで保証される (RFC 9000 Section 16)。
+/// バッファ不足の場合は `None` を返す。
+pub fn encode_frame_header(
+    buf: &mut [u8],
+    frame_type: VarInt,
+    payload_len: VarInt,
+) -> Option<usize> {
     let total = frame_type.encoded_len() + payload_len.encoded_len();
     if buf.len() < total {
         return None;
@@ -27,56 +30,63 @@ pub fn encode_frame_header(buf: &mut [u8], frame_type: u64, payload_len: u64) ->
 
 /// フレームをエンコードするのに必要なバイト数を計算する
 ///
-/// `Frame::Unknown` / `Frame::Goaway` / `Frame::MaxPushId` 等で
-/// `u64` フィールドが VarInt 範囲を超える場合は `None` を返す。
+/// 各 [`Frame`] のフィールドは構築時に [`VarInt`] 範囲が型レベルで保証されているため、
+/// 検査エラーが発生するのはペイロード長 (`payload.len()` または SETTINGS の累計長) を
+/// `VarInt` に押し込めない場合、もしくは合計長が `usize` を超える場合のみ。
+/// その場合は `None` を返す。
 /// 呼び出し側は本値を根拠にバッファを確保するため、嘘の長さを返さない。
 pub fn encoded_frame_len(frame: &Frame) -> Option<usize> {
-    let (frame_type, payload_len) = match frame {
-        Frame::Data(p) => (FrameType::Data as u64, p.data.len() as u64),
-        Frame::Headers(p) => (
-            FrameType::Headers as u64,
-            p.encoded_field_section.len() as u64,
+    let (frame_type, payload_len): (VarInt, VarInt) = match frame {
+        Frame::Data(p) => (
+            VarInt::from_static(FrameType::Data as u64),
+            VarInt::new(p.len() as u64).ok()?,
         ),
-        Frame::Settings(p) => (FrameType::Settings as u64, encoded_settings_payload_len(p)?),
-        Frame::Goaway(p) => (FrameType::Goaway as u64, encoded_varint_len(p.id)? as u64),
-        Frame::MaxPushId(id) => (FrameType::MaxPushId as u64, encoded_varint_len(*id)? as u64),
-        Frame::Unknown {
-            frame_type,
-            payload,
-        } => (*frame_type, payload.len() as u64),
+        Frame::Headers(p) => (
+            VarInt::from_static(FrameType::Headers as u64),
+            VarInt::new(p.len() as u64).ok()?,
+        ),
+        Frame::Settings(p) => (
+            VarInt::from_static(FrameType::Settings as u64),
+            encoded_settings_payload_len(p)?,
+        ),
+        Frame::Goaway(p) => (
+            VarInt::from_static(FrameType::Goaway as u64),
+            // VarInt::encoded_len() は 1/2/4/8 のいずれかなので必ず VarInt に収まる
+            VarInt::from_static(p.id().encoded_len() as u64),
+        ),
+        Frame::MaxPushId(id) => (
+            VarInt::from_static(FrameType::MaxPushId as u64),
+            VarInt::from_static(id.encoded_len() as u64),
+        ),
+        Frame::Unknown(p) => (p.frame_type(), VarInt::new(p.payload().len() as u64).ok()?),
     };
 
-    let header_len = encoded_varint_len(frame_type)? + encoded_varint_len(payload_len)?;
-    Some(header_len + payload_len as usize)
-}
-
-/// `u64` を VarInt とみなしたエンコード長を返す
-///
-/// 値が VarInt 範囲外の場合は `None` を返し、呼び出し側で短絡する。
-fn encoded_varint_len(value: u64) -> Option<usize> {
-    VarInt::new(value).ok().map(|v| v.encoded_len())
+    let header_len = frame_type.encoded_len() + payload_len.encoded_len();
+    // 32bit プラットフォームで payload_len が usize を超える場合は None
+    // (FrameHeader::total_len と同じ防御)
+    let payload_size = usize::try_from(payload_len.get()).ok()?;
+    header_len.checked_add(payload_size)
 }
 
 /// SETTINGS ペイロードのエンコード長を計算
 ///
 /// 各 [`Setting`](crate::settings::Setting) の wire 表現が VarInt 範囲内である
-/// ことは構築時に保証されているため、本関数はバッファサイズの合算のみを行う。
-/// 内部総和の `usize` オーバーフローのみ `None` で返す。
-fn encoded_settings_payload_len(payload: &SettingsPayload) -> Option<u64> {
+/// ことは構築時に保証されているため、本関数は累計長が `usize` および VarInt 範囲に
+/// 収まるかだけ検査する。
+fn encoded_settings_payload_len(payload: &SettingsPayload) -> Option<VarInt> {
     let mut total: usize = 0;
     for setting in payload.settings() {
         let (id, value) = setting.as_wire();
         total = total.checked_add(id.encoded_len())?;
         total = total.checked_add(value.encoded_len())?;
     }
-    Some(total as u64)
+    VarInt::new(total as u64).ok()
 }
 
 /// フレームをエンコードする
 ///
 /// 成功時はエンコードしたバイト数を返す。
-/// バッファ不足、または `Frame::Unknown` 等の `u64` フィールドが VarInt 範囲外の場合は
-/// `None` を返す。
+/// バッファ不足、または各種ペイロード長が VarInt 範囲を超える場合は `None` を返す。
 pub fn encode_frame(buf: &mut [u8], frame: &Frame) -> Option<usize> {
     let required = encoded_frame_len(frame)?;
     if buf.len() < required {
@@ -89,38 +99,34 @@ pub fn encode_frame(buf: &mut [u8], frame: &Frame) -> Option<usize> {
         Frame::Settings(p) => encode_settings_frame(buf, p),
         Frame::Goaway(p) => encode_goaway_frame(buf, p),
         Frame::MaxPushId(value) => encode_max_push_id_frame(buf, *value),
-        Frame::Unknown {
-            frame_type,
-            payload,
-        } => encode_unknown_frame(buf, *frame_type, payload),
+        Frame::Unknown(p) => encode_unknown_frame(buf, p),
     }
 }
 
 fn encode_data_frame(buf: &mut [u8], payload: &DataPayload) -> Option<usize> {
-    let frame_type = FrameType::Data as u64;
-    let payload_len = payload.data.len() as u64;
+    let frame_type = VarInt::from_static(FrameType::Data as u64);
+    let payload_len = VarInt::new(payload.len() as u64).ok()?;
 
     let mut offset = encode_frame_header(buf, frame_type, payload_len)?;
-    buf[offset..offset + payload.data.len()].copy_from_slice(&payload.data);
-    offset += payload.data.len();
+    buf[offset..offset + payload.len()].copy_from_slice(payload.data());
+    offset += payload.len();
 
     Some(offset)
 }
 
 fn encode_headers_frame(buf: &mut [u8], payload: &HeadersPayload) -> Option<usize> {
-    let frame_type = FrameType::Headers as u64;
-    let payload_len = payload.encoded_field_section.len() as u64;
+    let frame_type = VarInt::from_static(FrameType::Headers as u64);
+    let payload_len = VarInt::new(payload.len() as u64).ok()?;
 
     let mut offset = encode_frame_header(buf, frame_type, payload_len)?;
-    buf[offset..offset + payload.encoded_field_section.len()]
-        .copy_from_slice(&payload.encoded_field_section);
-    offset += payload.encoded_field_section.len();
+    buf[offset..offset + payload.len()].copy_from_slice(payload.encoded_field_section());
+    offset += payload.len();
 
     Some(offset)
 }
 
 fn encode_settings_frame(buf: &mut [u8], payload: &SettingsPayload) -> Option<usize> {
-    let frame_type = FrameType::Settings as u64;
+    let frame_type = VarInt::from_static(FrameType::Settings as u64);
     let payload_len = encoded_settings_payload_len(payload)?;
 
     let mut offset = encode_frame_header(buf, frame_type, payload_len)?;
@@ -135,9 +141,10 @@ fn encode_settings_frame(buf: &mut [u8], payload: &SettingsPayload) -> Option<us
 }
 
 fn encode_goaway_frame(buf: &mut [u8], payload: &GoawayPayload) -> Option<usize> {
-    let frame_type = FrameType::Goaway as u64;
-    let id = VarInt::new(payload.id).ok()?;
-    let payload_len = id.encoded_len() as u64;
+    let frame_type = VarInt::from_static(FrameType::Goaway as u64);
+    let id = payload.id();
+    // VarInt::encoded_len() は 1/2/4/8 のいずれかで必ず VarInt 範囲内
+    let payload_len = VarInt::from_static(id.encoded_len() as u64);
 
     let mut offset = encode_frame_header(buf, frame_type, payload_len)?;
     offset += varint::encode(&mut buf[offset..], id).ok()?;
@@ -145,10 +152,9 @@ fn encode_goaway_frame(buf: &mut [u8], payload: &GoawayPayload) -> Option<usize>
     Some(offset)
 }
 
-fn encode_max_push_id_frame(buf: &mut [u8], id: u64) -> Option<usize> {
-    let frame_type = FrameType::MaxPushId as u64;
-    let id = VarInt::new(id).ok()?;
-    let payload_len = id.encoded_len() as u64;
+fn encode_max_push_id_frame(buf: &mut [u8], id: VarInt) -> Option<usize> {
+    let frame_type = VarInt::from_static(FrameType::MaxPushId as u64);
+    let payload_len = VarInt::from_static(id.encoded_len() as u64);
 
     let mut offset = encode_frame_header(buf, frame_type, payload_len)?;
     offset += varint::encode(&mut buf[offset..], id).ok()?;
@@ -156,12 +162,14 @@ fn encode_max_push_id_frame(buf: &mut [u8], id: u64) -> Option<usize> {
     Some(offset)
 }
 
-fn encode_unknown_frame(buf: &mut [u8], frame_type: u64, payload: &[u8]) -> Option<usize> {
-    let payload_len = payload.len() as u64;
+fn encode_unknown_frame(buf: &mut [u8], payload: &UnknownFrame) -> Option<usize> {
+    let frame_type = payload.frame_type();
+    let bytes = payload.payload();
+    let payload_len = VarInt::new(bytes.len() as u64).ok()?;
 
     let mut offset = encode_frame_header(buf, frame_type, payload_len)?;
-    buf[offset..offset + payload.len()].copy_from_slice(payload);
-    offset += payload.len();
+    buf[offset..offset + bytes.len()].copy_from_slice(bytes);
+    offset += bytes.len();
 
     Some(offset)
 }
@@ -175,34 +183,25 @@ mod tests {
         let mut buf = [0u8; 16];
 
         // Type=0, Length=0
-        let len = encode_frame_header(&mut buf, 0, 0).unwrap();
+        let len =
+            encode_frame_header(&mut buf, VarInt::from_static(0), VarInt::from_static(0)).unwrap();
         assert_eq!(len, 2);
         assert_eq!(&buf[..2], &[0x00, 0x00]);
 
         // Type=4 (SETTINGS), Length=10
-        let len = encode_frame_header(&mut buf, 4, 10).unwrap();
+        let len =
+            encode_frame_header(&mut buf, VarInt::from_static(4), VarInt::from_static(10)).unwrap();
         assert_eq!(len, 2);
         assert_eq!(&buf[..2], &[0x04, 0x0a]);
     }
 
     #[test]
-    fn test_encode_frame_header_rejects_out_of_range() {
-        // frame_type が VarInt 範囲外の場合は None
-        let mut buf = [0u8; 16];
-        assert_eq!(encode_frame_header(&mut buf, 1u64 << 62, 0), None);
-        // payload_len が VarInt 範囲外の場合は None
-        assert_eq!(encode_frame_header(&mut buf, 0, 1u64 << 62), None);
-    }
-
-    #[test]
-    fn test_encoded_frame_len_rejects_unknown_out_of_range() {
-        // Frame::Unknown で frame_type が VarInt 範囲外の場合は None
-        let frame = Frame::Unknown {
-            frame_type: 1u64 << 62,
-            payload: vec![],
-        };
-        assert_eq!(encoded_frame_len(&frame), None);
-        let mut buf = vec![0u8; 16];
-        assert_eq!(encode_frame(&mut buf, &frame), None);
+    fn test_encode_frame_header_buffer_too_short() {
+        // バッファが必要バイト数未満なら None
+        let mut buf = [0u8; 1];
+        assert_eq!(
+            encode_frame_header(&mut buf, VarInt::from_static(0), VarInt::from_static(0)),
+            None
+        );
     }
 }

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -17,6 +17,7 @@ mod encoder;
 pub use decoder::{FrameHeader, decode_frame, decode_frame_header};
 pub use encoder::{encode_frame, encode_frame_header, encoded_frame_len};
 
+use core::fmt;
 use std::collections::HashSet;
 
 use crate::settings::{Setting, SettingError};
@@ -78,30 +79,144 @@ pub enum Frame {
     ///
     /// サーバープッシュ自体はサポートしないが、クライアントから control stream 上で
     /// 送信される正当なフレームのため、デコードして単調性検証だけ行う。
-    MaxPushId(u64),
-    /// 不明なフレーム (スキップ用)
-    Unknown { frame_type: u64, payload: Vec<u8> },
+    /// 値は wire 上 VarInt のため [`VarInt`] 型で保持する (RFC 9000 Section 16)。
+    MaxPushId(VarInt),
+    /// 未知のフレーム (RFC 9114 Section 9 拡張 / Section 7.2.8 Reserved Frame Types)
+    ///
+    /// 既知タイプ / HTTP/2 専用 ID を格納できない不変条件は [`UnknownFrame`] の
+    /// 構築 API (`new` / decoder 経路) で担保される。本 variant を受け取った側は
+    /// `frame_type` が未知の値であると仮定してよい。
+    Unknown(UnknownFrame),
 }
 
 impl Frame {
     /// フレームタイプを取得
-    pub fn frame_type(&self) -> u64 {
+    ///
+    /// RFC 9114 Section 7.2 の各フレームタイプは wire 上 VarInt であり、
+    /// RFC 9000 Section 16 の値域 (0..=2^62 - 1) に収まる。
+    pub fn frame_type(&self) -> VarInt {
         match self {
-            Self::Data(_) => FrameType::Data as u64,
-            Self::Headers(_) => FrameType::Headers as u64,
-            Self::Settings(_) => FrameType::Settings as u64,
-            Self::Goaway(_) => FrameType::Goaway as u64,
-            Self::MaxPushId(_) => FrameType::MaxPushId as u64,
-            Self::Unknown { frame_type, .. } => *frame_type,
+            Self::Data(_) => VarInt::from_static(FrameType::Data as u64),
+            Self::Headers(_) => VarInt::from_static(FrameType::Headers as u64),
+            Self::Settings(_) => VarInt::from_static(FrameType::Settings as u64),
+            Self::Goaway(_) => VarInt::from_static(FrameType::Goaway as u64),
+            Self::MaxPushId(_) => VarInt::from_static(FrameType::MaxPushId as u64),
+            Self::Unknown(p) => p.frame_type(),
         }
     }
 }
 
-/// DATA フレームペイロード
+/// [`Frame::Unknown`] 構築時の検査エラー
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum UnknownFrameError {
+    /// 既知の HTTP/3 フレームタイプを `Unknown` で構築しようとした
+    ///
+    /// RFC 9114 Section 7.2 で定義された 7 タイプ (DATA / HEADERS / CANCEL_PUSH /
+    /// SETTINGS / PUSH_PROMISE / GOAWAY / MAX_PUSH_ID) は専用 variant で表現する。
+    #[non_exhaustive]
+    KnownFrameType {
+        /// 該当フレームタイプ ID
+        frame_type: VarInt,
+    },
+    /// HTTP/2 専用フレームタイプ (0x02 / 0x06 / 0x08 / 0x09) を構築しようとした
+    ///
+    /// RFC 9114 Section 11.2.1 Table 2 で Reserved 登録、Section 7.2.8 で受信時
+    /// H3_FRAME_UNEXPECTED 必須。
+    #[non_exhaustive]
+    Http2OnlyFrameType {
+        /// 該当フレームタイプ ID
+        frame_type: VarInt,
+    },
+}
+
+impl fmt::Display for UnknownFrameError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::KnownFrameType { frame_type } => {
+                write!(
+                    f,
+                    "known HTTP/3 frame type {:#x} cannot be wrapped in Frame::Unknown",
+                    frame_type.get()
+                )
+            }
+            Self::Http2OnlyFrameType { frame_type } => {
+                write!(
+                    f,
+                    "HTTP/2-only frame type {:#x} cannot be wrapped in Frame::Unknown",
+                    frame_type.get()
+                )
+            }
+        }
+    }
+}
+
+impl core::error::Error for UnknownFrameError {}
+
+/// 未知の HTTP/3 フレーム (RFC 9114 Section 9 拡張 / Section 7.2.8 Reserved Frame Types)
+///
+/// `frame_type` は以下のいずれでもないことを構築時に保証する:
+/// - [`FrameType`] enum で表現される既知タイプ (DATA / HEADERS / CANCEL_PUSH / SETTINGS /
+///   PUSH_PROMISE / GOAWAY / MAX_PUSH_ID)
+/// - HTTP/2 専用 ID (RFC 9114 Section 11.2.1 Table 2: 0x02 / 0x06 / 0x08 / 0x09)
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnknownFrame {
+    frame_type: VarInt,
+    payload: Vec<u8>,
+}
+
+impl UnknownFrame {
+    /// 未知フレームを構築する
+    ///
+    /// エラー条件は [`UnknownFrameError`] の各バリアントを参照。
+    pub fn new(frame_type: VarInt, payload: Vec<u8>) -> Result<Self, UnknownFrameError> {
+        let t = frame_type.get();
+        if FrameType::from_type(t).is_some() {
+            return Err(UnknownFrameError::KnownFrameType { frame_type });
+        }
+        if FrameType::is_http2_only(t) {
+            return Err(UnknownFrameError::Http2OnlyFrameType { frame_type });
+        }
+        Ok(Self {
+            frame_type,
+            payload,
+        })
+    }
+
+    /// フレームタイプを取得
+    pub const fn frame_type(&self) -> VarInt {
+        self.frame_type
+    }
+
+    /// ペイロードバイト列の参照を返す
+    pub fn payload(&self) -> &[u8] {
+        &self.payload
+    }
+
+    /// ペイロードバイト列を所有権付きで取り出す
+    pub fn into_payload(self) -> Vec<u8> {
+        self.payload
+    }
+
+    /// ペイロードバイト数を返す
+    pub fn len(&self) -> usize {
+        self.payload.len()
+    }
+
+    /// ペイロードが空か
+    pub fn is_empty(&self) -> bool {
+        self.payload.is_empty()
+    }
+}
+
+/// DATA フレームペイロード (RFC 9114 Section 7.2.1)
+///
+/// ペイロードは任意のオクテット列で値域検査は無いが、構築後の改ざんを防ぐため
+/// フィールドを private にし、アクセサ経由で読み取る。
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DataPayload {
     /// ペイロードデータ
-    pub data: Vec<u8>,
+    data: Vec<u8>,
 }
 
 impl DataPayload {
@@ -109,13 +224,36 @@ impl DataPayload {
     pub fn new(data: Vec<u8>) -> Self {
         Self { data }
     }
+
+    /// ペイロードバイト列の参照を返す
+    pub fn data(&self) -> &[u8] {
+        &self.data
+    }
+
+    /// ペイロードバイト列を所有権付きで取り出す
+    pub fn into_data(self) -> Vec<u8> {
+        self.data
+    }
+
+    /// ペイロードバイト数を返す
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    /// ペイロードが空か
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
 }
 
-/// HEADERS フレームペイロード
+/// HEADERS フレームペイロード (RFC 9114 Section 7.2.2)
+///
+/// QPACK 符号化済みバイト列を保持する。フィールド単位の検査は [`crate::qpack::Header`]
+/// で別途行う。構築後の改ざんを防ぐためフィールドを private にする。
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HeadersPayload {
     /// QPACK エンコード済みヘッダーブロック
-    pub encoded_field_section: Vec<u8>,
+    encoded_field_section: Vec<u8>,
 }
 
 impl HeadersPayload {
@@ -124,6 +262,26 @@ impl HeadersPayload {
         Self {
             encoded_field_section,
         }
+    }
+
+    /// QPACK 符号化済みヘッダーブロックの参照を返す
+    pub fn encoded_field_section(&self) -> &[u8] {
+        &self.encoded_field_section
+    }
+
+    /// QPACK 符号化済みヘッダーブロックを所有権付きで取り出す
+    pub fn into_encoded_field_section(self) -> Vec<u8> {
+        self.encoded_field_section
+    }
+
+    /// 符号化済みヘッダーブロックのバイト数
+    pub fn len(&self) -> usize {
+        self.encoded_field_section.len()
+    }
+
+    /// 符号化済みヘッダーブロックが空か
+    pub fn is_empty(&self) -> bool {
+        self.encoded_field_section.is_empty()
     }
 }
 
@@ -200,17 +358,40 @@ impl SettingsPayload {
     }
 }
 
-/// GOAWAY フレームペイロード
+/// GOAWAY フレームペイロード (RFC 9114 Section 7.2.6)
+///
+/// `id` の意味は送受信ロールに依存する:
+/// - サーバー送信 / クライアント受信: client-initiated bidirectional stream ID
+///   (RFC 9000 Section 2.1 で 4 の倍数)
+/// - クライアント送信 / サーバー受信: push ID (本実装はサーバープッシュ非対応のため 0 のみ)
+///
+/// 単調減少制約 (RFC 9114 Section 5.2) と 4 の倍数制約は接続状態依存のため
+/// [`crate::Connection::send_goaway`] のランタイム検査で別途行う。
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GoawayPayload {
-    /// ストリーム ID またはプッシュ ID
-    pub id: u64,
+    /// ストリーム ID またはプッシュ ID (RFC 9000 Section 16 の VarInt)
+    id: VarInt,
 }
 
 impl GoawayPayload {
     /// 新しい GOAWAY ペイロードを作成
-    pub fn new(id: u64) -> Self {
+    pub const fn new(id: VarInt) -> Self {
         Self { id }
+    }
+
+    /// 静的値から GOAWAY ペイロードを構築する (const fn)
+    ///
+    /// `id` が VarInt 範囲外の場合はコンパイル時にエラーとなる。
+    /// ランタイム値からは [`Self::new`] と [`VarInt::new`] を組み合わせて使う。
+    pub const fn from_static(id: u64) -> Self {
+        Self {
+            id: VarInt::from_static(id),
+        }
+    }
+
+    /// `id` を取得する
+    pub const fn id(&self) -> VarInt {
+        self.id
     }
 }
 
@@ -221,21 +402,50 @@ mod tests {
     #[test]
     fn test_frame_frame_type() {
         let data = Frame::Data(DataPayload::new(vec![1, 2, 3]));
-        assert_eq!(data.frame_type(), 0x00);
+        assert_eq!(data.frame_type().get(), 0x00);
 
         let headers = Frame::Headers(HeadersPayload::new(vec![4, 5, 6]));
-        assert_eq!(headers.frame_type(), 0x01);
+        assert_eq!(headers.frame_type().get(), 0x01);
 
         let settings = Frame::Settings(SettingsPayload::new());
-        assert_eq!(settings.frame_type(), 0x04);
+        assert_eq!(settings.frame_type().get(), 0x04);
 
-        let goaway = Frame::Goaway(GoawayPayload::new(100));
-        assert_eq!(goaway.frame_type(), 0x07);
+        let goaway = Frame::Goaway(GoawayPayload::from_static(100));
+        assert_eq!(goaway.frame_type().get(), 0x07);
 
-        let unknown = Frame::Unknown {
-            frame_type: 0x99,
-            payload: vec![],
-        };
-        assert_eq!(unknown.frame_type(), 0x99);
+        let unknown = Frame::Unknown(
+            UnknownFrame::new(VarInt::from_static(0x21), vec![])
+                .expect("0x21 は RFC 9114 Section 7.2.8 の Reserved Frame Type"),
+        );
+        assert_eq!(unknown.frame_type().get(), 0x21);
+    }
+
+    #[test]
+    fn test_unknown_frame_rejects_all_known_types() {
+        // RFC 9114 Section 7.2 で定義された全 7 タイプは UnknownFrame に格納できない
+        for id in [0x00u64, 0x01, 0x03, 0x04, 0x05, 0x07, 0x0d] {
+            let frame_type = VarInt::from_static(id);
+            let err = UnknownFrame::new(frame_type, vec![]).unwrap_err();
+            assert_eq!(err, UnknownFrameError::KnownFrameType { frame_type });
+        }
+    }
+
+    #[test]
+    fn test_unknown_frame_rejects_all_http2_only_types() {
+        // RFC 9114 Section 11.2.1 Table 2 で Reserved 登録された HTTP/2 専用 4 タイプ
+        for id in [0x02u64, 0x06, 0x08, 0x09] {
+            let frame_type = VarInt::from_static(id);
+            let err = UnknownFrame::new(frame_type, vec![]).unwrap_err();
+            assert_eq!(err, UnknownFrameError::Http2OnlyFrameType { frame_type });
+        }
+    }
+
+    #[test]
+    fn test_unknown_frame_accepts_reserved_frame_type() {
+        // RFC 9114 Section 7.2.8 の Reserved Frame Type (0x1f * N + 0x21、N=0 で 0x21)
+        let unknown = UnknownFrame::new(VarInt::from_static(0x21), vec![1, 2, 3])
+            .expect("0x21 は既知タイプでも HTTP/2 専用でもない");
+        assert_eq!(unknown.frame_type().get(), 0x21);
+        assert_eq!(unknown.payload(), &[1, 2, 3][..]);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,7 @@ pub use error::{Error, ErrorCode, FrameDecodeError, QpackError};
 pub use event::Event;
 pub use frame::{
     DataPayload, Frame, FrameHeader, FrameType, GoawayPayload, HeadersPayload, SettingsPayload,
+    UnknownFrame, UnknownFrameError,
 };
 pub use limits::Limits;
 pub use qpack::{

--- a/src/stream/control.rs
+++ b/src/stream/control.rs
@@ -5,6 +5,7 @@
 use crate::error::{Error, ErrorCode};
 use crate::frame::{self, Frame, GoawayPayload, SettingsPayload};
 use crate::settings::Settings;
+use crate::varint::VarInt;
 
 use super::{RecvBuffer, SendBuffer};
 
@@ -88,27 +89,17 @@ impl ControlStreamSend {
     /// GOAWAY フレームを送信キューに追加
     ///
     /// 制御ストリームが Ready 状態でなければエラーを返す (RFC 9114 Section 7.2.6)。
-    pub fn send_goaway(&mut self, id: u64) -> Result<(), crate::error::Error> {
+    /// `id` の値域は [`VarInt`] 型レベルで保証される (RFC 9000 Section 16)。
+    pub fn send_goaway(&mut self, id: VarInt) -> Result<(), Error> {
         if self.send_state != ControlSendState::Ready {
             return Err(crate::error::Error::ConnectionError(
                 crate::error::ErrorCode::ClosedCriticalStream,
             ));
         }
 
-        // GOAWAY id は RFC 9000 Section 16 の VarInt 範囲内であること
-        // (RFC 9114 Section 7.2.6, RFC 9000 Section 2.1)。
-        // 本 issue 時点では `u64` 受けのまま検査するが、後続 issue 0087 で
-        // 引数型を `VarInt` に昇格させて型レベルで保証する。
-        // 範囲外はローカル API 利用側のバグなので H3_INTERNAL_ERROR で返す
-        // (wire frame の問題ではないため H3_FRAME_ERROR は不適切)。
-        if crate::varint::VarInt::new(id).is_err() {
-            return Err(crate::error::Error::ConnectionError(
-                crate::error::ErrorCode::InternalError,
-            ));
-        }
         let frame = Frame::Goaway(GoawayPayload::new(id));
-        let frame_len =
-            frame::encoded_frame_len(&frame).expect("GOAWAY id fits in VarInt after check");
+        let frame_len = frame::encoded_frame_len(&frame)
+            .expect("GOAWAY id is VarInt typed, payload always fits");
         let mut buf = vec![0u8; frame_len];
         let written =
             frame::encode_frame(&mut buf, &frame).expect("encoded_frame_len validated above");
@@ -232,7 +223,12 @@ impl ControlStreamRecv {
                     };
 
                     // フレーム全体を受信できているか
-                    if data.len() < header.total_len() {
+                    // total_len が None なら 32bit プラットフォームで usize に収まらない
+                    // → H3_FRAME_ERROR (RFC 9114 Section 7.1)
+                    let Some(total_len) = header.total_len() else {
+                        return Err(Error::ConnectionError(ErrorCode::FrameError));
+                    };
+                    if data.len() < total_len {
                         return Ok(None);
                     }
 

--- a/src/stream/request.rs
+++ b/src/stream/request.rs
@@ -294,7 +294,12 @@ impl RequestStream {
             };
 
             // フレーム全体を受信できているか
-            if data.len() < header.total_len() {
+            // total_len が None なら 32bit プラットフォームで usize に収まらない
+            // → H3_FRAME_ERROR (RFC 9114 Section 7.1)
+            let Some(total_len) = header.total_len() else {
+                return Err(Error::ConnectionError(ErrorCode::FrameError));
+            };
+            if data.len() < total_len {
                 // FIN 受信済みならフレームが切断されている (RFC 9114 Section 7.1)
                 if self.recv_buf.is_fin() {
                     return Err(Error::ConnectionError(ErrorCode::FrameError));
@@ -304,7 +309,7 @@ impl RequestStream {
 
             // SETTINGS はリクエストストリームでは内容に関わらず接続エラー
             // (RFC 9114 Section 7.2.4: ペイロードデコード前に判定する)
-            if header.frame_type == 0x04 {
+            if header.frame_type().get() == 0x04 {
                 return Err(Error::ConnectionError(ErrorCode::FrameUnexpected));
             }
 
@@ -335,14 +340,14 @@ impl RequestStream {
                         // 2 回目の HEADERS はトレーラー (RFC 9114 Section 4.1)
                         self.recv_state = RequestRecvState::TrailersReceived;
                         return Ok(Some(RawReceivedData::Trailers(
-                            payload.encoded_field_section,
+                            payload.into_encoded_field_section(),
                         )));
                     } else {
                         // 最初の HEADERS
                         self.recv_state = RequestRecvState::ReceivingBody;
                     }
                     return Ok(Some(RawReceivedData::Headers(
-                        payload.encoded_field_section,
+                        payload.into_encoded_field_section(),
                     )));
                 }
                 Frame::Data(payload) => {
@@ -353,11 +358,13 @@ impl RequestStream {
                     {
                         return Err(Error::ConnectionError(ErrorCode::FrameUnexpected));
                     }
-                    self.recv_body.extend_from_slice(&payload.data);
-                    return Ok(Some(RawReceivedData::Data(payload.data)));
+                    let data = payload.into_data();
+                    self.recv_body.extend_from_slice(&data);
+                    return Ok(Some(RawReceivedData::Data(data)));
                 }
-                Frame::Unknown { .. } => {
-                    // RFC 9114: 不明なフレームは無視する (GREASE 対応)
+                Frame::Unknown(_) => {
+                    // RFC 9114 Section 9 / Section 7.2.8: 不明なフレームは無視する
+                    // (Reserved Frame Types: 0x1f * N + 0x21)
                     // ループを継続して次のフレームを処理
                 }
                 // SETTINGS/GOAWAY/MAX_PUSH_ID はリクエストストリームで受信した場合は接続エラー

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -169,7 +169,7 @@ fn test_goaway_exchange() -> Result<(), Box<dyn std::error::Error>> {
     let _ = server.poll_event()?;
 
     // サーバーが GOAWAY を送信
-    server.send_goaway(0)?;
+    server.send_goaway(vi(0))?;
 
     // GOAWAY データを取得して送信
     let (goaway_data, _) = server.take_stream_data(3).unwrap();
@@ -178,7 +178,32 @@ fn test_goaway_exchange() -> Result<(), Box<dyn std::error::Error>> {
 
     // クライアントが GOAWAY を受信
     let event = client.poll_event()?.unwrap();
-    assert!(matches!(event, Event::GoawayReceived { id: 0 }));
+    let Event::GoawayReceived { id } = event else {
+        panic!("expected Event::GoawayReceived, got {event:?}");
+    };
+    assert_eq!(id, vi(0));
+
+    Ok(())
+}
+
+/// GOAWAY の単調減少制約 (RFC 9114 Section 5.2: "MUST NOT increase the value")
+#[test]
+fn test_goaway_monotonic_decrease() -> Result<(), Box<dyn std::error::Error>> {
+    let mut server = ServerConnection::with_default_settings();
+    server.set_control_stream_id(3)?;
+
+    // 初回 GOAWAY (stream id 8 = client-initiated bidi 3 番目)
+    server.send_goaway(vi(8))?;
+
+    // 同一 ID の再送は許可される
+    server.send_goaway(vi(8))?;
+
+    // より小さな ID への減少も許可される
+    server.send_goaway(vi(4))?;
+
+    // より大きな ID への増加は IdError で拒否される
+    let result = server.send_goaway(vi(8));
+    assert!(result.is_err(), "GOAWAY id increase must be rejected");
 
     Ok(())
 }


### PR DESCRIPTION
## 概要

HTTP/3 フレームペイロード (`DataPayload` / `HeadersPayload` / `GoawayPayload` / `Frame::MaxPushId` / `Frame::Unknown`) を構築時検査型に作り変える。`VarInt` 型 (issue 0084) と `UnknownFrame` newtype の導入で RFC 9000 Section 16 の値域と RFC 9114 Section 7.2 / 11.2.1 の既知タイプ偽装を型レベル + 構築時検査で排除する。

## 変更内容

- `DataPayload` / `HeadersPayload` / `GoawayPayload` の全フィールドを private 化、アクセサ (`data` / `into_data` / `encoded_field_section` / `into_encoded_field_section` / `id` / `len` / `is_empty`) を提供
- `GoawayPayload.id` / `Frame::MaxPushId` / `Frame::Unknown.frame_type` / `Frame::frame_type()` / `FrameHeader.frame_type` / `FrameHeader.payload_len` の型を `u64` → `VarInt`
- `FrameHeader` のフィールド private 化、`from_validated_parts` 経由で組み立て (wire 上の実バイト長を `header_len` で保持し RFC 9000 §16 の非最小エンコードに対応)
- `FrameHeader::total_len()` を `Option<usize>` 化し 32bit プラットフォームでの silent truncation を防止
- `GoawayPayload::from_static` を `const fn` で追加 (不正リテラルをコンパイル時検出)
- `Frame::Unknown` を `Frame::Unknown(UnknownFrame)` tuple variant 化、`UnknownFrame::new` で既知 HTTP/3 タイプ (RFC 9114 §7.2) / HTTP/2 専用 ID (§11.2.1 Table 2 / §7.2.8 H3_FRAME_UNEXPECTED) 偽装を弾く
- `UnknownFrameError` (`#[non_exhaustive]` + バリアントも `#[non_exhaustive]`) を新設
- `Event::GoawayReceived.id` / `Connection::send_goaway` 系の引数型を `VarInt`
- `encode_frame_header` のシグネチャを `(buf, frame_type: VarInt, payload_len: VarInt)` に変更
- decoder の `encoded_settings_payload_len` 戻り値を `Option<VarInt>` に集約
- PBT を `prop_filter` で VarInt 全領域 (既知 / HTTP/2 専用除外) に拡張

## 完了条件

- [x] `DataPayload` / `HeadersPayload` / `GoawayPayload` の全フィールドが private、アクセサ経由でのみ読み取れる
- [x] `GoawayPayload.id` / `Frame::MaxPushId` / `UnknownFrame::frame_type` / `Frame::frame_type()` の型が `VarInt`
- [x] `FrameHeader.frame_type` / `payload_len` の型が `VarInt` で private、アクセサが提供
- [x] `GoawayPayload::from_static` が `const fn` で実装
- [x] decoder が `FrameHeader::from_validated_parts` 経由で組み立て、wire 上の実バイト長を保持
- [x] `Event::GoawayReceived.id` の型が `VarInt`
- [x] `send_goaway(id: VarInt)` のシグネチャ変更が反映
- [x] 既存の GOAWAY 単調減少検査 (issue 0067) が維持
- [x] サーバープッシュ非対応の方針が維持
- [x] 既存の全テスト・PBT・fuzz が通る

## 関連 issue

- issues/closed/0087-change-frame-construct-time-validation.md
- 依存: [[0084-add-varint-constructor-type]] / [[0085-change-header-construct-time-validation]] / [[0086-change-settings-construct-time-validation]]