### PR TITLE
0063 send_request が GOAWAY 境界超過 / WT セッション上限超過時に接続全体を閉じていた問題を修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -156,6 +156,8 @@
   - @voluntas
 - [FIX] QPACK エンコーダーストリームレシーバーでテーブル操作前にバッファを drain していた処理順序を修正する
   - @voluntas
+- [FIX] send_request で GOAWAY 境界超過およびフロー制御なし WT セッション上限超過時に ConnectionError ではなく StreamError を返すよう修正する
+  - @voluntas
 
 ### misc
 

--- a/issues/closed/0063-bug-fix-send-request-connection-error.md
+++ b/issues/closed/0063-bug-fix-send-request-connection-error.md
@@ -2,6 +2,7 @@
 
 - Priority: High
 - Created: 2026-05-14
+- Completed: 2026-05-26
 - Model: deepseek-v4-pro
 - Branch: feature/fix-send-request-error-level
 
@@ -83,9 +84,20 @@ return Err(Error::StreamError(ErrorCode::RequestRejected));
 - RFC 9114 Section 5.2: GOAWAY 受信後の新規リクエスト禁止規定。境界超過リクエストは処理されないが接続自体は維持される
 - draft-ietf-webtrans-http3-15 Section 5.1: フロー制御無効時の同時セッション制限。サーバーは過剰ストリームを `H3_REQUEST_REJECTED` で個別にリセットしなければならない (MUST)
 
+## 解決方法
+
+`src/connection/mod.rs` の `send_request` 関数内の 2 箇所で `Error::ConnectionError(ErrorCode::RequestRejected)` を `Error::StreamError(ErrorCode::RequestRejected)` に変更した:
+
+1. フロー制御なし WT セッション上限超過時 (line 3422)
+2. GOAWAY 境界超過時 (line 3434)
+
+テスト変更:
+- `tests/test_webtransport_draft_connect.rs`: 既存テストの期待値を `ConnectionError` から `StreamError` に修正
+- `tests/test_connection.rs`: 新規作成。GOAWAY 受信後の send_request 拒否、境界値テスト、接続維持確認の 3 テストを追加
+
 ## CHANGES.md エントリ案
 
 ```
 - [FIX] send_request で GOAWAY 境界超過およびフロー制御なし WT セッション上限超過時に ConnectionError ではなく StreamError を返すよう修正する
-  - @担当者
+  - @voluntas
 ```

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -3419,7 +3419,7 @@ impl Connection {
             // (draft-ietf-webtrans-http3-15 Section 5.1)
             // 将来のドラフトで定義が変更される可能性がある。
             if !self.is_wt_flow_control_enabled() && self.count_active_wt_sessions() >= 1 {
-                return Err(Error::ConnectionError(ErrorCode::RequestRejected));
+                return Err(Error::StreamError(ErrorCode::RequestRejected));
             }
         }
 
@@ -3431,7 +3431,7 @@ impl Connection {
         if let Some(goaway_id) = self.peer_goaway_request_boundary()
             && self.next_stream_id >= goaway_id.get()
         {
-            return Err(Error::ConnectionError(ErrorCode::RequestRejected));
+            return Err(Error::StreamError(ErrorCode::RequestRejected));
         }
 
         let stream_id = self.next_stream_id;

--- a/tests/test_connection.rs
+++ b/tests/test_connection.rs
@@ -1,0 +1,121 @@
+use shiguredo_http3::{
+    ClientConnection, Error, ErrorCode, Event, Header, ServerConnection, Settings, VarInt,
+};
+
+/// GOAWAY テスト用のクライアント・サーバーペアを構築する
+fn setup_pair() -> (ClientConnection, ServerConnection) {
+    let mut client = ClientConnection::new(Settings::default());
+    client.set_control_stream_id(2).unwrap();
+    let mut server = ServerConnection::new(Settings::default());
+    server.set_control_stream_id(3).unwrap();
+
+    // サーバー制御ストリームデータ（ストリームタイプ + SETTINGS）をクライアントに feed
+    let (server_ctrl, _) = server.take_stream_data(3).unwrap();
+    client.feed_stream(3, &server_ctrl, false).unwrap();
+
+    // SETTINGS イベントを消費
+    while let Some(_ev) = client.poll_event().unwrap() {}
+
+    (client, server)
+}
+
+fn request_headers() -> Vec<Header> {
+    vec![
+        Header::new(b":method", b"GET").unwrap(),
+        Header::new(b":path", b"/").unwrap(),
+        Header::new(b":scheme", b"https").unwrap(),
+        Header::new(b":authority", b"example.com").unwrap(),
+    ]
+}
+
+#[test]
+fn send_request_after_goaway_returns_stream_error() {
+    // GOAWAY 受信後の send_request が StreamError(RequestRejected) を返すことを検証する
+    let (mut client, mut server) = setup_pair();
+    let headers = request_headers();
+
+    // 1 本目のリクエスト送信 (stream_id=0, next_stream_id は 4 になる)
+    let stream_id = client.send_request(&headers, true).unwrap();
+    assert_eq!(stream_id, 0);
+
+    // サーバーが GOAWAY(4) を送信: stream_id >= 4 は受け付けない
+    server.send_goaway(VarInt::new(4).unwrap()).unwrap();
+    let (goaway_data, _) = server.take_stream_data(3).unwrap();
+    client.feed_stream(3, &goaway_data, false).unwrap();
+
+    // GoawayReceived イベントを消費
+    let event = client.poll_event().unwrap();
+    assert!(
+        matches!(event, Some(Event::GoawayReceived { .. })),
+        "GoawayReceived イベントが発生すること"
+    );
+
+    // 2 本目のリクエスト送信: StreamError(RequestRejected) で拒否される
+    let err = client.send_request(&headers, true).unwrap_err();
+    assert!(
+        matches!(err, Error::StreamError(ErrorCode::RequestRejected)),
+        "GOAWAY 境界超過時は StreamError(RequestRejected) であること: {err:?}"
+    );
+}
+
+#[test]
+fn send_request_below_goaway_boundary_succeeds() {
+    // GOAWAY 境界値未満のストリーム ID では正常に送信できることを検証する
+    let (mut client, mut server) = setup_pair();
+    let headers = request_headers();
+
+    // サーバーが GOAWAY(8) を送信: stream_id >= 8 は受け付けない
+    server.send_goaway(VarInt::new(8).unwrap()).unwrap();
+    let (goaway_data, _) = server.take_stream_data(3).unwrap();
+    client.feed_stream(3, &goaway_data, false).unwrap();
+
+    // GoawayReceived イベントを消費
+    while let Some(_ev) = client.poll_event().unwrap() {}
+
+    // stream_id=0 (next=4): 4 < 8 なので送信できる
+    let stream_id = client.send_request(&headers, true).unwrap();
+    assert_eq!(stream_id, 0, "境界値未満のリクエストは送信できること");
+
+    // stream_id=4 (next=8): 8 >= 8 なので次は拒否される
+    let stream_id2 = client.send_request(&headers, true).unwrap();
+    assert_eq!(stream_id2, 4, "境界値直前のリクエストも送信できること");
+
+    // stream_id=8 (next=12): 8 >= 8 で拒否
+    let err = client.send_request(&headers, true).unwrap_err();
+    assert!(
+        matches!(err, Error::StreamError(ErrorCode::RequestRejected)),
+        "境界値以上のリクエストは拒否されること: {err:?}"
+    );
+}
+
+#[test]
+fn connection_maintained_after_stream_error() {
+    // StreamError 返却後も接続が維持され、既存ストリームの操作が可能であることを検証する
+    let (mut client, mut server) = setup_pair();
+    let headers = request_headers();
+
+    // 1 本目のリクエスト送信 (fin=false でストリームを開いたまま)
+    let stream_id = client.send_request(&headers, false).unwrap();
+    assert_eq!(stream_id, 0);
+
+    // サーバーが GOAWAY(4) を送信
+    server.send_goaway(VarInt::new(4).unwrap()).unwrap();
+    let (goaway_data, _) = server.take_stream_data(3).unwrap();
+    client.feed_stream(3, &goaway_data, false).unwrap();
+    while let Some(_ev) = client.poll_event().unwrap() {}
+
+    // 新規リクエストは拒否される
+    let err = client.send_request(&headers, true).unwrap_err();
+    assert!(matches!(
+        err,
+        Error::StreamError(ErrorCode::RequestRejected)
+    ));
+
+    // 既存ストリーム (stream_id=0) のデータ取得は引き続き可能
+    // (send_request 時に HEADERS フレームが生成されているので take_stream_data で取得できる)
+    let data = client.take_stream_data(stream_id);
+    assert!(
+        data.is_some(),
+        "StreamError 後も既存ストリームのデータ取得が可能であること"
+    );
+}

--- a/tests/test_webtransport_draft_connect.rs
+++ b/tests/test_webtransport_draft_connect.rs
@@ -681,11 +681,11 @@ mod no_flow_control_single_session {
             .send_request(&headers, false)
             .expect("1 本目の WT CONNECT は送信できるべき");
 
-        // 2 本目: RequestRejected で拒否される
+        // 2 本目: RequestRejected で拒否される (接続は維持)
         let err = client.send_request(&headers, false).unwrap_err();
         assert!(
-            matches!(err, Error::ConnectionError(ErrorCode::RequestRejected)),
-            "FC 無効時の 2 本目は RequestRejected で拒否されるべき: {err:?}"
+            matches!(err, Error::StreamError(ErrorCode::RequestRejected)),
+            "FC 無効時の 2 本目は StreamError(RequestRejected) で拒否されるべき: {err:?}"
         );
     }
 }


### PR DESCRIPTION
## 概要

send_request で GOAWAY 境界超過およびフロー制御なし WT セッション上限超過時に ConnectionError ではなく StreamError を返すよう修正し、接続全体が不必要に閉じられることを防ぐ。

## 変更内容

- `src/connection/mod.rs`: send_request 内の 2 箇所で `ConnectionError(RequestRejected)` を `StreamError(RequestRejected)` に変更
- `tests/test_webtransport_draft_connect.rs`: 既存テストの期待値を StreamError に修正
- `tests/test_connection.rs`: GOAWAY 境界超過テスト 3 件を新規追加

## 完了条件

- [x] 2 箇所の ConnectionError(RequestRejected) が StreamError(RequestRejected) に変更されていること
- [x] 既存テストの期待値修正が完了し全テスト pass すること
- [x] GOAWAY 境界超過の単体テストが追加され pass すること
- [x] 既存テスト (cargo test) が全て pass すること
- [x] CHANGES.md にエントリが追記されていること

## 関連 issue

- issues/closed/0063-bug-fix-send-request-connection-error.md