### PR TITLE
0088 構築時検査の compile_fail doctest と PBT 整合性検証を整備する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,16 @@
 
 ## develop
 
+- [ADD] `VarInt::from_static` / `qpack::Header::from_static` / `frame::GoawayPayload::from_static` の doc に `compile_fail` ブロックを追加し、`const fn` 検査のリグレッションを CI (`cargo test --doc`) で防止する
+  - @voluntas
+- [ADD] 構築時検査の `from_static` ↔ `new` 一貫性、`from_validated_parts` ↔ `new` 整合性、`Header::new` ↔ QPACK ラウンドトリップ完全性を検証する PBT を追加する
+  - @voluntas
+- [ADD] `Makefile` に `doc-test` ターゲットを追加し `cargo test --doc --workspace --exclude nghttp3-sys --exclude ngtcp2-sys --features shiguredo_http3/internal-test` を実行する (sys クレートは bindgen 生成 doc が rustc でパースできないため除外)
+  - @voluntas
+- [ADD] `VarInt::from_validated_parts` を `internal-test` フィーチャー限定で公開し、PBT から `from_validated_parts` と `new` の整合性検証を可能にする (内部用は `from_validated_parts_internal` に改名)
+  - @voluntas
+- [ADD] `pbt` クレートに `strategies` モジュールを追加し、構築時検査型の `valid_*` / `invalid_*` 戦略を集約する (`pbt/Cargo.toml` の `proptest` / `shiguredo_http3` を `[dev-dependencies]` から `[dependencies]` に格上げ)
+  - @voluntas
 - [ADD] `VarInt` / `VarIntError` を新設し、RFC 9000 Section 16 の値域 (`0..=2^62 - 1`) を型で表現する
   - @voluntas
 - [ADD] `VarInt::from_static` を `const fn` で提供し、`2^62` 以上のリテラル定数を `const` / `static` 宣言時にコンパイル時 panic として検出可能にする

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,16 @@
-.PHONY: test cover pbt pbt-cover fuzz fuzzing fuzzing-list interop-test-h3 interop-test-wt interop-test check clippy fmt clean
+.PHONY: test doc-test cover pbt pbt-cover fuzz fuzzing fuzzing-list interop-test-h3 interop-test-wt interop-test check clippy fmt clean
 
 # 全テストを実行する
 test:
 	cargo test --workspace --tests
+
+# doctest を実行する (compile_fail ブロックを含む)
+# bindgen 生成 doc (`nghttp3-sys` / `ngtcp2-sys`) には C 言語サンプルが含まれ
+# rustc ではパースできないため `--exclude` で除外する
+# `internal-test` は本クレート (`shiguredo_http3`) の compile_fail doctest を
+# 有効化するため明示する
+doc-test:
+	cargo test --doc --workspace --exclude nghttp3-sys --exclude ngtcp2-sys --features shiguredo_http3/internal-test
 
 # 全テストカバレッジ付きで実行する
 cover:

--- a/issues/closed/0088-add-compile-fail-doctest-and-pbt-construct-time-validation.md
+++ b/issues/closed/0088-add-compile-fail-doctest-and-pbt-construct-time-validation.md
@@ -1,7 +1,9 @@
 # 0088: 構築時検査の compile_fail doctest と PBT 整合性検証を整備する
 
 Created: 2026-05-23
+Completed: 2026-05-24
 Model: Opus 4.7
+Branch: feature/add-compile-fail-doctest-and-pbt-consistency
 
 ## 概要
 
@@ -291,3 +293,67 @@ doc-test:
 - [[0085-change-header-construct-time-validation]] (Header の from_static)
 - [[0086-change-settings-construct-time-validation]] (Setting の from_static)
 - [[0087-change-frame-construct-time-validation]] (GoawayPayload の from_static)
+
+## 解決方法
+
+### compile_fail doctest
+
+`*::from_static` の不正リテラルがコンパイル時に弾かれることを `cargo test --doc` で
+担保する。追加した compile_fail ブロック:
+
+- `src/varint.rs`: `VarInt::from_static(1u64 << 62)` (値域外)
+- `src/frame/mod.rs`: `GoawayPayload::from_static(1u64 << 62)` (値域外)
+- `src/qpack/header.rs`: `Header::from_static` の大文字 / CRLF / 空 / 不明な疑似ヘッダー
+  4 件
+
+`Makefile` に `doc-test` ターゲットを追加し、`cargo test --doc --workspace --exclude
+nghttp3-sys --exclude ngtcp2-sys --features shiguredo_http3/internal-test` を実行する
+(bindgen 生成 doc の C 言語サンプルが rustc でパースできないため sys クレートは除外)。
+
+### PBT 戦略の集約
+
+`pbt/src/lib.rs` の `strategies` モジュールに以下を集約し、`pbt/tests/prop_varint.rs`
+と `pbt/tests/prop_qpack.rs` のローカル定義を削除して `use pbt::strategies::*` に統一:
+
+- `valid_varint()` / `invalid_varint_u64()`
+- `valid_header_name()` / `valid_header_value()`
+
+`pbt/Cargo.toml` の `proptest` / `shiguredo_http3` を `[dev-dependencies]` から
+`[dependencies]` に格上げし、`pbt/src/lib.rs` から参照できるようにした。
+
+### PBT 整合性検証
+
+- `prop_from_static_matches_new` (VarInt) / `prop_goaway_from_static_matches_new`
+  (GoawayPayload) / `prop_header_from_static_matches_new` (Header): `from_static` と
+  `new` の同値性
+- `prop_from_validated_parts_matches_new` (VarInt) /
+  `prop_header_from_validated_parts_matches_new` (Header): `from_validated_parts` と
+  `new` の同値性
+- `prop_invalid_varint_rejected`: VarInt 値域外で `new` / `try_from` が必ず Err
+- `prop_header_new_accepts_imply_qpack_roundtrip` (**完全性**): `Header::new` が受理する
+  任意 (name, value) は QPACK encode → decode の往復で同じ Header に復元される
+
+完全性 (`new` ⇔ decoder) の `VarInt` / `GoawayPayload` 分は既存
+`prop_roundtrip_preserves_value` / `prop_goaway_frame_roundtrip` でカバー済み。
+
+### VarInt 命名統一
+
+`VarInt::from_validated_parts` を `Header` 側と同じパターンに揃えた:
+
+- `pub(crate) const fn from_validated_parts_internal(value: u64) -> Self`: decoder 内部用
+- `#[cfg(any(test, feature = "internal-test"))] #[doc(hidden)] pub const fn
+  from_validated_parts(value: u64) -> Self`: PBT / fuzz / 統合テスト用バックドア
+
+以前の `from_validated_parts_pub` は削除。
+
+### review-diff-code 1 周
+
+致命的 6 件のすべてに対応 (C1+C2: strategies 実利用化、C3: Header 完全性 PBT 追加、
+C4: Box::leak cases を 16 に縮小、C5: VarInt 命名統一、C6: Makefile を CHANGES.md と
+整合)。重要のうち M3 (proptest! ブロック分割) も対応。
+
+未対応:
+
+- M1: Header compile_fail の検査経路追加 3 件 (token 外 / leading whitespace / pseudo
+  header value) — 受け入れ条件は満たすため別 issue 化が妥当
+- 既存 PBT の死にコード (`prop_qpack.rs::valid_capacity` 等) — 本 issue スコープ外

--- a/pbt/Cargo.toml
+++ b/pbt/Cargo.toml
@@ -5,6 +5,6 @@ edition.workspace = true
 rust-version.workspace = true
 publish = false
 
-[dev-dependencies]
+[dependencies]
 proptest = "1.11"
 shiguredo_http3 = { path = "../", features = ["internal-test"] }

--- a/pbt/src/lib.rs
+++ b/pbt/src/lib.rs
@@ -1,1 +1,50 @@
 //! Property-Based Testing for shiguredo_http3
+//!
+//! 各構築時検査型の `valid_*` 戦略を集約する。
+//! 個別の `pbt/tests/prop_*.rs` から `use pbt::strategies::*;` で再利用する。
+
+pub mod strategies {
+    use proptest::prelude::*;
+    use shiguredo_http3::VarInt;
+
+    /// RFC 9000 Section 16: VarInt の値域 (0..=2^62 - 1)
+    pub fn valid_varint() -> impl Strategy<Value = VarInt> {
+        (0u64..=VarInt::MAX.get()).prop_map(|v| VarInt::new(v).unwrap())
+    }
+
+    /// `VarInt::new` / `VarInt::try_from` が必ず `Err` を返す入力 (PBT の
+    /// negative path 用)
+    pub fn invalid_varint_u64() -> impl Strategy<Value = u64> {
+        (VarInt::MAX.get() + 1)..=u64::MAX
+    }
+
+    /// RFC 9114 Section 4.2 / RFC 9110 Section 5.1: 小文字 token-char のみで
+    /// 構成された valid な field name (1..64 byte)
+    pub fn valid_header_name() -> impl Strategy<Value = Vec<u8>> {
+        (1usize..64)
+            .prop_flat_map(|len| prop::collection::vec(prop::char::range('a', 'z'), len))
+            .prop_map(|chars| chars.into_iter().map(|c| c as u8).collect())
+    }
+
+    /// RFC 9110 Section 5.5 の field-content に従い、両端は field-vchar
+    /// (0x21-0x7E)、間には SP (0x20) も許す。空文字列も valid。
+    /// (obs-text 0x80-0xFF は QPACK Huffman デコードとの整合性を保つため除外)
+    pub fn valid_header_value() -> impl Strategy<Value = Vec<u8>> {
+        (0usize..256)
+            .prop_flat_map(|len| prop::collection::vec(0x20u8..=0x7e, len))
+            .prop_map(|middle| {
+                if middle.is_empty() {
+                    return Vec::new();
+                }
+                let mut v = middle;
+                if v[0] == 0x20 {
+                    v[0] = 0x21;
+                }
+                let last = v.len() - 1;
+                if v[last] == 0x20 {
+                    v[last] = 0x21;
+                }
+                v
+            })
+    }
+}

--- a/pbt/tests/prop_frame.rs
+++ b/pbt/tests/prop_frame.rs
@@ -354,3 +354,18 @@ proptest! {
         );
     }
 }
+
+// =============================================================================
+// Construct-Time Validation Consistency
+// =============================================================================
+
+proptest! {
+    /// Property: GoawayPayload::from_static と new(VarInt::new(id)) が同じ値を返す
+    /// (`const fn` 検査とランタイム検査のロジック一致)
+    #[test]
+    fn prop_goaway_from_static_matches_new(value in 0u64..=VarInt::MAX.get()) {
+        let via_new = GoawayPayload::new(VarInt::new(value).unwrap());
+        let via_static = GoawayPayload::from_static(value);
+        prop_assert_eq!(via_new, via_static);
+    }
+}

--- a/pbt/tests/prop_qpack.rs
+++ b/pbt/tests/prop_qpack.rs
@@ -2,6 +2,7 @@
 
 use std::borrow::Cow;
 
+use pbt::strategies::{valid_header_name, valid_header_value};
 use proptest::prelude::*;
 use shiguredo_http3::qpack::{
     DecodeOutput, Decoder, DecoderInstruction, DecoderStream, DecoderStreamReceiver,
@@ -23,44 +24,6 @@ const DYNAMIC_TABLE_CAPACITY: u64 = 4096;
 
 /// エントリオーバーヘッド (RFC 9204 Section 3.2.1)
 const ENTRY_OVERHEAD: u64 = 32;
-
-prop_compose! {
-    /// 有効なヘッダー名を生成 (ASCII 小文字のみ)
-    fn valid_header_name()(
-        len in 1usize..64,
-    )(
-        name in prop::collection::vec(prop::char::range('a', 'z'), len)
-    ) -> Vec<u8> {
-        name.into_iter().map(|c| c as u8).collect()
-    }
-}
-
-prop_compose! {
-    /// 有効なヘッダー値を生成
-    ///
-    /// RFC 9110 Section 5.5 の field-content に従い、両端は field-vchar
-    /// (0x21-0x7E)、間には SP (0x20) も許す。空文字列も valid。
-    /// (obs-text 0x80-0xFF は QPACK Huffman デコードとの整合性を保つため除外)
-    fn valid_header_value()(
-        len in 0usize..256,
-    )(
-        middle in prop::collection::vec(0x20u8..=0x7e, len),
-    ) -> Vec<u8> {
-        if middle.is_empty() {
-            return Vec::new();
-        }
-        let mut v = middle;
-        // 両端は field-vchar (0x21..=0x7e) でなければならない
-        if v[0] == 0x20 {
-            v[0] = 0x21;
-        }
-        let last = v.len() - 1;
-        if v[last] == 0x20 {
-            v[last] = 0x21;
-        }
-        v
-    }
-}
 
 prop_compose! {
     /// 有効なテーブル容量を生成
@@ -997,5 +960,68 @@ proptest! {
             prop_assert_eq!(decoded[0].name().to_vec(), entry_name);
             prop_assert_eq!(decoded[0].value().to_vec(), entry_value);
         }
+    }
+}
+
+// =============================================================================
+// Construct-Time Validation Consistency (Header)
+// =============================================================================
+
+proptest! {
+    // `Header::from_static` は `&'static [u8]` を要求するため `Box::leak` で
+    // 擬似的に静的化する。proptest の shrink でケースが追加発火するたびに
+    // リークが累積するためケース数を絞る (cases: 16)。
+    #![proptest_config(ProptestConfig { cases: 16, ..ProptestConfig::default() })]
+
+    /// Property: `Header::from_static` と `Header::new` が同じ値を返す
+    /// (`const fn` 検査とランタイム検査のロジック一致)
+    #[test]
+    fn prop_header_from_static_matches_new(
+        name in valid_header_name(),
+        value in valid_header_value(),
+    ) {
+        let via_new = Header::new(&name, &value).unwrap();
+        let static_name: &'static [u8] = Box::leak(name.clone().into_boxed_slice());
+        let static_value: &'static [u8] = Box::leak(value.clone().into_boxed_slice());
+        let via_static = Header::from_static(static_name, static_value);
+        prop_assert_eq!(via_new, via_static);
+    }
+}
+
+proptest! {
+    /// Property: `Header::from_validated_parts` と `Header::new` が同じ値を返す
+    /// (内部バックドアと公開 API のロジック一致。Box::leak を使わないので
+    /// デフォルトのケース数で網羅する)
+    #[test]
+    fn prop_header_from_validated_parts_matches_new(
+        name in valid_header_name(),
+        value in valid_header_value(),
+    ) {
+        let via_new = Header::new(&name, &value).unwrap();
+        let via_validated = Header::from_validated_parts(
+            Cow::Owned(name.clone()),
+            Cow::Owned(value.clone()),
+        );
+        prop_assert_eq!(via_new, via_validated);
+    }
+
+    /// Property (完全性): `Header::new` が受理する任意 (name, value) は、
+    /// QPACK encode → decode の往復で同じ Header が再構築される。
+    /// (構築時検査と decoder の受理集合一致の片方向確認)
+    #[test]
+    fn prop_header_new_accepts_imply_qpack_roundtrip(
+        name in valid_header_name(),
+        value in valid_header_value(),
+    ) {
+        let original = Header::new(&name, &value).unwrap();
+        let encoder = Encoder::new();
+        let decoder = Decoder::new();
+        let headers = vec![original.clone()];
+        let mut buf = vec![0u8; 8192];
+        let encoded_len = encoder.encode(&mut buf, &headers).unwrap();
+        let decoded = decoder.decode(&buf[..encoded_len]).unwrap();
+        prop_assert_eq!(decoded.len(), 1);
+        prop_assert_eq!(decoded[0].name(), original.name());
+        prop_assert_eq!(decoded[0].value(), original.value());
     }
 }

--- a/pbt/tests/prop_varint.rs
+++ b/pbt/tests/prop_varint.rs
@@ -1,15 +1,9 @@
 //! Property-Based Testing for QUIC Variable-Length Integer (RFC 9000 Section 16)
 
+use pbt::strategies::{invalid_varint_u64, valid_varint};
 use proptest::prelude::*;
 use shiguredo_http3::VarInt;
 use shiguredo_http3::varint;
-
-prop_compose! {
-    /// 有効な VarInt を生成
-    fn valid_varint()(value in 0u64..=VarInt::MAX.get()) -> VarInt {
-        VarInt::new(value).unwrap()
-    }
-}
 
 prop_compose! {
     /// 1 バイトエンコード範囲の値を生成 (0-63)
@@ -194,5 +188,31 @@ proptest! {
     #[test]
     fn prop_display_matches_u64(value in valid_varint()) {
         prop_assert_eq!(format!("{value}"), format!("{}", value.get()));
+    }
+
+    /// Property: `from_static` と `new` が同じ値を返す (`const fn` 検査と
+    /// ランタイム検査のロジック一致)
+    #[test]
+    fn prop_from_static_matches_new(value in 0u64..=VarInt::MAX.get()) {
+        let via_new = VarInt::new(value).unwrap();
+        let via_static = VarInt::from_static(value);
+        prop_assert_eq!(via_new, via_static);
+    }
+
+    /// Property: `from_validated_parts` と `new` が同じ値を返す (内部バックドアと
+    /// 公開 API のロジック一致)
+    #[test]
+    fn prop_from_validated_parts_matches_new(value in 0u64..=VarInt::MAX.get()) {
+        let via_new = VarInt::new(value).unwrap();
+        let via_validated = VarInt::from_validated_parts(value);
+        prop_assert_eq!(via_new, via_validated);
+    }
+
+    /// Property: VarInt 範囲外の `u64` は `new` で必ず Err、`TryFrom<u64>` でも必ず Err
+    /// (構築 API の値域判定が一貫している)
+    #[test]
+    fn prop_invalid_varint_rejected(value in invalid_varint_u64()) {
+        prop_assert!(VarInt::new(value).is_err());
+        prop_assert!(VarInt::try_from(value).is_err());
     }
 }

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -383,6 +383,13 @@ impl GoawayPayload {
     ///
     /// `id` が VarInt 範囲外の場合はコンパイル時にエラーとなる。
     /// ランタイム値からは [`Self::new`] と [`VarInt::new`] を組み合わせて使う。
+    ///
+    /// VarInt 値域外 (`>= 2^62`) のリテラルはコンパイル時に弾かれる:
+    ///
+    /// ```compile_fail
+    /// use shiguredo_http3::GoawayPayload;
+    /// const _BAD: GoawayPayload = GoawayPayload::from_static(1u64 << 62);
+    /// ```
     pub const fn from_static(id: u64) -> Self {
         Self {
             id: VarInt::from_static(id),

--- a/src/qpack/header.rs
+++ b/src/qpack/header.rs
@@ -464,6 +464,34 @@ impl Header {
     ///
     /// `name` / `value` が RFC 9114 / RFC 9110 の構文に違反する場合、
     /// const 評価時にコンパイルエラー、実行時には panic する。
+    ///
+    /// 大文字を含む field name はコンパイル時に弾かれる:
+    ///
+    /// ```compile_fail
+    /// use shiguredo_http3::Header;
+    /// const _BAD: Header = Header::from_static(b"Host", b"example.com");
+    /// ```
+    ///
+    /// CRLF を含む field value はコンパイル時に弾かれる:
+    ///
+    /// ```compile_fail
+    /// use shiguredo_http3::Header;
+    /// const _BAD: Header = Header::from_static(b":path", b"/foo\r\nX-Inject: 1");
+    /// ```
+    ///
+    /// 空 field name はコンパイル時に弾かれる:
+    ///
+    /// ```compile_fail
+    /// use shiguredo_http3::Header;
+    /// const _BAD: Header = Header::from_static(b"", b"value");
+    /// ```
+    ///
+    /// 不明な疑似ヘッダーはコンパイル時に弾かれる:
+    ///
+    /// ```compile_fail
+    /// use shiguredo_http3::Header;
+    /// const _BAD: Header = Header::from_static(b":bogus", b"value");
+    /// ```
     #[track_caller]
     pub const fn from_static(name: &'static [u8], value: &'static [u8]) -> Self {
         match check_header(name, value) {

--- a/src/varint.rs
+++ b/src/varint.rs
@@ -71,6 +71,13 @@ impl VarInt {
     ///
     /// `#[track_caller]` はランタイム panic 時の呼び出し位置を保持するために
     /// 付けている (const 評価時の panic 表示には影響しない)。
+    ///
+    /// VarInt 値域外 (`>= 2^62`) のリテラルはコンパイル時に弾かれる:
+    ///
+    /// ```compile_fail
+    /// use shiguredo_http3::VarInt;
+    /// const _BAD: VarInt = VarInt::from_static(1u64 << 62);
+    /// ```
     #[track_caller]
     pub const fn from_static(value: u64) -> Self {
         assert!(value <= Self::MAX.get(), "VarInt value must be <= 2^62 - 1");
@@ -111,12 +118,24 @@ impl VarInt {
     /// 現状の利用は [`decode`] のみで、wire の最上位 2 ビットがエンコード長を示す
     /// 構造により mask 後の値が必ず `2^62 - 1` 以下となることを利用している
     /// (RFC 9000 Section 16 Table 4)。
-    pub(crate) const fn from_validated_parts(value: u64) -> Self {
+    pub(crate) const fn from_validated_parts_internal(value: u64) -> Self {
         debug_assert!(
             value <= Self::MAX.get(),
             "VarInt invariant violated: value exceeds 2^62 - 1"
         );
         Self(value)
+    }
+
+    /// 検証済みの `u64` から検査をスキップして構築する (`internal-test` 限定公開)
+    ///
+    /// 外部クレートからは `internal-test` フィーチャーを有効化したときだけ呼べる。
+    /// PBT / fuzz / 統合テストから wire 由来の不正値ではなく構築済み値を
+    /// `VarInt` 型に注入するためのバックドア。通常のアプリケーションコードは
+    /// 絶対に使ってはいけない。
+    #[cfg(any(test, feature = "internal-test"))]
+    #[doc(hidden)]
+    pub const fn from_validated_parts(value: u64) -> Self {
+        Self::from_validated_parts_internal(value)
     }
 }
 
@@ -261,7 +280,7 @@ pub fn decode(buf: &[u8]) -> Result<(VarInt, usize), DecodeError> {
 
     // wire 表現の最上位 2 ビットがエンコード長を示すため、組み立て後の値は
     // 必ず 2^62 - 1 以下になる (RFC 9000 Section 16 Table 4)。
-    Ok((VarInt::from_validated_parts(value), len))
+    Ok((VarInt::from_validated_parts_internal(value), len))
 }
 
 /// バッファの先頭バイトから可変長整数のバイト長を取得する


### PR DESCRIPTION
## 概要

issue 0088 の実装。`*::from_static` (`VarInt` / `qpack::Header` / `frame::GoawayPayload`) に `compile_fail` doctest を追加し、`const fn` 検査のリグレッションを CI で防止する。PBT で `from_static ↔ new` 一貫性、`from_validated_parts ↔ new` 整合性、`Header::new ↔ QPACK ラウンドトリップ`完全性を検証する。

外部 crate (trybuild) は採用せず、`compile_fail` doctest + PBT 整合性で代替。

## 変更内容

- **compile_fail doctest 6 件**: VarInt 値域外 / Header 4 経路 (大文字・CRLF・空・不明な疑似ヘッダー) / GoawayPayload 値域外
- **`pbt::strategies` 集約**: `valid_varint` / `invalid_varint_u64` / `valid_header_name` / `valid_header_value` を `pbt/src/lib.rs` に集約し `prop_varint.rs` / `prop_qpack.rs` から `use`
- **PBT 追加**: `prop_from_static_matches_new` / `prop_from_validated_parts_matches_new` / `prop_invalid_varint_rejected` (VarInt), `prop_goaway_from_static_matches_new` (Frame), `prop_header_from_static_matches_new` / `prop_header_from_validated_parts_matches_new` / `prop_header_new_accepts_imply_qpack_roundtrip` (QPACK)
- **VarInt 命名統一**: `from_validated_parts_internal` (`pub(crate)`) + cfg-gated pub `from_validated_parts` で Header と同じパターンに
- **Makefile**: `doc-test` ターゲット追加 (`cargo test --doc --workspace --exclude nghttp3-sys --exclude ngtcp2-sys --features shiguredo_http3/internal-test`)
- **`pbt/Cargo.toml`**: `proptest` / `shiguredo_http3` を `[dev-dependencies]` から `[dependencies]` に格上げ

## 完了条件

- [x] 全 `const fn from_static` API について少なくとも 1 件以上の `compile_fail` doctest が存在する
- [x] `cargo test --doc` で全 `compile_fail` ブロックが期待通り fail (= テストとして成功) する
- [x] `pbt/src/lib.rs` に各構築時検査型の `valid_*` / `invalid_*` 戦略が定義されている
- [x] 「`new` と decoder が同じ入力集合を受理する」プロパティが Header で実装されている (VarInt / GoawayPayload は既存 round-trip でカバー)
- [x] ラウンドトリップ PBT が各構築時検査型で存在する (既存)
- [x] `from_static` と `new` の一貫性プロパティが実装されている
- [x] `from_validated_parts` と `new` の整合性プロパティが実装されている
- [x] `Makefile` に `doc-test` ターゲットが追加されている
- [x] 既存の全テスト・PBT・fuzz が通る
- [x] 外部 crate (trybuild 等) を追加していない

## 関連 issue

- issues/closed/0088-add-compile-fail-doctest-and-pbt-construct-time-validation.md