### PR TITLE
0090 Connection::peer_goaway_request_boundary を Option<VarInt> 化する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
 
 ## develop
 
+- [CHANGE] `Connection::peer_goaway_request_boundary` の戻り値型を `Option<u64>` から `Option<VarInt>` に変更し、GOAWAY ID の値域を型で保証する
+  - @voluntas
 - [CHANGE] `FrameDecodeError::Http2Frame` / `FrameDecodeError::ServerPushNotSupported` のフィールド型を `u64` から `VarInt` に変更し、HTTP/3 frame type の値域 (RFC 9000 Section 16) を型で保証する
   - @voluntas
 - [ADD] `VarInt::from_static` / `qpack::Header::from_static` / `frame::GoawayPayload::from_static` の doc に `compile_fail` ブロックを追加し、`const fn` 検査のリグレッションを CI (`cargo test --doc`) で防止する

--- a/issues/closed/0090-change-peer-goaway-boundary-varint.md
+++ b/issues/closed/0090-change-peer-goaway-boundary-varint.md
@@ -1,7 +1,9 @@
 # 0090: Connection::peer_goaway_request_boundary を Option<VarInt> 化する
 
 Created: 2026-05-24
+Completed: 2026-05-24
 Model: Opus 4.7
+Branch: feature/change-peer-goaway-boundary-varint
 
 ## 概要
 
@@ -120,3 +122,14 @@ stream_id 側が `u64` で持っているなら境界値を `.get()` で降ろ�
 ## 関連
 
 - [[0087-change-frame-construct-time-validation]] の 2 周目レビュー指摘 I2 由来
+
+## 解決方法
+
+`src/connection/mod.rs` の `peer_goaway_request_boundary` シグネチャを
+`Option<u64>` → `Option<VarInt>` に変更。内部実装は `self.peer_goaway_last_id`
+(既に `Option<VarInt>`) をそのまま返す形に簡略化 (`.map(|v| v.get())` を削除)。
+
+呼び出し元 (`src/connection/mod.rs:3432`) は `goaway_id.get()` で `u64` に降ろして
+`next_stream_id` (`u64`) と比較する形に修正。
+
+変更は `connection/mod.rs` に閉じる小規模な変更。review-diff-code はスキップし CI に委ねた。

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -734,9 +734,9 @@ impl Connection {
     /// push ID を運ぶものであり、request stream や WebTransport セッションの
     /// 新規拒否判定には使えない。
     /// (RFC 9114 Section 5.2 / 7.2.6, draft-ietf-webtrans-http3-15 Section 4.7)
-    fn peer_goaway_request_boundary(&self) -> Option<u64> {
+    fn peer_goaway_request_boundary(&self) -> Option<VarInt> {
         if self.role == Role::Client {
-            self.peer_goaway_last_id.map(|v| v.get())
+            self.peer_goaway_last_id
         } else {
             None
         }
@@ -3429,7 +3429,7 @@ impl Connection {
         // サーバーが受信する GOAWAY は push ID を運ぶものであり、request stream
         // 境界値としては使えない (RFC 9114 Section 7.2.6)
         if let Some(goaway_id) = self.peer_goaway_request_boundary()
-            && self.next_stream_id >= goaway_id
+            && self.next_stream_id >= goaway_id.get()
         {
             return Err(Error::ConnectionError(ErrorCode::RequestRejected));
         }


### PR DESCRIPTION
## 概要

issue 0090 の実装。`Connection::peer_goaway_request_boundary` の戻り値型を `Option<u64>` から `Option<VarInt>` に変更する。

## 変更内容

- `src/connection/mod.rs`: シグネチャ変更、内部実装を `peer_goaway_last_id` (`Option<VarInt>`) の直接返却に簡略化、呼び出し元の比較を `goaway_id.get()` 経由に修正

## 完了条件

- [x] `peer_goaway_request_boundary` の戻り値が `Option<VarInt>`
- [x] 呼び出し元の比較ロジックが追従し既存挙動を保つ
- [x] 既存テスト・PBT・fuzz が通る
- [x] `make fmt && make clippy && cargo test --tests` が通る

## 関連 issue

- issues/closed/0090-change-peer-goaway-boundary-varint.md
- [[0087-change-frame-construct-time-validation]] の 2 周目レビュー指摘 I2 由来