### PR TITLE
0080 未使用コードと不要な lint 抑制を削除する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,8 @@
   - @voluntas
 - [CHANGE] `FrameDecodeError::Http2Frame` / `FrameDecodeError::ServerPushNotSupported` のフィールド型を `u64` から `VarInt` に変更し、HTTP/3 frame type の値域 (RFC 9000 Section 16) を型で保証する
   - @voluntas
+- [CHANGE] `stream::request::ReceivedData` enum を削除する (未使用の死にコード)
+  - @voluntas
 - [ADD] `VarInt::from_static` / `qpack::Header::from_static` / `frame::GoawayPayload::from_static` の doc に `compile_fail` ブロックを追加し、`const fn` 検査のリグレッションを CI (`cargo test --doc`) で防止する
   - @voluntas
 - [ADD] 構築時検査の `from_static` ↔ `new` 一貫性、`from_validated_parts` ↔ `new` 整合性、`Header::new` ↔ QPACK ラウンドトリップ完全性を検証する PBT を追加する
@@ -174,6 +176,10 @@
 ### misc
 
 - [UPDATE] QPACK 整数エンコード/デコードの重複実装を src/qpack/integer.rs に一本化する
+  - @voluntas
+- [UPDATE] disassociate_stream の不要な `#[allow(dead_code)]` を削除する
+  - @voluntas
+- [UPDATE] connection/mod.rs の重複定数を webtransport/session.rs に集約する
   - @voluntas
 - [UPDATE] prop_webtransport.rs をディレクトリモジュールに分割し PBT 間の重複テストを削除する
   - @voluntas

--- a/issues/closed/0080-refactor-remove-unused-and-dead-code.md
+++ b/issues/closed/0080-refactor-remove-unused-and-dead-code.md
@@ -2,6 +2,7 @@
 
 - Priority: Low
 - Created: 2026-05-14
+- Completed: 2026-05-26
 - Polished: 2026-05-26
 - Model: deepseek-v4-pro
 - Branch: feature/refactor-remove-unused-and-dead-code
@@ -73,6 +74,23 @@ Low: コンパイルやテストに問題はないが、死にコードの放置
 - `src/stream/request.rs`: `ReceivedData` enum の削除
 - `src/connection/mod.rs`: `#[allow(dead_code)]` 削除、重複定数の削除と参照変更
 - `src/webtransport/session.rs`: 定数の可視性を `pub(crate)` に変更
+
+## 解決方法
+
+issue に記載された 3 項目を全て対応した。
+
+### 項目 1: `ReceivedData` enum の削除
+- `src/stream/request.rs` から `pub enum ReceivedData` を削除
+- `grep -rn 'ReceivedData'` でゼロヒットを確認済み
+
+### 項目 2: `#[allow(dead_code)]` の削除
+- `src/connection/mod.rs` の `disassociate_stream` メソッドから `#[allow(dead_code)]` 属性を削除
+- 実際に `mod.rs:3836` で呼び出されていることを確認済み
+
+### 項目 3: 重複定数の集約
+- `src/connection/mod.rs` の `WT_MAX_BUFFERED_STREAMS` / `WT_MAX_BUFFERED_DATAGRAMS` を削除
+- `src/webtransport/session.rs` の `MAX_BUFFERED_STREAMS` / `MAX_BUFFERED_DATAGRAMS` を `pub(crate)` に変更
+- `connection/mod.rs` 内の参照を `crate::webtransport::session::MAX_BUFFERED_STREAMS` / `MAX_BUFFERED_DATAGRAMS` に置換
 
 ## CHANGES.md エントリ案
 

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -71,12 +71,6 @@ enum AssocOutcome {
     BufferOverflow,
 }
 
-/// セッション確立前にバッファリングするストリームの上限 (draft-ietf-webtrans-http3-15 Section 4.6)
-const WT_MAX_BUFFERED_STREAMS: usize = 100;
-
-/// セッション確立前にバッファリングするデータグラムの上限 (draft-ietf-webtrans-http3-15 Section 4.6)
-const WT_MAX_BUFFERED_DATAGRAMS: usize = 100;
-
 /// サーバー側で許容する Pending WebTransport セッション数の上限
 ///
 /// クライアントは未知の `session_id` で先行ストリーム / データグラムを送ってくることが
@@ -353,7 +347,6 @@ impl WtSession {
     }
 
     /// ストリームの関連付けを解除する
-    #[allow(dead_code)]
     fn disassociate_stream(&mut self, stream_id: u64) {
         self.associated_streams.remove(&stream_id);
     }
@@ -363,7 +356,7 @@ impl WtSession {
     /// バッファ上限を超えた場合は `false` を返す。
     /// 呼び出し元は `WT_BUFFERED_STREAM_REJECTED` で RESET_STREAM を送信すること。
     fn buffer_stream(&mut self, stream_id: u64, is_bidi: bool) -> bool {
-        if self.buffered_streams.len() >= WT_MAX_BUFFERED_STREAMS {
+        if self.buffered_streams.len() >= crate::webtransport::session::MAX_BUFFERED_STREAMS {
             return false;
         }
         self.buffered_streams.push(stream_id);
@@ -410,7 +403,7 @@ impl WtSession {
     /// バッファ上限を超えた場合は `false` を返す。
     /// 呼び出し元はデータグラムを破棄すること。
     fn buffer_datagram(&mut self, data: Vec<u8>) -> bool {
-        if self.buffered_datagrams.len() >= WT_MAX_BUFFERED_DATAGRAMS {
+        if self.buffered_datagrams.len() >= crate::webtransport::session::MAX_BUFFERED_DATAGRAMS {
             return false;
         }
         self.buffered_datagrams.push(data);

--- a/src/stream/request.rs
+++ b/src/stream/request.rs
@@ -483,17 +483,6 @@ impl RequestStream {
     }
 }
 
-/// 受信データの種類 (デコード済み)
-#[derive(Debug, Clone)]
-pub enum ReceivedData {
-    /// ヘッダー
-    Headers(Vec<Header>),
-    /// ボディデータ
-    Data(Vec<u8>),
-    /// ストリーム終了
-    StreamEnd,
-}
-
 /// 受信データの種類 (生データ)
 ///
 /// QPACK デコード前のデータを返す。Connection が動的テーブルを使用してデコードする。

--- a/src/webtransport/session.rs
+++ b/src/webtransport/session.rs
@@ -9,10 +9,10 @@ use super::error::{Error, ErrorCode};
 use super::stream::Stream;
 
 /// セッション確立前にバッファリングするストリームの上限 (draft-ietf-webtrans-http3-15 Section 4.6)
-const MAX_BUFFERED_STREAMS: usize = 100;
+pub(crate) const MAX_BUFFERED_STREAMS: usize = 100;
 
 /// セッション確立前にバッファリングするデータグラムの上限 (draft-ietf-webtrans-http3-15 Section 4.6)
-const MAX_BUFFERED_DATAGRAMS: usize = 100;
+pub(crate) const MAX_BUFFERED_DATAGRAMS: usize = 100;
 
 /// バッファリングされたストリームの情報 (draft-ietf-webtrans-http3-15 Section 4.6)
 #[derive(Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
## 概要

未使用コード・不要な lint 抑制・重複定数を整理し、コードベースの衛生状態を改善する。

## 変更内容

- `stream::request::ReceivedData` enum を削除 (未使用の死にコード)
- `disassociate_stream` の不要な `#[allow(dead_code)]` を削除
- `connection/mod.rs` の重複定数 `WT_MAX_BUFFERED_STREAMS` / `WT_MAX_BUFFERED_DATAGRAMS` を `webtransport/session.rs` に集約

## 完了条件

- [x] `ReceivedData` enum が削除されていること
- [x] `disassociate_stream` の `#[allow(dead_code)]` が削除されていること
- [x] 重複定数が `webtransport/session.rs` に集約されていること
- [x] `cargo test --workspace` が全て pass すること
- [x] `cargo clippy --workspace` で新たな警告がないこと

## 関連 issue

- issues/closed/0080-refactor-remove-unused-and-dead-code.md