### PR TITLE
0076 close_with_error がクローズ済みセッションで close_session_sent フラグを誤設定する問題を修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -164,6 +164,8 @@
   - @voluntas
 - [FIX] WebTransport CONNECT リクエストで fin=true が拒否されない問題を修正する
   - @voluntas
+- [FIX] close_with_error がクローズ済みセッションで close_session_sent フラグを誤設定する問題を修正する
+  - @voluntas
 - [FIX] validate_max_data に VarInt 上限チェックを追加し MaxDataExceedsLimit エラーの発生経路を実装する
   - @voluntas
 - [FIX] QPACK エンコーダーの ack_section を Result 化し、Post-Base 参照エンコードを実装し、RIC エンコードの max_entries=0 時のエッジケースを修正する

--- a/issues/closed/0076-bug-fix-close-with-error-session-closed.md
+++ b/issues/closed/0076-bug-fix-close-with-error-session-closed.md
@@ -2,6 +2,7 @@
 
 - Priority: Medium
 - Created: 2026-05-14
+- Completed: 2026-05-26
 - Model: deepseek-v4-pro
 - Branch: feature/fix-close-with-error-session-closed
 
@@ -76,9 +77,18 @@ pub fn close_with_error(&mut self, code: u32, message: impl Into<String>) {
 
 - `src/webtransport/session.rs`: `close_with_error` 関数 (763行)
 
+## 解決方法
+
+`close_with_error` の先頭に `is_closed()` チェックを追加し、クローズ済みセッションでは早期リターンするようにした。
+
+### 変更内容
+
+- `src/webtransport/session.rs`: `close_with_error` の先頭に `if self.is_closed() { return; }` を追加
+- `src/webtransport/session.rs`: クローズ済みセッションでの `close_with_error` 呼び出し時に `close_session_sent` が `false` のまま、送信キューが空であることを検証する単体テストを追加
+
 ## CHANGES.md エントリ案
 
 ```
 - [FIX] close_with_error がクローズ済みセッションで close_session_sent フラグを誤設定する問題を修正する
-  - @担当者
+  - @voluntas
 ```

--- a/src/webtransport/session.rs
+++ b/src/webtransport/session.rs
@@ -761,6 +761,9 @@ impl Session {
     ///
     /// WT_CLOSE_SESSION 送信後すぐに CONNECT ストリームへ FIN を送信すること (draft-ietf-webtrans-http3-15 Section 6)。
     pub fn close_with_error(&mut self, code: u32, message: impl Into<String>) {
+        if self.is_closed() {
+            return;
+        }
         let mut message = message.into();
         // エラーメッセージは 1024 バイトを超えてはならない
         // (draft-ietf-webtrans-http3-15 Section 6)
@@ -1103,6 +1106,32 @@ mod tests {
 
         assert!(session.is_closed());
         assert_eq!(session.pending_capsules().len(), 1);
+    }
+
+    #[test]
+    fn test_session_close_with_error_on_closed_session() {
+        // クローズ済みセッションで close_with_error を呼んでも
+        // close_session_sent フラグが誤設定されないことを確認する
+        let mut session = Session::new(0);
+        session.set_established();
+
+        // ピアからの CloseSession を先に処理してセッションをクローズする
+        session
+            .process_capsule(&Capsule::CloseSession {
+                error_code: 1,
+                message: "peer closed".to_string(),
+            })
+            .expect("CloseSession capsule should be accepted");
+        assert!(session.is_closed());
+        assert!(!session.is_close_session_sent());
+
+        // クローズ済みセッションに対して close_with_error を呼ぶ
+        session.close_with_error(42, "local close");
+
+        // close_session_sent が false のまま (カプセルは送信されていない)
+        assert!(!session.is_close_session_sent());
+        // 送信キューにカプセルが追加されていない
+        assert!(session.pending_capsules().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## 概要

`close_with_error` がクローズ済みセッションで呼ばれた場合に、`queue_capsule` は `is_closed()` で早期リターンするが `close_session_sent = true` が無条件に設定される不整合を修正する。

## 変更内容

- `close_with_error` の先頭に `if self.is_closed() { return; }` を追加
- クローズ済みセッションでの `close_with_error` 呼び出しの単体テストを追加

## 完了条件

- [x] クローズ済みセッションで `close_with_error` を呼んだ際に不整合が発生しないこと
- [x] 単体テストが pass すること
- [x] 既存テスト (`cargo test`) が全て pass すること

## 関連 issue

- issues/closed/0076-bug-fix-close-with-error-session-closed.md