### PR TITLE
0065 interop/h3 と interop/wt の workspace 継承漏れを修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -177,6 +177,8 @@
   - @voluntas
 - [UPDATE] fuzz ターゲットからラウンドトリップ等のプロパティ検証を削除し、パニック安全性の検証だけに絞る
   - @voluntas
+- [UPDATE] interop/h3 と interop/wt の edition / rust-version を workspace 継承に変更する
+  - @voluntas
 - [ADD] `refs/` に RFC 7541, RFC 9110, RFC 9651 の一次資料を追加する
   - @voluntas
 - [ADD] ngtcp2/nghttp3 と s2n-quic の WebTransport 相互運用テストを平日 JST 11:00 に実行する GitHub Actions ワークフローを追加する

--- a/interop/h3/Cargo.toml
+++ b/interop/h3/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "interop_h3"
 version = "0.0.0"
-edition = "2024"
-rust-version = "1.88"
+edition.workspace = true
+rust-version.workspace = true
 publish = false
 
 [dependencies]

--- a/interop/wt/Cargo.toml
+++ b/interop/wt/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "interop_wt"
 version = "0.0.0"
-edition = "2024"
-rust-version = "1.88"
+edition.workspace = true
+rust-version.workspace = true
 publish = false
 
 [lib]

--- a/issues/closed/0065-bug-fix-interop-workspace-inheritance.md
+++ b/issues/closed/0065-bug-fix-interop-workspace-inheritance.md
@@ -2,6 +2,7 @@
 
 - Priority: Low
 - Created: 2026-05-14
+- Completed: 2026-05-26
 - Model: deepseek-v4-pro
 - Branch: feature/fix-interop-workspace-inheritance
 
@@ -44,13 +45,15 @@ rust-version.workspace = true
 - `interop/h3/Cargo.toml`
 - `interop/wt/Cargo.toml`
 
-## CHANGES.md エントリ案
+## 解決方法
 
-既存エントリ「edition と rust-version を `[workspace.package]` で共通化...」の対象漏れの修正であり、新規エントリは不要（misc セクションに記載する場合のみ以下）:
+`interop/h3/Cargo.toml` と `interop/wt/Cargo.toml` の `edition = "2024"` / `rust-version = "1.88"` を `edition.workspace = true` / `rust-version.workspace = true` に変更した。
+
+## CHANGES.md エントリ案
 
 ```
 ### misc
 
 - [UPDATE] interop/h3 と interop/wt の edition / rust-version を workspace 継承に変更する
-  - @担当者
+  - @voluntas
 ```


### PR DESCRIPTION
## 概要

interop/h3 と interop/wt が workspace 継承を使用せず edition / rust-version を直書きしていた問題を修正する。

## 変更内容

- `interop/h3/Cargo.toml`: `edition.workspace = true` / `rust-version.workspace = true` に変更
- `interop/wt/Cargo.toml`: 同上

## 完了条件

- [x] interop/h3/Cargo.toml と interop/wt/Cargo.toml が workspace 継承を使用していること
- [x] cargo check --workspace が pass すること
- [x] cargo test --workspace が pass すること

## 関連 issue

- issues/closed/0065-bug-fix-interop-workspace-inheritance.md