### PR TITLE
0068 send_request / send_response の track_section 順序と WT CONNECT FIN 拒否を修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -160,6 +160,10 @@
   - @voluntas
 - [FIX] feed_stream がエラー状態で本来のエラーではなく InternalError を返していた問題を修正する
   - @voluntas
+- [FIX] send_request / send_response で track_section が send_encoded_headers の前に呼ばれていた問題を修正する
+  - @voluntas
+- [FIX] WebTransport CONNECT リクエストで fin=true が拒否されない問題を修正する
+  - @voluntas
 
 ### misc
 

--- a/issues/closed/0068-bug-fix-track-section-and-wt-connect-fin.md
+++ b/issues/closed/0068-bug-fix-track-section-and-wt-connect-fin.md
@@ -2,6 +2,7 @@
 
 - Priority: High
 - Created: 2026-05-14
+- Completed: 2026-05-26
 - Model: deepseek-v4-pro
 - Branch: feature/fix-track-section-and-wt-connect-fin
 
@@ -107,11 +108,27 @@ if is_connect {
 - RFC 9114 Section 4.4: CONNECT メソッド — ストリームは open のまま維持する必要がある
 - draft-ietf-webtrans-http3-15 Section 3: WebTransport セッションは CONNECT ストリーム上で確立され、双方向の Capsule 通信に使用される
 
+## 解決方法
+
+### 問題 1: track_section の順序修正
+
+`src/connection/mod.rs` の `send_request` と `send_response` で `qpack_encoder.track_section()` を `stream.send_encoded_headers()` の後に移動した。`send_encoded_headers` が失敗した場合に `track_section` へ到達しないため、未送出セクションがエンコーダーに登録されたままになる問題が解消される。
+
+### 問題 2: WebTransport CONNECT の FIN 拒否
+
+`send_request` の FIN チェックの条件を `is_connect && !has_protocol` から `is_connect` に拡張し、`stream.set_connect_request()` は `!has_protocol` の場合のみ実行するようにした。
+
+### テスト
+
+インラインテスト 2 件を追加:
+- `test_wt_connect_rejects_fin`: WebTransport CONNECT で fin=true → `StreamError(MessageError)`
+- `test_wt_connect_without_fin_succeeds`: WebTransport CONNECT で fin=false → 成功
+
 ## CHANGES.md エントリ案
 
 ```
 - [FIX] send_request / send_response で track_section が send_encoded_headers の前に呼ばれていた問題を修正する
-  - @担当者
+  - @voluntas
 - [FIX] WebTransport CONNECT リクエストで fin=true が拒否されない問題を修正する
-  - @担当者
+  - @voluntas
 ```

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -3448,10 +3448,6 @@ impl Connection {
             .ok_or(Error::ConnectionError(ErrorCode::InternalError))?;
         qpack_buf.truncate(qpack_len);
 
-        // フィールドセクションの送信を記録 (RFC 9204 Section 2.1.1, 4.4.1)
-        let ric = self.qpack_encoder.last_required_insert_count();
-        self.qpack_encoder.track_section(stream_id, ric);
-
         let mut stream = RequestStream::new(stream_id);
         // HEAD リクエストの場合は Content-Length 検証でのレスポンス body チェックをスキップする
         if headers
@@ -3466,14 +3462,24 @@ impl Connection {
             .iter()
             .any(|h| h.name() == b":method" && h.value() == b"CONNECT");
         let has_protocol = headers.iter().any(|h| h.name() == b":protocol");
-        if is_connect && !has_protocol {
-            // plain CONNECT ではストリームを open のまま維持する必要がある (RFC 9114 Section 4.4)
+        if is_connect {
+            // CONNECT ストリームは open のまま維持する必要があるため FIN は禁止
+            // (RFC 9114 Section 4.4, draft-ietf-webtrans-http3-15 Section 3)
             if fin {
                 return Err(Error::StreamError(ErrorCode::MessageError));
             }
-            stream.set_connect_request();
+            if !has_protocol {
+                stream.set_connect_request();
+            }
         }
         stream.send_encoded_headers(&qpack_buf, fin, false)?;
+
+        // フィールドセクションの送信を記録 (RFC 9204 Section 2.1.1, 4.4.1)
+        // 送信成功後に行う: send_encoded_headers が失敗した場合に未送出セクションが
+        // エンコーダーに登録されたままになるのを防ぐ
+        let ric = self.qpack_encoder.last_required_insert_count();
+        self.qpack_encoder.track_section(stream_id, ric);
+
         self.streams.insert(stream_id, stream);
 
         // WebTransport CONNECT の場合、セッションを Pending 状態で登録
@@ -3572,10 +3578,6 @@ impl Connection {
             .get_mut(&stream_id)
             .ok_or(Error::StreamNotFound(stream_id))?;
 
-        // フィールドセクションの送信を記録 (RFC 9204 Section 2.1.1, 4.4.1)
-        let ric = self.qpack_encoder.last_required_insert_count();
-        self.qpack_encoder.track_section(stream_id, ric);
-
         // 1xx 中間レスポンスかどうかを判定 (RFC 9114 Section 4.1)
         // HTTP/3 は 101 (Switching Protocols) をサポートしない (RFC 9114 Section 4.5)
         let is_interim = headers.iter().any(|h| {
@@ -3588,6 +3590,12 @@ impl Connection {
         });
 
         stream.send_encoded_headers(&qpack_buf, fin, is_interim)?;
+
+        // フィールドセクションの送信を記録 (RFC 9204 Section 2.1.1, 4.4.1)
+        // 送信成功後に行う: send_encoded_headers が失敗した場合に未送出セクションが
+        // エンコーダーに登録されたままになるのを防ぐ
+        let ric = self.qpack_encoder.last_required_insert_count();
+        self.qpack_encoder.track_section(stream_id, ric);
 
         // サーバー側: WebTransport CONNECT に対する 2xx レスポンス送信時に
         // セッションを Established に遷移させる (draft-ietf-webtrans-http3-15 Section 3)
@@ -5799,6 +5807,46 @@ mod tests {
             err,
             Error::ConnectionError(ErrorCode::FrameError),
             "feed_stream は元の FrameError を返すこと"
+        );
+    }
+
+    #[test]
+    fn test_wt_connect_rejects_fin() {
+        // WebTransport CONNECT で fin=true を指定すると StreamError(MessageError) が返ることを検証
+        let (mut client, _server) = setup_wt_pair();
+
+        let headers = vec![
+            Header::new(b":method", b"CONNECT").unwrap(),
+            Header::new(b":protocol", b"webtransport-h3").unwrap(),
+            Header::new(b":scheme", b"https").unwrap(),
+            Header::new(b":authority", b"example.com").unwrap(),
+            Header::new(b":path", b"/wt").unwrap(),
+        ];
+
+        let err = client.send_request(&headers, true).unwrap_err();
+        assert!(
+            matches!(err, Error::StreamError(ErrorCode::MessageError)),
+            "WebTransport CONNECT で fin=true は StreamError(MessageError) であること: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_wt_connect_without_fin_succeeds() {
+        // WebTransport CONNECT で fin=false なら成功することを検証
+        let (mut client, _server) = setup_wt_pair();
+
+        let headers = vec![
+            Header::new(b":method", b"CONNECT").unwrap(),
+            Header::new(b":protocol", b"webtransport-h3").unwrap(),
+            Header::new(b":scheme", b"https").unwrap(),
+            Header::new(b":authority", b"example.com").unwrap(),
+            Header::new(b":path", b"/wt").unwrap(),
+        ];
+
+        let stream_id = client.send_request(&headers, false).unwrap();
+        assert_eq!(
+            stream_id, 0,
+            "WebTransport CONNECT で fin=false は成功すること"
         );
     }
 }


### PR DESCRIPTION
## 概要

send_request / send_response の track_section 順序の問題と、WebTransport CONNECT で fin=true が拒否されない問題を修正する。

## 変更内容

- `send_request` / `send_response`: `track_section` を `send_encoded_headers` の成功後に移動
- `send_request`: FIN チェックを `is_connect` 全体に拡張し、WT CONNECT でも fin=true を拒否するよう修正
- インラインテスト 2 件追加

## 完了条件

- [x] send_request / send_response の track_section が send_encoded_headers の後に移動
- [x] WebTransport CONNECT で fin=true が拒否される
- [x] テスト全 pass
- [x] 既存テスト全 pass
- [x] CHANGES.md にエントリ追記

## 関連 issue

- issues/closed/0068-bug-fix-track-section-and-wt-connect-fin.md