### PR TITLE
0066 feed_stream がエラー状態で本来のエラーではなく InternalError を返していた問題を修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -158,6 +158,8 @@
   - @voluntas
 - [FIX] send_request で GOAWAY 境界超過およびフロー制御なし WT セッション上限超過時に ConnectionError ではなく StreamError を返すよう修正する
   - @voluntas
+- [FIX] feed_stream がエラー状態で本来のエラーではなく InternalError を返していた問題を修正する
+  - @voluntas
 
 ### misc
 

--- a/issues/closed/0066-bug-fix-feed-stream-error-propagation.md
+++ b/issues/closed/0066-bug-fix-feed-stream-error-propagation.md
@@ -2,6 +2,7 @@
 
 - Priority: Medium
 - Created: 2026-05-14
+- Completed: 2026-05-26
 - Model: deepseek-v4-pro
 - Branch: feature/fix-feed-stream-error-propagation
 
@@ -65,9 +66,27 @@ if let Some(ref err) = self.error {
 
 - `src/connection/mod.rs`: `feed_stream` 関数冒頭のエラーチェック（1099行付近）
 
+## 解決方法
+
+`src/connection/mod.rs` の `feed_stream` 関数冒頭のエラー状態チェックを `feed_datagram` と同一パターンに統一した:
+
+```rust
+// 修正前
+if self.error.is_some() {
+    return Err(Error::ConnectionError(ErrorCode::InternalError));
+}
+
+// 修正後
+if let Some(ref err) = self.error {
+    return Err(err.clone());
+}
+```
+
+インラインテスト 2 件を `connection/mod.rs` の `#[cfg(test)]` モジュールに追加し、`ClosedCriticalStream` と `FrameError` の 2 パターンで元のエラーが正しく伝播されることを検証した。
+
 ## CHANGES.md エントリ案
 
 ```
 - [FIX] feed_stream がエラー状態で本来のエラーではなく InternalError を返していた問題を修正する
-  - @担当者
+  - @voluntas
 ```

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -1096,8 +1096,8 @@ impl Connection {
 
     /// QUIC からストリームデータを受信
     pub fn feed_stream(&mut self, stream_id: u64, data: &[u8], fin: bool) -> Result<(), Error> {
-        if self.error.is_some() {
-            return Err(Error::ConnectionError(ErrorCode::InternalError));
+        if let Some(ref err) = self.error {
+            return Err(err.clone());
         }
 
         let kind = StreamKind::from_stream_id(stream_id);
@@ -5766,5 +5766,39 @@ mod tests {
         // send_datagram も拒否される (datagram の前提として Established だが、
         // 念のため Draining で WtSessionDraining を返す経路を確認する)
         // ※ Pending → Draining でも内部状態として Draining になることを確認する
+    }
+
+    #[test]
+    fn test_feed_stream_propagates_original_error() {
+        // エラー状態の接続に対して feed_stream を呼んだ場合、
+        // InternalError ではなく元のエラーが返ることを検証する
+        let mut conn = Connection::client(Settings::default());
+        conn.set_control_stream_id(2).unwrap();
+
+        // 接続エラー状態を直接設定する
+        conn.error = Some(Error::ConnectionError(ErrorCode::ClosedCriticalStream));
+
+        let err = conn.feed_stream(0, &[0x01], false).unwrap_err();
+        assert_eq!(
+            err,
+            Error::ConnectionError(ErrorCode::ClosedCriticalStream),
+            "feed_stream は InternalError ではなく元のエラーを返すこと"
+        );
+    }
+
+    #[test]
+    fn test_feed_stream_propagates_frame_error() {
+        // 別のエラー種別でも正しく伝播されることを検証する
+        let mut conn = Connection::client(Settings::default());
+        conn.set_control_stream_id(2).unwrap();
+
+        conn.error = Some(Error::ConnectionError(ErrorCode::FrameError));
+
+        let err = conn.feed_stream(4, &[0x01, 0x00], false).unwrap_err();
+        assert_eq!(
+            err,
+            Error::ConnectionError(ErrorCode::FrameError),
+            "feed_stream は元の FrameError を返すこと"
+        );
     }
 }


### PR DESCRIPTION
## 概要

feed_stream がエラー状態で InternalError に差し替えてしまい、本来のエラーが伝播しない問題を修正する。feed_datagram と同一パターンに統一。

## 変更内容

- `src/connection/mod.rs`: feed_stream のエラー状態チェックを `self.error.clone()` パターンに変更
- インラインテスト 2 件追加 (ClosedCriticalStream / FrameError の伝播検証)

## 完了条件

- [x] feed_stream のエラー状態チェックが feed_datagram と同一パターンになっていること
- [x] 単体テストが pass すること
- [x] 既存テスト (cargo test) が全て pass すること
- [x] CHANGES.md にエントリが追記されていること

## 関連 issue

- issues/closed/0066-bug-fix-feed-stream-error-propagation.md