### PR TITLE
0079 QPACK 整数エンコード/デコードの重複実装を一本化する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -173,6 +173,8 @@
 
 ### misc
 
+- [UPDATE] QPACK 整数エンコード/デコードの重複実装を src/qpack/integer.rs に一本化する
+  - @voluntas
 - [UPDATE] prop_webtransport.rs をディレクトリモジュールに分割し PBT 間の重複テストを削除する
   - @voluntas
 - [UPDATE] validation.rs のインラインテストを tests/test_validation.rs に分割する

--- a/issues/closed/0079-refactor-unify-qpack-integer-codec.md
+++ b/issues/closed/0079-refactor-unify-qpack-integer-codec.md
@@ -2,6 +2,7 @@
 
 - Priority: Low
 - Created: 2026-05-14
+- Completed: 2026-05-26
 - Polished: 2026-05-26
 - Model: deepseek-v4-pro
 - Branch: feature/refactor-unify-qpack-integer-codec
@@ -106,6 +107,25 @@ encode はスライス版と Vec 版でセマンティクスが異なる (バッ
 
 - refs/rfc7541.txt Section 5.1 "Integer Representation": プレフィックス整数表現のエンコード/デコードアルゴリズム
 - refs/h3/rfc9204.txt Section 4.1.1 "Prefixed Integers": QPACK が RFC 7541 Section 5.1 を unmodified で参照。 62 ビットまでのデコード MUST 要件
+
+## 解決方法
+
+`src/qpack/integer.rs` を新設し、4 ファイル (encoder.rs, decoder.rs, encoder_stream.rs, decoder_stream.rs) に散在していた 8 箇所の整数エンコード/デコード実装を 3 関数 (`encode_integer`, `encode_integer_to_vec`, `decode_integer`) に統合した。
+
+### 変更内容
+
+- `src/qpack/integer.rs` を新設し、スライス版エンコード・Vec 版エンコード・デコードの 3 関数を配置
+- `src/qpack/mod.rs` にモジュール宣言を追加
+- `src/qpack/encoder.rs` から `Encoder::encode_integer` メソッドと `encode_integer_to_buf` フリー関数を削除し、`integer::encode_integer` に置換
+- `src/qpack/decoder.rs` から `Decoder::decode_integer` メソッドと `decode_integer` フリー関数を削除し、`integer::decode_integer` に置換
+- `src/qpack/encoder_stream.rs` から `encode_integer` と `decode_integer` フリー関数を削除し、`integer::encode_integer_to_vec` / `integer::decode_integer` に置換
+- `src/qpack/decoder_stream.rs` から `encode_integer` と `decode_integer` フリー関数を削除し、`integer::encode_integer_to_vec` / `integer::decode_integer` に置換
+- `pbt/tests/prop_qpack.rs` を `pbt/tests/prop_qpack/main.rs` に変換し、`integer.rs` サブモジュールとして整数コーデック専用の PBT と境界値テストを追加
+
+### テスト
+
+- PBT: encode -> decode ラウンドトリップ (スライス版・Vec 版)、スライス版と Vec 版の一致、1 バイトエンコーディング
+- 境界値テスト: 空バッファ、0 値、max_prefix 境界、バッファ不足、オーバーフロー保護、不完全多バイト、最大デコード可能値
 
 ## CHANGES.md エントリ案
 

--- a/pbt/tests/prop_qpack/integer.rs
+++ b/pbt/tests/prop_qpack/integer.rs
@@ -1,0 +1,191 @@
+//! Property-Based Testing for QPACK 整数コーデック (RFC 7541 Section 5.1)
+
+use proptest::prelude::*;
+use shiguredo_http3::qpack::integer;
+
+// RFC 9204 Section 4.1.1: 62 ビットまでデコード可能 (MUST)
+const MAX_DECODABLE_VALUE: u64 = (1u64 << 62) - 1;
+
+proptest! {
+    /// Property: encode -> decode のラウンドトリップで値が一致する (スライス版)
+    #[test]
+    fn prop_integer_roundtrip_slice(
+        prefix_bits in 1u8..=8,
+        value in 0u64..=MAX_DECODABLE_VALUE,
+        raw_prefix in any::<u8>(),
+    ) {
+        let prefix_mask = 0xFFu8.checked_shl(prefix_bits as u32).unwrap_or(0);
+        let prefix = raw_prefix & prefix_mask;
+
+        let mut buf = vec![0u8; 16];
+        let Some(encoded_len) = integer::encode_integer(&mut buf, value, prefix_bits, prefix) else {
+            return Err(TestCaseError::reject("バッファが小さすぎる"));
+        };
+
+        let (decoded_value, decoded_len) = integer::decode_integer(&buf[..encoded_len], prefix_bits)
+            .map_err(|e| TestCaseError::fail(format!("デコード失敗: {:?}", e)))?;
+
+        prop_assert_eq!(decoded_value, value, "値が一致しない");
+        prop_assert_eq!(decoded_len, encoded_len, "長さが一致しない");
+
+        // prefix ビット外のビットが保存されていること
+        let first_byte_prefix = buf[0] & prefix_mask;
+        prop_assert_eq!(first_byte_prefix, prefix & prefix_mask, "prefix ビットが壊れている");
+    }
+
+    /// Property: encode -> decode のラウンドトリップで値が一致する (Vec 版)
+    #[test]
+    fn prop_integer_roundtrip_vec(
+        prefix_bits in 1u8..=8,
+        value in 0u64..=MAX_DECODABLE_VALUE,
+        raw_prefix in any::<u8>(),
+    ) {
+        let prefix_mask = 0xFFu8.checked_shl(prefix_bits as u32).unwrap_or(0);
+        let prefix = raw_prefix & prefix_mask;
+
+        let mut buf = Vec::new();
+        integer::encode_integer_to_vec(&mut buf, value, prefix_bits, prefix);
+
+        let (decoded_value, decoded_len) = integer::decode_integer(&buf, prefix_bits)
+            .map_err(|e| TestCaseError::fail(format!("デコード失敗: {:?}", e)))?;
+
+        prop_assert_eq!(decoded_value, value, "値が一致しない");
+        prop_assert_eq!(decoded_len, buf.len(), "長さが一致しない");
+    }
+
+    /// Property: スライス版と Vec 版のエンコード結果が一致する
+    #[test]
+    fn prop_slice_and_vec_encode_match(
+        prefix_bits in 1u8..=8,
+        value in 0u64..=MAX_DECODABLE_VALUE,
+        raw_prefix in any::<u8>(),
+    ) {
+        let prefix_mask = 0xFFu8.checked_shl(prefix_bits as u32).unwrap_or(0);
+        let prefix = raw_prefix & prefix_mask;
+
+        let mut slice_buf = vec![0u8; 16];
+        let Some(encoded_len) = integer::encode_integer(&mut slice_buf, value, prefix_bits, prefix) else {
+            return Err(TestCaseError::reject("バッファが小さすぎる"));
+        };
+
+        let mut vec_buf = Vec::new();
+        integer::encode_integer_to_vec(&mut vec_buf, value, prefix_bits, prefix);
+
+        prop_assert_eq!(&slice_buf[..encoded_len], &vec_buf[..], "エンコード結果が一致しない");
+    }
+
+    /// Property: prefix_bits の上限値 (2^N - 1) 未満の値は 1 バイトでエンコードされる
+    #[test]
+    fn prop_small_value_single_byte(
+        prefix_bits in 1u8..=8,
+    ) {
+        let max_prefix = (1u64 << prefix_bits) - 1;
+        let value = max_prefix - 1;
+        let mut buf = vec![0u8; 16];
+        let encoded_len = integer::encode_integer(&mut buf, value, prefix_bits, 0x00)
+            .expect("エンコードは成功するはず");
+
+        prop_assert_eq!(encoded_len, 1, "max_prefix 未満の値は 1 バイトでエンコードされるべき");
+    }
+}
+
+// =============================================================================
+// 境界値テスト (PBT で到達しにくいケース)
+// =============================================================================
+
+#[test]
+fn test_decode_empty_buffer() {
+    let result = integer::decode_integer(&[], 5);
+    assert!(result.is_err(), "空バッファではエラーを返すこと");
+}
+
+#[test]
+fn test_encode_zero() {
+    let mut buf = vec![0u8; 16];
+    let len = integer::encode_integer(&mut buf, 0, 5, 0x00).expect("0 のエンコードは成功するはず");
+    assert_eq!(len, 1);
+    assert_eq!(buf[0], 0x00);
+
+    let (val, dec_len) = integer::decode_integer(&buf[..len], 5).expect("デコードは成功するはず");
+    assert_eq!(val, 0);
+    assert_eq!(dec_len, 1);
+}
+
+#[test]
+fn test_encode_max_prefix_boundary() {
+    for prefix_bits in 1u8..=8 {
+        let max_prefix = (1u64 << prefix_bits) - 1;
+
+        let mut buf = vec![0u8; 16];
+        let len = integer::encode_integer(&mut buf, max_prefix, prefix_bits, 0x00)
+            .expect("max_prefix のエンコードは成功するはず");
+
+        // max_prefix 以上は複数バイト
+        assert!(
+            len >= 2,
+            "prefix_bits={}: max_prefix ({}) は 2 バイト以上",
+            prefix_bits,
+            max_prefix
+        );
+
+        let (val, dec_len) =
+            integer::decode_integer(&buf[..len], prefix_bits).expect("デコードは成功するはず");
+        assert_eq!(val, max_prefix);
+        assert_eq!(dec_len, len);
+    }
+}
+
+#[test]
+fn test_encode_slice_buffer_too_small() {
+    let mut buf = [0u8; 0];
+    assert!(
+        integer::encode_integer(&mut buf, 0, 5, 0x00).is_none(),
+        "空バッファで None を返すこと"
+    );
+
+    let mut buf = [0u8; 1];
+    assert!(
+        integer::encode_integer(&mut buf, 31, 5, 0x00).is_none(),
+        "1 バイトバッファで多バイト値は None を返すこと"
+    );
+}
+
+#[test]
+fn test_decode_overflow_protection() {
+    // shift > 56 でオーバーフロー保護が発動する入力を構築する
+    // prefix_bits=1, prefix value = 1 (= max_prefix for 1-bit prefix), then 9 continuation bytes
+    let mut data = vec![0x01];
+    data.extend(std::iter::repeat_n(0x80, 9));
+    data.push(0x01);
+
+    let result = integer::decode_integer(&data, 1);
+    assert!(
+        result.is_err(),
+        "shift > 56 でオーバーフロー保護が発動すること"
+    );
+}
+
+#[test]
+fn test_decode_truncated_multi_byte() {
+    // 多バイトエンコードの途中でデータが途切れるケース
+    let data = [0x1f, 0x80];
+    let result = integer::decode_integer(&data, 5);
+    assert!(
+        result.is_err(),
+        "不完全な多バイトエンコードではエラーを返すこと"
+    );
+}
+
+#[test]
+fn test_max_decodable_value_roundtrip() {
+    // RFC 9204 Section 4.1.1: 62 ビットまでデコード可能
+    let max_value = (1u64 << 62) - 1;
+    let mut buf = vec![0u8; 16];
+    let len = integer::encode_integer(&mut buf, max_value, 8, 0x00)
+        .expect("最大デコード可能値のエンコードは成功するはず");
+
+    let (val, dec_len) = integer::decode_integer(&buf[..len], 8)
+        .expect("最大デコード可能値のデコードは成功するはず");
+    assert_eq!(val, max_value);
+    assert_eq!(dec_len, len);
+}

--- a/pbt/tests/prop_qpack/main.rs
+++ b/pbt/tests/prop_qpack/main.rs
@@ -1,5 +1,7 @@
 //! Property-Based Testing for QPACK (RFC 9204)
 
+mod integer;
+
 use pbt::strategies::{valid_header_name, valid_header_value};
 use pbt::wire_header;
 use proptest::prelude::*;

--- a/src/qpack/decoder.rs
+++ b/src/qpack/decoder.rs
@@ -14,6 +14,7 @@ use crate::error::QpackError;
 use super::dynamic_table::DynamicTable;
 use super::header::Header;
 use super::huffman;
+use super::integer;
 use super::table::{STATIC_TABLE_LEN, get_static_entry};
 
 /// QPACK 動的デコードの結果 (RFC 9204 Section 2.1.2)
@@ -63,7 +64,7 @@ impl Decoder {
         let mut offset = 0;
 
         // Required Insert Count
-        let (ric, ric_len) = self.decode_integer(&data[offset..], 8)?;
+        let (ric, ric_len) = integer::decode_integer(&data[offset..], 8)?;
         offset += ric_len;
 
         if ric != 0 {
@@ -75,7 +76,7 @@ impl Decoder {
         if offset >= data.len() {
             return Err(QpackError::BufferTooShort);
         }
-        let (_, delta_len) = self.decode_integer(&data[offset..], 7)?;
+        let (_, delta_len) = integer::decode_integer(&data[offset..], 7)?;
         offset += delta_len;
 
         // ヘッダーをデコード
@@ -136,7 +137,7 @@ impl Decoder {
             return Err(QpackError::DecodeFailed);
         }
 
-        let (index, consumed) = self.decode_integer(data, 6)?;
+        let (index, consumed) = integer::decode_integer(data, 6)?;
 
         if index as usize >= STATIC_TABLE_LEN {
             return Err(QpackError::InvalidIndex(index));
@@ -161,7 +162,7 @@ impl Decoder {
         let mut offset = 0;
 
         // Name index
-        let (index, index_len) = self.decode_integer(data, 4)?;
+        let (index, index_len) = integer::decode_integer(data, 4)?;
         offset += index_len;
 
         if index as usize >= STATIC_TABLE_LEN {
@@ -185,7 +186,7 @@ impl Decoder {
         let mut offset = 0;
 
         // Skip prefix byte (already validated)
-        let (name_len_value, prefix_len) = self.decode_integer(data, 3)?;
+        let (name_len_value, prefix_len) = integer::decode_integer(data, 3)?;
         offset += prefix_len;
 
         // Decode name
@@ -209,7 +210,7 @@ impl Decoder {
         }
 
         let is_huffman = (data[0] & 0x80) != 0;
-        let (length, prefix_len) = self.decode_integer(data, 7)?;
+        let (length, prefix_len) = integer::decode_integer(data, 7)?;
 
         let total_len = prefix_len + length as usize;
         if data.len() < total_len {
@@ -247,45 +248,6 @@ impl Decoder {
         };
 
         Ok((decoded, length))
-    }
-
-    /// 整数をデコード (RFC 7541 Section 5.1)
-    fn decode_integer(&self, data: &[u8], prefix_bits: u8) -> Result<(u64, usize), QpackError> {
-        if data.is_empty() {
-            return Err(QpackError::BufferTooShort);
-        }
-
-        let mask = ((1u16 << prefix_bits) - 1) as u8;
-        let prefix_value = data[0] & mask;
-
-        if prefix_value < mask {
-            return Ok((prefix_value as u64, 1));
-        }
-
-        let mut value = prefix_value as u64;
-        let mut shift = 0u32;
-        let mut offset = 1;
-
-        loop {
-            if offset >= data.len() {
-                return Err(QpackError::BufferTooShort);
-            }
-
-            let byte = data[offset];
-            value += ((byte & 0x7f) as u64) << shift;
-            offset += 1;
-
-            if byte & 0x80 == 0 {
-                break;
-            }
-
-            shift += 7;
-            if shift > 56 {
-                return Err(QpackError::DecodeFailed);
-            }
-        }
-
-        Ok((value, offset))
     }
 }
 
@@ -364,7 +326,7 @@ impl DynamicDecoder {
         let mut offset = 0;
 
         // Required Insert Count をデコード
-        let (enc_insert_count, ric_len) = decode_integer(&data[offset..], 8)?;
+        let (enc_insert_count, ric_len) = integer::decode_integer(&data[offset..], 8)?;
         offset += ric_len;
 
         // Required Insert Count を復元
@@ -381,7 +343,7 @@ impl DynamicDecoder {
             return Err(QpackError::BufferTooShort);
         }
         let sign = (data[offset] & 0x80) != 0;
-        let (delta_base, delta_len) = decode_integer(&data[offset..], 7)?;
+        let (delta_base, delta_len) = integer::decode_integer(&data[offset..], 7)?;
         offset += delta_len;
 
         // Base を計算
@@ -494,7 +456,7 @@ impl DynamicDecoder {
     ) -> Result<(Header, usize), QpackError> {
         let is_static = (data[0] & 0x40) != 0;
 
-        let (index, consumed) = decode_integer(data, 6)?;
+        let (index, consumed) = integer::decode_integer(data, 6)?;
 
         if is_static {
             // 静的テーブル
@@ -534,7 +496,7 @@ impl DynamicDecoder {
         base: u64,
         required_insert_count: u64,
     ) -> Result<(Header, usize), QpackError> {
-        let (post_base_index, consumed) = decode_integer(data, 4)?;
+        let (post_base_index, consumed) = integer::decode_integer(data, 4)?;
 
         // absolute_index = base + post_base_index
         // RFC 9204 Section 2.2.3: absolute index >= Required Insert Count は
@@ -569,7 +531,7 @@ impl DynamicDecoder {
         let mut offset = 0;
 
         // Name index
-        let (index, index_len) = decode_integer(data, 4)?;
+        let (index, index_len) = integer::decode_integer(data, 4)?;
         offset += index_len;
 
         let name = if is_static {
@@ -614,7 +576,7 @@ impl DynamicDecoder {
         let mut offset = 0;
 
         // Name index (post-base)
-        let (post_base_index, index_len) = decode_integer(data, 3)?;
+        let (post_base_index, index_len) = integer::decode_integer(data, 3)?;
         offset += index_len;
 
         // absolute_index = base + post_base_index
@@ -645,7 +607,7 @@ impl DynamicDecoder {
         let mut offset = 0;
 
         // Skip prefix byte (already validated)
-        let (name_len_value, prefix_len) = decode_integer(data, 3)?;
+        let (name_len_value, prefix_len) = integer::decode_integer(data, 3)?;
         offset += prefix_len;
 
         // Decode name
@@ -675,45 +637,6 @@ impl DynamicDecoder {
     }
 }
 
-/// 整数をデコード
-fn decode_integer(data: &[u8], prefix_bits: u8) -> Result<(u64, usize), QpackError> {
-    if data.is_empty() {
-        return Err(QpackError::BufferTooShort);
-    }
-
-    let mask = ((1u16 << prefix_bits) - 1) as u8;
-    let prefix_value = data[0] & mask;
-
-    if prefix_value < mask {
-        return Ok((prefix_value as u64, 1));
-    }
-
-    let mut value = prefix_value as u64;
-    let mut shift = 0u32;
-    let mut offset = 1;
-
-    loop {
-        if offset >= data.len() {
-            return Err(QpackError::BufferTooShort);
-        }
-
-        let byte = data[offset];
-        value += ((byte & 0x7f) as u64) << shift;
-        offset += 1;
-
-        if byte & 0x80 == 0 {
-            break;
-        }
-
-        shift += 7;
-        if shift > 56 {
-            return Err(QpackError::DecodeFailed);
-        }
-    }
-
-    Ok((value, offset))
-}
-
 /// 文字列をデコード
 fn decode_string(data: &[u8]) -> Result<(Vec<u8>, usize), QpackError> {
     if data.is_empty() {
@@ -721,7 +644,7 @@ fn decode_string(data: &[u8]) -> Result<(Vec<u8>, usize), QpackError> {
     }
 
     let is_huffman = (data[0] & 0x80) != 0;
-    let (length, prefix_len) = decode_integer(data, 7)?;
+    let (length, prefix_len) = integer::decode_integer(data, 7)?;
 
     let total_len = prefix_len + length as usize;
     if data.len() < total_len {

--- a/src/qpack/decoder_stream.rs
+++ b/src/qpack/decoder_stream.rs
@@ -10,6 +10,8 @@
 
 use crate::error::QpackError;
 
+use super::integer;
+
 /// デコーダーストリーム命令
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DecoderInstruction {
@@ -62,21 +64,21 @@ impl DecoderStream {
     ///
     /// Format: 1xxxxxxx (7-bit prefix integer)
     pub fn encode_section_acknowledgment(&mut self, stream_id: u64) {
-        encode_integer(&mut self.send_buffer, stream_id, 7, 0x80);
+        integer::encode_integer_to_vec(&mut self.send_buffer, stream_id, 7, 0x80);
     }
 
     /// ストリームキャンセルをエンコード (Section 4.4.2)
     ///
     /// Format: 01xxxxxx (6-bit prefix integer)
     pub fn encode_stream_cancellation(&mut self, stream_id: u64) {
-        encode_integer(&mut self.send_buffer, stream_id, 6, 0x40);
+        integer::encode_integer_to_vec(&mut self.send_buffer, stream_id, 6, 0x40);
     }
 
     /// 挿入カウントインクリメントをエンコード (Section 4.4.3)
     ///
     /// Format: 00xxxxxx (6-bit prefix integer)
     pub fn encode_insert_count_increment(&mut self, increment: u64) {
-        encode_integer(&mut self.send_buffer, increment, 6, 0x00);
+        integer::encode_integer_to_vec(&mut self.send_buffer, increment, 6, 0x00);
     }
 
     /// 送信データを取得
@@ -175,7 +177,7 @@ impl DecoderStreamReceiver {
 
     /// Section Acknowledgment をデコード
     fn decode_section_acknowledgment(&mut self) -> Result<Option<DecoderInstruction>, QpackError> {
-        let (stream_id, consumed) = decode_integer(&self.recv_buffer, 7)?;
+        let (stream_id, consumed) = integer::decode_integer(&self.recv_buffer, 7)?;
 
         self.recv_buffer.drain(..consumed);
 
@@ -186,7 +188,7 @@ impl DecoderStreamReceiver {
 
     /// Stream Cancellation をデコード
     fn decode_stream_cancellation(&mut self) -> Result<Option<DecoderInstruction>, QpackError> {
-        let (stream_id, consumed) = decode_integer(&self.recv_buffer, 6)?;
+        let (stream_id, consumed) = integer::decode_integer(&self.recv_buffer, 6)?;
 
         self.recv_buffer.drain(..consumed);
 
@@ -198,7 +200,7 @@ impl DecoderStreamReceiver {
         &mut self,
         total_insert_count: u64,
     ) -> Result<Option<DecoderInstruction>, QpackError> {
-        let (increment, consumed) = decode_integer(&self.recv_buffer, 6)?;
+        let (increment, consumed) = integer::decode_integer(&self.recv_buffer, 6)?;
 
         // インクリメントが 0 の場合はエラー (RFC 9204 Section 4.4.3)
         if increment == 0 {
@@ -222,65 +224,6 @@ impl DecoderStreamReceiver {
     pub fn buffer(&self) -> &[u8] {
         &self.recv_buffer
     }
-}
-
-// ヘルパー関数
-
-/// 整数をエンコード (RFC 7541 Section 5.1)
-fn encode_integer(buf: &mut Vec<u8>, value: u64, prefix_bits: u8, prefix: u8) {
-    let max_prefix = (1u64 << prefix_bits) - 1;
-
-    if value < max_prefix {
-        buf.push(prefix | (value as u8));
-    } else {
-        buf.push(prefix | (max_prefix as u8));
-        let mut remaining = value - max_prefix;
-
-        while remaining >= 128 {
-            buf.push(0x80 | ((remaining & 0x7f) as u8));
-            remaining >>= 7;
-        }
-        buf.push(remaining as u8);
-    }
-}
-
-/// 整数をデコード
-fn decode_integer(data: &[u8], prefix_bits: u8) -> Result<(u64, usize), QpackError> {
-    if data.is_empty() {
-        return Err(QpackError::BufferTooShort);
-    }
-
-    let mask = ((1u16 << prefix_bits) - 1) as u8;
-    let prefix_value = data[0] & mask;
-
-    if prefix_value < mask {
-        return Ok((prefix_value as u64, 1));
-    }
-
-    let mut value = prefix_value as u64;
-    let mut shift = 0u32;
-    let mut offset = 1;
-
-    loop {
-        if offset >= data.len() {
-            return Err(QpackError::BufferTooShort);
-        }
-
-        let byte = data[offset];
-        value += ((byte & 0x7f) as u64) << shift;
-        offset += 1;
-
-        if byte & 0x80 == 0 {
-            break;
-        }
-
-        shift += 7;
-        if shift > 56 {
-            return Err(QpackError::DecodeFailed);
-        }
-    }
-
-    Ok((value, offset))
 }
 
 #[cfg(test)]

--- a/src/qpack/encoder.rs
+++ b/src/qpack/encoder.rs
@@ -14,6 +14,7 @@ use crate::error::QpackError;
 use super::dynamic_table::DynamicTable;
 use super::header::Header;
 use super::huffman;
+use super::integer;
 use super::table::{STATIC_TABLE, find_static_entry};
 
 /// QPACK エンコーダー
@@ -94,7 +95,7 @@ impl Encoder {
             Some(1)
         } else {
             // 6-bit prefix を超える場合
-            self.encode_integer(buf, index as u64, 6, 0xc0)
+            integer::encode_integer(buf, index as u64, 6, 0xc0)
         }
     }
 
@@ -115,7 +116,7 @@ impl Encoder {
             buf[0] = 0x50 | (index as u8);
             1
         } else {
-            self.encode_integer(buf, index as u64, 4, 0x50)?
+            integer::encode_integer(buf, index as u64, 4, 0x50)?
         };
 
         // Value
@@ -176,14 +177,14 @@ impl Encoder {
                 // H ビットを設定: prefix に 0x08 を OR (3-bit prefix の場合)
                 let h_bit = 1u8 << prefix_bits;
                 let offset =
-                    self.encode_integer(buf, huffman_len as u64, prefix_bits, prefix | h_bit)?;
+                    integer::encode_integer(buf, huffman_len as u64, prefix_bits, prefix | h_bit)?;
                 huffman::encode(&mut buf[offset..], data)?;
                 return Some(offset + huffman_len);
             }
         }
 
         // リテラル文字列 (H=0)
-        let offset = self.encode_integer(buf, data.len() as u64, prefix_bits, prefix)?;
+        let offset = integer::encode_integer(buf, data.len() as u64, prefix_bits, prefix)?;
         if buf.len() < offset + data.len() {
             return None;
         }
@@ -197,60 +198,19 @@ impl Encoder {
             let huffman_len = huffman::encoded_len(data);
             if huffman_len < data.len() {
                 // ハフマン符号化を使用
-                let offset = self.encode_integer(buf, huffman_len as u64, 7, 0x80)?;
+                let offset = integer::encode_integer(buf, huffman_len as u64, 7, 0x80)?;
                 huffman::encode(&mut buf[offset..], data)?;
                 return Some(offset + huffman_len);
             }
         }
 
         // リテラル文字列
-        let offset = self.encode_integer(buf, data.len() as u64, 7, 0x00)?;
+        let offset = integer::encode_integer(buf, data.len() as u64, 7, 0x00)?;
         if buf.len() < offset + data.len() {
             return None;
         }
         buf[offset..offset + data.len()].copy_from_slice(data);
         Some(offset + data.len())
-    }
-
-    /// 整数をエンコード (RFC 7541 Section 5.1)
-    fn encode_integer(
-        &self,
-        buf: &mut [u8],
-        value: u64,
-        prefix_bits: u8,
-        prefix: u8,
-    ) -> Option<usize> {
-        let max_prefix = (1u64 << prefix_bits) - 1;
-
-        if value < max_prefix {
-            if buf.is_empty() {
-                return None;
-            }
-            buf[0] = prefix | (value as u8);
-            Some(1)
-        } else {
-            if buf.is_empty() {
-                return None;
-            }
-            buf[0] = prefix | (max_prefix as u8);
-            let mut offset = 1;
-            let mut remaining = value - max_prefix;
-
-            while remaining >= 128 {
-                if offset >= buf.len() {
-                    return None;
-                }
-                buf[offset] = 0x80 | ((remaining & 0x7f) as u8);
-                remaining >>= 7;
-                offset += 1;
-            }
-
-            if offset >= buf.len() {
-                return None;
-            }
-            buf[offset] = remaining as u8;
-            Some(offset + 1)
-        }
     }
 }
 
@@ -542,7 +502,7 @@ impl DynamicEncoder {
 
         // Required Insert Count をエンコード
         let enc_insert_count = self.encode_required_insert_count(required_insert_count);
-        offset += encode_integer_to_buf(&mut buf[offset..], enc_insert_count, 8, 0x00)?;
+        offset += integer::encode_integer(&mut buf[offset..], enc_insert_count, 8, 0x00)?;
 
         // Base = Required Insert Count (シンプルな実装)
         // Sign = 0, Delta Base = 0
@@ -639,7 +599,7 @@ impl DynamicEncoder {
     /// Format: 1TNNNNNN (T=1 for static)
     fn encode_indexed_field_static(&self, buf: &mut [u8], index: usize) -> Option<usize> {
         // 0xc0 = 11000000 (T=1)
-        encode_integer_to_buf(buf, index as u64, 6, 0xc0)
+        integer::encode_integer(buf, index as u64, 6, 0xc0)
     }
 
     /// Indexed Field Line (動的テーブル) をエンコード (RFC 9204 Section 4.5.2, 4.5.3)
@@ -665,11 +625,11 @@ impl DynamicEncoder {
             // Post-Base Indexed Field Line (RFC 9204 Section 4.5.3)
             let post_base_index = absolute_index - base;
             // 0x10 = 00010000
-            encode_integer_to_buf(buf, post_base_index, 4, 0x10)
+            integer::encode_integer(buf, post_base_index, 4, 0x10)
         } else {
             let relative_index = base - absolute_index - 1;
             // 0x80 = 10000000 (T=0)
-            encode_integer_to_buf(buf, relative_index, 6, 0x80)
+            integer::encode_integer(buf, relative_index, 6, 0x80)
         }
     }
 
@@ -683,7 +643,7 @@ impl DynamicEncoder {
         value: &[u8],
     ) -> Option<usize> {
         // 0x50 = 01010000 (N=0, T=1)
-        let mut offset = encode_integer_to_buf(buf, index as u64, 4, 0x50)?;
+        let mut offset = integer::encode_integer(buf, index as u64, 4, 0x50)?;
 
         // Value
         let value_len = self.encode_string(&mut buf[offset..], value)?;
@@ -716,11 +676,11 @@ impl DynamicEncoder {
             // Post-Base Name Reference (RFC 9204 Section 4.5.5)
             let post_base_index = absolute_index - base;
             // 0x00 = 00000000 (N=0)
-            encode_integer_to_buf(buf, post_base_index, 3, 0x00)?
+            integer::encode_integer(buf, post_base_index, 3, 0x00)?
         } else {
             let relative_index = base - absolute_index - 1;
             // 0x40 = 01000000 (N=0, T=0)
-            encode_integer_to_buf(buf, relative_index, 4, 0x40)?
+            integer::encode_integer(buf, relative_index, 4, 0x40)?
         };
 
         // Value
@@ -781,14 +741,14 @@ impl DynamicEncoder {
                 // H ビットを設定: prefix に 0x08 を OR (3-bit prefix の場合)
                 let h_bit = 1u8 << prefix_bits;
                 let offset =
-                    encode_integer_to_buf(buf, huffman_len as u64, prefix_bits, prefix | h_bit)?;
+                    integer::encode_integer(buf, huffman_len as u64, prefix_bits, prefix | h_bit)?;
                 huffman::encode(&mut buf[offset..], data)?;
                 return Some(offset + huffman_len);
             }
         }
 
         // リテラル文字列 (H=0)
-        let offset = encode_integer_to_buf(buf, data.len() as u64, prefix_bits, prefix)?;
+        let offset = integer::encode_integer(buf, data.len() as u64, prefix_bits, prefix)?;
         if buf.len() < offset + data.len() {
             return None;
         }
@@ -801,13 +761,13 @@ impl DynamicEncoder {
         if self.use_huffman {
             let huffman_len = huffman::encoded_len(data);
             if huffman_len < data.len() {
-                let offset = encode_integer_to_buf(buf, huffman_len as u64, 7, 0x80)?;
+                let offset = integer::encode_integer(buf, huffman_len as u64, 7, 0x80)?;
                 huffman::encode(&mut buf[offset..], data)?;
                 return Some(offset + huffman_len);
             }
         }
 
-        let offset = encode_integer_to_buf(buf, data.len() as u64, 7, 0x00)?;
+        let offset = integer::encode_integer(buf, data.len() as u64, 7, 0x00)?;
         if buf.len() < offset + data.len() {
             return None;
         }
@@ -842,41 +802,6 @@ impl DynamicEncoder {
             .name
             .clone();
         self.table.insert(name, value)
-    }
-}
-
-/// 整数をバッファにエンコード
-fn encode_integer_to_buf(buf: &mut [u8], value: u64, prefix_bits: u8, prefix: u8) -> Option<usize> {
-    let max_prefix = (1u64 << prefix_bits) - 1;
-
-    if value < max_prefix {
-        if buf.is_empty() {
-            return None;
-        }
-        buf[0] = prefix | (value as u8);
-        Some(1)
-    } else {
-        if buf.is_empty() {
-            return None;
-        }
-        buf[0] = prefix | (max_prefix as u8);
-        let mut offset = 1;
-        let mut remaining = value - max_prefix;
-
-        while remaining >= 128 {
-            if offset >= buf.len() {
-                return None;
-            }
-            buf[offset] = 0x80 | ((remaining & 0x7f) as u8);
-            remaining >>= 7;
-            offset += 1;
-        }
-
-        if offset >= buf.len() {
-            return None;
-        }
-        buf[offset] = remaining as u8;
-        Some(offset + 1)
     }
 }
 

--- a/src/qpack/encoder_stream.rs
+++ b/src/qpack/encoder_stream.rs
@@ -13,6 +13,7 @@ use crate::error::QpackError;
 
 use super::dynamic_table::DynamicTable;
 use super::huffman;
+use super::integer;
 use super::table::STATIC_TABLE;
 
 /// エンコーダーストリーム命令
@@ -86,7 +87,7 @@ impl EncoderStream {
         if capacity > self.max_table_capacity {
             return Err(QpackError::CapacityExceeded);
         }
-        encode_integer(&mut self.send_buffer, capacity, 5, 0x20);
+        integer::encode_integer_to_vec(&mut self.send_buffer, capacity, 5, 0x20);
         Ok(())
     }
 
@@ -107,7 +108,7 @@ impl EncoderStream {
             return Err(QpackError::DynamicTableDisabled);
         }
         let prefix = if is_static { 0xc0 } else { 0x80 };
-        encode_integer(&mut self.send_buffer, name_index, 6, prefix);
+        integer::encode_integer_to_vec(&mut self.send_buffer, name_index, 6, prefix);
         encode_string(&mut self.send_buffer, value);
         Ok(())
     }
@@ -145,7 +146,7 @@ impl EncoderStream {
         if self.max_table_capacity == 0 {
             return Err(QpackError::DynamicTableDisabled);
         }
-        encode_integer(&mut self.send_buffer, relative_index, 5, 0x00);
+        integer::encode_integer_to_vec(&mut self.send_buffer, relative_index, 5, 0x00);
         Ok(())
     }
 
@@ -246,7 +247,7 @@ impl EncoderStreamReceiver {
         &mut self,
         table: &mut DynamicTable,
     ) -> Result<Option<EncoderInstruction>, QpackError> {
-        let (capacity, consumed) = decode_integer(&self.recv_buffer, 5)?;
+        let (capacity, consumed) = integer::decode_integer(&self.recv_buffer, 5)?;
 
         // 最大容量を超えていないかチェック
         if capacity > self.max_table_capacity {
@@ -267,7 +268,7 @@ impl EncoderStreamReceiver {
         table: &mut DynamicTable,
     ) -> Result<Option<EncoderInstruction>, QpackError> {
         let is_static = (self.recv_buffer[0] & 0x40) != 0;
-        let (name_index, mut consumed) = decode_integer(&self.recv_buffer, 6)?;
+        let (name_index, mut consumed) = integer::decode_integer(&self.recv_buffer, 6)?;
 
         // Value をデコード
         let (value, value_len) = decode_string(&self.recv_buffer[consumed..])?;
@@ -331,7 +332,7 @@ impl EncoderStreamReceiver {
         &mut self,
         table: &mut DynamicTable,
     ) -> Result<Option<EncoderInstruction>, QpackError> {
-        let (relative_index, consumed) = decode_integer(&self.recv_buffer, 5)?;
+        let (relative_index, consumed) = integer::decode_integer(&self.recv_buffer, 5)?;
 
         // テーブル操作を先に行い、成功後に drain
         table
@@ -351,24 +352,6 @@ impl EncoderStreamReceiver {
 
 // ヘルパー関数
 
-/// 整数をエンコード (RFC 7541 Section 5.1)
-fn encode_integer(buf: &mut Vec<u8>, value: u64, prefix_bits: u8, prefix: u8) {
-    let max_prefix = (1u64 << prefix_bits) - 1;
-
-    if value < max_prefix {
-        buf.push(prefix | (value as u8));
-    } else {
-        buf.push(prefix | (max_prefix as u8));
-        let mut remaining = value - max_prefix;
-
-        while remaining >= 128 {
-            buf.push(0x80 | ((remaining & 0x7f) as u8));
-            remaining >>= 7;
-        }
-        buf.push(remaining as u8);
-    }
-}
-
 /// 文字列をエンコード (7-bit prefix)
 fn encode_string(buf: &mut Vec<u8>, data: &[u8]) {
     encode_string_with_prefix(buf, data, 7, 0x00);
@@ -386,54 +369,15 @@ fn encode_string_with_prefix(buf: &mut Vec<u8>, data: &[u8], prefix_bits: u8, ba
         // ハフマン符号化を使用
         // H ビットは prefix ビットの直上
         let huffman_flag = 1u8 << prefix_bits;
-        encode_integer(buf, huffman_len as u64, prefix_bits, base | huffman_flag);
+        integer::encode_integer_to_vec(buf, huffman_len as u64, prefix_bits, base | huffman_flag);
         let start = buf.len();
         buf.resize(start + huffman_len, 0);
         huffman::encode(&mut buf[start..], data);
     } else {
         // リテラル
-        encode_integer(buf, data.len() as u64, prefix_bits, base);
+        integer::encode_integer_to_vec(buf, data.len() as u64, prefix_bits, base);
         buf.extend_from_slice(data);
     }
-}
-
-/// 整数をデコード
-fn decode_integer(data: &[u8], prefix_bits: u8) -> Result<(u64, usize), QpackError> {
-    if data.is_empty() {
-        return Err(QpackError::BufferTooShort);
-    }
-
-    let mask = ((1u16 << prefix_bits) - 1) as u8;
-    let prefix_value = data[0] & mask;
-
-    if prefix_value < mask {
-        return Ok((prefix_value as u64, 1));
-    }
-
-    let mut value = prefix_value as u64;
-    let mut shift = 0u32;
-    let mut offset = 1;
-
-    loop {
-        if offset >= data.len() {
-            return Err(QpackError::BufferTooShort);
-        }
-
-        let byte = data[offset];
-        value += ((byte & 0x7f) as u64) << shift;
-        offset += 1;
-
-        if byte & 0x80 == 0 {
-            break;
-        }
-
-        shift += 7;
-        if shift > 56 {
-            return Err(QpackError::DecodeFailed);
-        }
-    }
-
-    Ok((value, offset))
 }
 
 /// 文字列をデコード (7-bit prefix)
@@ -455,7 +399,7 @@ fn decode_string_with_prefix(data: &[u8], prefix_bits: u8) -> Result<(Vec<u8>, u
     // H ビットは prefix ビットの直上
     let huffman_flag = 1u8 << prefix_bits;
     let is_huffman = (data[0] & huffman_flag) != 0;
-    let (length, prefix_len) = decode_integer(data, prefix_bits)?;
+    let (length, prefix_len) = integer::decode_integer(data, prefix_bits)?;
 
     let total_len = prefix_len + length as usize;
     if data.len() < total_len {

--- a/src/qpack/integer.rs
+++ b/src/qpack/integer.rs
@@ -1,0 +1,107 @@
+//! RFC 7541 Section 5.1 のプレフィックス整数エンコード/デコード
+//!
+//! QPACK (RFC 9204 Section 4.1.1) は RFC 7541 Section 5.1 を unmodified で参照する。
+//! RFC 9204 Section 4.1.1 では 62 ビットまでデコードできること (MUST) を要求している。
+//! この要件は shift > 56 でのオーバーフロー保護によって満たされる。
+//!
+//! 仕様は将来変更される可能性がある。
+
+use crate::error::QpackError;
+
+/// スライスにエンコード (RFC 7541 Section 5.1)
+///
+/// バッファ不足時は None を返す。
+pub fn encode_integer(buf: &mut [u8], value: u64, prefix_bits: u8, prefix: u8) -> Option<usize> {
+    let max_prefix = (1u64 << prefix_bits) - 1;
+
+    if value < max_prefix {
+        if buf.is_empty() {
+            return None;
+        }
+        buf[0] = prefix | (value as u8);
+        Some(1)
+    } else {
+        if buf.is_empty() {
+            return None;
+        }
+        buf[0] = prefix | (max_prefix as u8);
+        let mut offset = 1;
+        let mut remaining = value - max_prefix;
+
+        while remaining >= 128 {
+            if offset >= buf.len() {
+                return None;
+            }
+            buf[offset] = 0x80 | ((remaining & 0x7f) as u8);
+            remaining >>= 7;
+            offset += 1;
+        }
+
+        if offset >= buf.len() {
+            return None;
+        }
+        buf[offset] = remaining as u8;
+        Some(offset + 1)
+    }
+}
+
+/// Vec にエンコード (RFC 7541 Section 5.1)
+///
+/// Vec に push で追記する。バッファ不足は発生しない。
+pub fn encode_integer_to_vec(buf: &mut Vec<u8>, value: u64, prefix_bits: u8, prefix: u8) {
+    let max_prefix = (1u64 << prefix_bits) - 1;
+
+    if value < max_prefix {
+        buf.push(prefix | (value as u8));
+    } else {
+        buf.push(prefix | (max_prefix as u8));
+        let mut remaining = value - max_prefix;
+
+        while remaining >= 128 {
+            buf.push(0x80 | ((remaining & 0x7f) as u8));
+            remaining >>= 7;
+        }
+        buf.push(remaining as u8);
+    }
+}
+
+/// デコード (RFC 7541 Section 5.1)
+///
+/// shift > 56 でオーバーフロー保護 (RFC 9204 Section 4.1.1: 62 ビットまでデコード可能)。
+pub fn decode_integer(data: &[u8], prefix_bits: u8) -> Result<(u64, usize), QpackError> {
+    if data.is_empty() {
+        return Err(QpackError::BufferTooShort);
+    }
+
+    let mask = ((1u16 << prefix_bits) - 1) as u8;
+    let prefix_value = data[0] & mask;
+
+    if prefix_value < mask {
+        return Ok((prefix_value as u64, 1));
+    }
+
+    let mut value = prefix_value as u64;
+    let mut shift = 0u32;
+    let mut offset = 1;
+
+    loop {
+        if offset >= data.len() {
+            return Err(QpackError::BufferTooShort);
+        }
+
+        let byte = data[offset];
+        value += ((byte & 0x7f) as u64) << shift;
+        offset += 1;
+
+        if byte & 0x80 == 0 {
+            break;
+        }
+
+        shift += 7;
+        if shift > 56 {
+            return Err(QpackError::DecodeFailed);
+        }
+    }
+
+    Ok((value, offset))
+}

--- a/src/qpack/mod.rs
+++ b/src/qpack/mod.rs
@@ -36,6 +36,7 @@ mod encoder;
 pub mod encoder_stream;
 mod header;
 pub mod huffman;
+pub mod integer;
 pub mod table;
 
 pub use decoder::{DecodeOutput, Decoder, DynamicDecoder};


### PR DESCRIPTION
## 概要

4 ファイルに散在していた QPACK 整数エンコード/デコードの 8 重複実装を `src/qpack/integer.rs` に一本化する。

## 変更内容

- `src/qpack/integer.rs` を新設し、`encode_integer` (スライス版)、`encode_integer_to_vec` (Vec 版)、`decode_integer` の 3 関数を配置
- `encoder.rs`、`decoder.rs`、`encoder_stream.rs`、`decoder_stream.rs` の重複実装を削除し、`integer` モジュール経由に置換
- `pbt/tests/prop_qpack.rs` をディレクトリモジュールに変換し、整数コーデック専用の PBT と境界値テストを追加

## 完了条件

- [x] 8 箇所の重複実装が全て削除され `integer.rs` に一本化されていること
- [x] 統合後の実装が RFC 7541 Section 5.1 の MUST 要件を満たすこと
- [x] 統合後の実装が RFC 9204 Section 4.1.1 の MUST 要件を満たすこと
- [x] `cargo test` が全て pass すること
- [x] 相互運用テストが pass すること

## 関連 issue

- issues/closed/0079-refactor-unify-qpack-integer-codec.md