### PR TITLE
0061 エンコーダーストリームでバッファ消費後にテーブル操作していた処理順序を修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -154,6 +154,8 @@
   `ServerConnection::send_goaway` の引数型を `u64` から `VarInt` に変更し、
   ローカル API 利用時の値域違反を型レベルで排除する
   - @voluntas
+- [FIX] QPACK エンコーダーストリームレシーバーでテーブル操作前にバッファを drain していた処理順序を修正する
+  - @voluntas
 
 ### misc
 

--- a/issues/closed/0061-bug-fix-encoder-stream-drain-order.md
+++ b/issues/closed/0061-bug-fix-encoder-stream-drain-order.md
@@ -2,6 +2,7 @@
 
 - Priority: Medium
 - Created: 2026-05-14
+- Completed: 2026-05-26
 - Model: deepseek-v4-pro
 - Branch: feature/fix-encoder-stream-drain-order
 
@@ -183,9 +184,25 @@ Fuzzing: 不要（意図的エラーパスは単体テストでカバー）。
 - RFC 9204 Section 3.2.2 (Dynamic Table Capacity and Eviction): 容量超過エントリの追加は QPACK_ENCODER_STREAM_ERROR で接続エラーとする MUST 規定
 - RFC 9204 Section 6 (Error Handling): QPACK_ENCODER_STREAM_ERROR (0x0201) の定義
 
+## 解決方法
+
+`src/qpack/encoder_stream.rs` の 3 メソッドで `self.recv_buffer.drain(..consumed)` をテーブル操作・テーブル参照の後に移動した:
+
+- `decode_insert_with_name_ref`: 静的/動的テーブル参照と insert の後に drain
+- `decode_insert_with_literal_name`: insert の後に drain
+- `decode_duplicate`: duplicate の後に drain
+
+`tests/test_qpack_encoder_stream.rs` を新規作成し、以下の 5 エラーパスについて「正しいエラーが返ること」および「バッファが drain されていないこと」を検証する単体テストを追加した:
+
+1. 静的テーブル不正インデックス (InvalidIndex)
+2. 動的テーブル不正相対インデックス (InvalidIndex)
+3. 名前参照挿入の容量超過 (DecodeFailed)
+4. リテラル名挿入の容量超過 (DecodeFailed)
+5. 複製の不正相対インデックス (InvalidIndex)
+
 ## CHANGES.md エントリ案
 
 ```
 - [FIX] QPACK エンコーダーストリームレシーバーでテーブル操作前にバッファを drain していた処理順序を修正する
-  - @担当者
+  - @voluntas
 ```

--- a/src/qpack/encoder_stream.rs
+++ b/src/qpack/encoder_stream.rs
@@ -273,9 +273,7 @@ impl EncoderStreamReceiver {
         let (value, value_len) = decode_string(&self.recv_buffer[consumed..])?;
         consumed += value_len;
 
-        self.recv_buffer.drain(..consumed);
-
-        // 動的テーブルに挿入
+        // テーブル参照・テーブル操作を先に行い、成功後に drain
         let name = if is_static {
             STATIC_TABLE
                 .get(name_index as usize)
@@ -293,6 +291,8 @@ impl EncoderStreamReceiver {
         table
             .insert(name, value.clone())
             .ok_or(QpackError::DecodeFailed)?;
+
+        self.recv_buffer.drain(..consumed);
 
         Ok(Some(EncoderInstruction::InsertWithNameReference {
             is_static,
@@ -313,12 +313,12 @@ impl EncoderStreamReceiver {
         let (value, value_len) = decode_string(&self.recv_buffer[consumed..])?;
         consumed += value_len;
 
-        self.recv_buffer.drain(..consumed);
-
-        // 動的テーブルに挿入
+        // テーブル操作を先に行い、成功後に drain
         table
             .insert(name.clone(), value.clone())
             .ok_or(QpackError::DecodeFailed)?;
+
+        self.recv_buffer.drain(..consumed);
 
         Ok(Some(EncoderInstruction::InsertWithLiteralName {
             name,
@@ -333,12 +333,12 @@ impl EncoderStreamReceiver {
     ) -> Result<Option<EncoderInstruction>, QpackError> {
         let (relative_index, consumed) = decode_integer(&self.recv_buffer, 5)?;
 
-        self.recv_buffer.drain(..consumed);
-
-        // 動的テーブルで複製
+        // テーブル操作を先に行い、成功後に drain
         table
             .duplicate(relative_index)
             .ok_or(QpackError::InvalidIndex(relative_index))?;
+
+        self.recv_buffer.drain(..consumed);
 
         Ok(Some(EncoderInstruction::Duplicate { relative_index }))
     }

--- a/tests/test_qpack_encoder_stream.rs
+++ b/tests/test_qpack_encoder_stream.rs
@@ -1,0 +1,134 @@
+use shiguredo_http3::QpackError;
+use shiguredo_http3::qpack::{DynamicTable, EncoderStreamReceiver};
+
+#[test]
+fn insert_with_name_ref_static_invalid_index_does_not_drain() {
+    // 静的テーブルに存在しないインデックス 99 で Insert with Name Reference を送信する
+    // QPACK 静的テーブルは 0-98 の 99 エントリのみ
+    let mut receiver = EncoderStreamReceiver::new();
+    receiver.set_max_table_capacity(4096);
+    let mut table = DynamicTable::with_capacity(4096);
+
+    // 名前参照による挿入 (static=1, name_index=99, value=空)
+    // 6-bit prefix: 99 >= 63 → 0xFF, 0x24 (99-63=36)
+    // 値文字列 (7-bit prefix): 長さ=0 → 0x00
+    let data: &[u8] = &[0xFF, 0x24, 0x00];
+    receiver.receive(data);
+
+    let result = receiver.process(&mut table);
+    assert_eq!(
+        result,
+        Err(QpackError::InvalidIndex(99)),
+        "不正な静的テーブルインデックスでエラーが返ること"
+    );
+    assert_eq!(
+        receiver.buffer(),
+        data,
+        "エラー時にバッファが drain されていないこと"
+    );
+}
+
+#[test]
+fn insert_with_name_ref_dynamic_invalid_index_does_not_drain() {
+    // 空の動的テーブルに対して relative_index=5 で Insert with Name Reference を送信する
+    let mut receiver = EncoderStreamReceiver::new();
+    receiver.set_max_table_capacity(4096);
+    let mut table = DynamicTable::with_capacity(4096);
+
+    // 名前参照による挿入 (static=0, name_index=5, value=空)
+    // 6-bit prefix: 5 < 63 → 0x80 | 5 = 0x85
+    // 値文字列 (7-bit prefix): 長さ=0 → 0x00
+    let data: &[u8] = &[0x85, 0x00];
+    receiver.receive(data);
+
+    let result = receiver.process(&mut table);
+    assert_eq!(
+        result,
+        Err(QpackError::InvalidIndex(5)),
+        "不正な動的テーブル相対インデックスでエラーが返ること"
+    );
+    assert_eq!(
+        receiver.buffer(),
+        data,
+        "エラー時にバッファが drain されていないこと"
+    );
+}
+
+#[test]
+fn insert_with_name_ref_capacity_overflow_does_not_drain() {
+    // 容量不足で insert が失敗するケース
+    // 静的テーブル index 0 (:authority) のエントリサイズ = 10 + 0 + 32 = 42 > 32
+    let mut receiver = EncoderStreamReceiver::new();
+    receiver.set_max_table_capacity(32);
+    let mut table = DynamicTable::with_capacity(32);
+
+    // 名前参照による挿入 (static=1, name_index=0, value=空)
+    // 6-bit prefix: 0 < 63 → 0xC0 | 0 = 0xC0
+    // 値文字列 (7-bit prefix): 長さ=0 → 0x00
+    let data: &[u8] = &[0xC0, 0x00];
+    receiver.receive(data);
+
+    let result = receiver.process(&mut table);
+    assert_eq!(
+        result,
+        Err(QpackError::DecodeFailed),
+        "容量超過で挿入が失敗しエラーが返ること"
+    );
+    assert_eq!(
+        receiver.buffer(),
+        data,
+        "エラー時にバッファが drain されていないこと"
+    );
+}
+
+#[test]
+fn insert_with_literal_name_capacity_overflow_does_not_drain() {
+    // 容量不足で insert が失敗するケース
+    // エントリサイズ = 1 (name "a") + 0 (empty value) + 32 = 33 > 32
+    let mut receiver = EncoderStreamReceiver::new();
+    receiver.set_max_table_capacity(32);
+    let mut table = DynamicTable::with_capacity(32);
+
+    // リテラル名による挿入 (01 prefix, H=0, name 長さ=1)
+    // 5-bit prefix: 1 < 31 → 0x40 | 1 = 0x41
+    // name バイト列: 0x61 ('a')
+    // 値文字列 (7-bit prefix): 長さ=0 → 0x00
+    let data: &[u8] = &[0x41, 0x61, 0x00];
+    receiver.receive(data);
+
+    let result = receiver.process(&mut table);
+    assert_eq!(
+        result,
+        Err(QpackError::DecodeFailed),
+        "容量超過で挿入が失敗しエラーが返ること"
+    );
+    assert_eq!(
+        receiver.buffer(),
+        data,
+        "エラー時にバッファが drain されていないこと"
+    );
+}
+
+#[test]
+fn duplicate_invalid_index_does_not_drain() {
+    // 空の動的テーブルに対して relative_index=5 で Duplicate を送信する
+    let mut receiver = EncoderStreamReceiver::new();
+    receiver.set_max_table_capacity(4096);
+    let mut table = DynamicTable::with_capacity(4096);
+
+    // 複製命令 (000 prefix, 5-bit prefix: 5 < 31 → 0x00 | 5 = 0x05)
+    let data: &[u8] = &[0x05];
+    receiver.receive(data);
+
+    let result = receiver.process(&mut table);
+    assert_eq!(
+        result,
+        Err(QpackError::InvalidIndex(5)),
+        "不正な相対インデックスでエラーが返ること"
+    );
+    assert_eq!(
+        receiver.buffer(),
+        data,
+        "エラー時にバッファが drain されていないこと"
+    );
+}


### PR DESCRIPTION
## 概要

QPACK エンコーダーストリームレシーバーの 3 メソッドで、テーブル操作前にバッファを drain していた処理順序を修正する。

## 変更内容

- `decode_insert_with_name_ref` / `decode_insert_with_literal_name` / `decode_duplicate` の `self.recv_buffer.drain(..consumed)` をテーブル操作・テーブル参照の後に移動
- `tests/test_qpack_encoder_stream.rs` を新規作成し、5 エラーパスの単体テストを追加

## 完了条件

- [x] 3 メソッドの drain が全テーブル操作・テーブル参照の後に移動していること
- [x] 上記 5 エラーパスの単体テストが全て pass すること
- [x] 既存テスト (cargo test) が全て pass すること
- [x] CHANGES.md にエントリが追記されていること

## 関連 issue

- issues/closed/0061-bug-fix-encoder-stream-drain-order.md