### PR TITLE
0075 validate_max_data に VarInt 上限チェックを追加し MaxDataExceedsLimit エラーの発生経路を実装する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -164,6 +164,8 @@
   - @voluntas
 - [FIX] WebTransport CONNECT リクエストで fin=true が拒否されない問題を修正する
   - @voluntas
+- [FIX] validate_max_data に VarInt 上限チェックを追加し MaxDataExceedsLimit エラーの発生経路を実装する
+  - @voluntas
 - [FIX] QPACK エンコーダーの ack_section を Result 化し、Post-Base 参照エンコードを実装し、RIC エンコードの max_entries=0 時のエッジケースを修正する
   - @voluntas
 

--- a/issues/closed/0075-bug-fix-max-data-exceeds-limit.md
+++ b/issues/closed/0075-bug-fix-max-data-exceeds-limit.md
@@ -2,6 +2,7 @@
 
 - Priority: Medium
 - Created: 2026-05-14
+- Completed: 2026-05-26
 - Model: deepseek-v4-pro
 - Branch: feature/fix-max-data-exceeds-limit
 
@@ -62,9 +63,19 @@ pub fn validate_max_data(maximum: u64, current_max: u64) -> Result<(), CapsuleVa
 
 - draft-ietf-webtrans-http3-15 Section 5.6: フロー制御の MAX_DATA / MAX_STREAMS — VarInt 値域内であるべき
 
+## 解決方法
+
+`Capsule::validate_max_data` に VarInt 上限チェック (`maximum > VarInt::MAX.get()`) を追加した。
+
+### 変更内容
+
+- `src/webtransport/capsule.rs`: `validate_max_data` に `maximum > crate::VarInt::MAX.get()` のチェックを追加し、超過時に `MaxDataExceedsLimit` を返す
+- `src/webtransport/capsule.rs`: 単体テストに VarInt 上限値の正常テストと上限超過のエラーテストを追加
+- `pbt/tests/prop_capsule.rs`: `prop_validate_max_data_exceeds_limit` PBT を追加
+
 ## CHANGES.md エントリ案
 
 ```
 - [FIX] validate_max_data に VarInt 上限チェックを追加し MaxDataExceedsLimit エラーの発生経路を実装する
-  - @担当者
+  - @voluntas
 ```

--- a/pbt/tests/prop_capsule.rs
+++ b/pbt/tests/prop_capsule.rs
@@ -245,4 +245,18 @@ proptest! {
             "maximum < current_max なのに MaxDataDecreased でない: maximum={}, current_max={}", maximum, current_max
         );
     }
+
+    /// Property: maximum > MAX_VARINT なら MaxDataExceedsLimit
+    #[test]
+    fn prop_validate_max_data_exceeds_limit(
+        excess in 1u64..1000,
+    ) {
+        let maximum = MAX_VARINT + excess;
+        let result = Capsule::validate_max_data(maximum, 0);
+        prop_assert_eq!(
+            result,
+            Err(CapsuleValidationError::MaxDataExceedsLimit),
+            "maximum > MAX_VARINT なのに MaxDataExceedsLimit でない: maximum={}", maximum
+        );
+    }
 }

--- a/src/webtransport/capsule.rs
+++ b/src/webtransport/capsule.rs
@@ -458,8 +458,15 @@ impl Capsule {
 
     /// WT_MAX_DATA の値を検証する
     ///
+    /// - `maximum` が VarInt 上限 (`2^62-1`) を超える場合: `MaxDataExceedsLimit` (H3_DATAGRAM_ERROR)
     /// - `maximum` が `current_max` より小さい場合: `MaxDataDecreased` (WT_FLOW_CONTROL_ERROR)
+    ///
+    /// draft-ietf-webtrans-http3-15 Section 5.6.4
+    /// 将来のドラフトで変更される可能性がある
     pub fn validate_max_data(maximum: u64, current_max: u64) -> Result<(), CapsuleValidationError> {
+        if maximum > crate::VarInt::MAX.get() {
+            return Err(CapsuleValidationError::MaxDataExceedsLimit);
+        }
         if maximum < current_max {
             return Err(CapsuleValidationError::MaxDataDecreased);
         }
@@ -574,10 +581,17 @@ mod tests {
         assert!(Capsule::validate_max_data(100, 50).is_ok());
         // 正常: 同じ値
         assert!(Capsule::validate_max_data(100, 100).is_ok());
+        // 正常: VarInt 上限値
+        assert!(Capsule::validate_max_data(crate::VarInt::MAX.get(), 0).is_ok());
         // エラー: 減少
         assert_eq!(
             Capsule::validate_max_data(50, 100),
             Err(CapsuleValidationError::MaxDataDecreased)
+        );
+        // エラー: VarInt 上限超過
+        assert_eq!(
+            Capsule::validate_max_data(crate::VarInt::MAX.get() + 1, 0),
+            Err(CapsuleValidationError::MaxDataExceedsLimit)
         );
     }
 


### PR DESCRIPTION
## 概要

`validate_max_data` に VarInt 上限チェック (`2^62-1`) を追加し、定義済みだが到達不能だった `MaxDataExceedsLimit` エラーバリアントの発生経路を実装する。

## 変更内容

- `validate_max_data` に `maximum > VarInt::MAX.get()` のチェックを追加
- 単体テストに VarInt 上限値の正常テストと上限超過のエラーテストを追加
- PBT に `prop_validate_max_data_exceeds_limit` を追加

## 完了条件

- [x] `validate_max_data` に上限チェックが実装されていること
- [x] `MaxDataExceedsLimit` のテストが pass すること
- [x] 既存テスト (`cargo test`) が全て pass すること

## 関連 issue

- issues/closed/0075-bug-fix-max-data-exceeds-limit.md