### PR TITLE
0081 Connection の send_request / send_response を pub(crate) 化する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@
   - @voluntas
 - [CHANGE] `stream::request::ReceivedData` enum を削除する (未使用の死にコード)
   - @voluntas
+- [CHANGE] `Connection::send_request` / `Connection::send_response` を `pub(crate)` に変更し `ClientConnection` / `ServerConnection` 経由でのみ呼び出し可能にする
+  - @voluntas
 - [ADD] `VarInt::from_static` / `qpack::Header::from_static` / `frame::GoawayPayload::from_static` の doc に `compile_fail` ブロックを追加し、`const fn` 検査のリグレッションを CI (`cargo test --doc`) で防止する
   - @voluntas
 - [ADD] 構築時検査の `from_static` ↔ `new` 一貫性、`from_validated_parts` ↔ `new` 整合性、`Header::new` ↔ QPACK ラウンドトリップ完全性を検証する PBT を追加する

--- a/crates/tokio-s2n-quic/src/internal/connection_state.rs
+++ b/crates/tokio-s2n-quic/src/internal/connection_state.rs
@@ -2,12 +2,14 @@
 //!
 //! std::sync::Mutex で保護される。await を跨がない。
 
-use shiguredo_http3::{Connection, Event, H3InitData, Header, Settings as H3Settings};
+use shiguredo_http3::{
+    ClientConnection, Event, H3InitData, Header, ServerConnection, Settings as H3Settings,
+};
 
 /// サーバー側 HTTP/3 接続状態
 pub(crate) struct ServerConnectionState {
     /// HTTP/3 接続 (Sans I/O)
-    pub(crate) h3_conn: Connection,
+    pub(crate) h3_conn: ServerConnection,
     /// 制御ストリーム ID (送信側)
     pub(crate) control_stream_id: Option<u64>,
     /// QPACK エンコーダーストリーム ID (送信側)
@@ -20,7 +22,7 @@ impl ServerConnectionState {
     /// 新しいサーバー接続状態を作成する
     pub(crate) fn new(settings: H3Settings) -> Self {
         Self {
-            h3_conn: Connection::server(settings),
+            h3_conn: ServerConnection::new(settings),
             control_stream_id: None,
             encoder_stream_id: None,
             decoder_stream_id: None,
@@ -110,7 +112,7 @@ impl ServerConnectionState {
 /// クライアント側 HTTP/3 接続状態
 pub(crate) struct ClientConnectionState {
     /// HTTP/3 接続 (Sans I/O)
-    pub(crate) h3_conn: Connection,
+    pub(crate) h3_conn: ClientConnection,
     /// 制御ストリーム ID (送信側)
     pub(crate) control_stream_id: Option<u64>,
     /// QPACK エンコーダーストリーム ID (送信側)
@@ -123,7 +125,7 @@ impl ClientConnectionState {
     /// 新しいクライアント接続状態を作成する
     pub(crate) fn new(settings: H3Settings) -> Self {
         Self {
-            h3_conn: Connection::client(settings),
+            h3_conn: ClientConnection::new(settings),
             control_stream_id: None,
             encoder_stream_id: None,
             decoder_stream_id: None,

--- a/examples/wt_server/src/webtransport.rs
+++ b/examples/wt_server/src/webtransport.rs
@@ -18,7 +18,7 @@ use shiguredo_http3::webtransport::stream::{
     ClassifiedUniStream, StreamHeader, StreamHeaderDecodeError, classify_uni_stream_checked,
 };
 use shiguredo_http3::{
-    Connection, Event, Setting, Settings as H3Settings, SettingsPayload, VarInt,
+    Event, ServerConnection, Setting, Settings as H3Settings, SettingsPayload, VarInt,
 };
 use tokio::sync::Notify;
 use tokio::sync::mpsc;
@@ -96,14 +96,14 @@ pub type Result<T> = std::result::Result<T, Error>;
 // ---------------------------------------------------------------------------
 
 struct ServerConnectionState {
-    h3_conn: Connection,
+    h3_conn: ServerConnection,
     control_stream_id: Option<u64>,
 }
 
 impl ServerConnectionState {
     fn new(settings: H3Settings) -> Self {
         Self {
-            h3_conn: Connection::server(settings),
+            h3_conn: ServerConnection::new(settings),
             control_stream_id: None,
         }
     }

--- a/issues/closed/0081-refactor-client-server-wrapper.md
+++ b/issues/closed/0081-refactor-client-server-wrapper.md
@@ -2,6 +2,7 @@
 
 - Priority: Low
 - Created: 2026-05-14
+- Completed: 2026-05-26
 - Polished: 2026-05-26
 - Model: deepseek-v4-pro
 - Branch: feature/refactor-client-server-wrapper
@@ -64,6 +65,14 @@ Low: 型安全性の改善であり、現状で誤使用はコンパイル時に
 - `src/connection/client.rs`: 変更なし (既に委譲している)
 - `src/connection/server.rs`: `ServerConnection` に未委譲メソッドの追加が必要な場合あり
 - `examples/wt_server/src/webtransport.rs`: `Connection` → `ServerConnection` に移行
+
+## 解決方法
+
+1. `src/connection/mod.rs` の `Connection::send_request` / `Connection::send_response` を `pub` → `pub(crate)` に変更
+2. `examples/wt_server/src/webtransport.rs` を `Connection::server()` → `ServerConnection::new()` に移行
+3. `crates/tokio-s2n-quic/src/internal/connection_state.rs` を `Connection::server()` / `Connection::client()` → `ServerConnection::new()` / `ClientConnection::new()` に移行
+
+issue の影響範囲には `tokio-s2n-quic` が未記載だったが、`pub(crate)` 化の必然的帰結として移行が必要だったため対応した。
 
 ## CHANGES.md エントリ案
 

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -3343,7 +3343,7 @@ impl Connection {
     }
 
     /// リクエストを送信 (クライアント専用)
-    pub fn send_request(&mut self, headers: &[Header], fin: bool) -> Result<u64, Error> {
+    pub(crate) fn send_request(&mut self, headers: &[Header], fin: bool) -> Result<u64, Error> {
         if self.role != Role::Client {
             return Err(Error::ConnectionError(ErrorCode::InternalError));
         }
@@ -3496,7 +3496,7 @@ impl Connection {
     }
 
     /// レスポンスを送信 (サーバー専用)
-    pub fn send_response(
+    pub(crate) fn send_response(
         &mut self,
         stream_id: u64,
         headers: &[Header],


### PR DESCRIPTION
## 概要

`Connection::send_request` / `Connection::send_response` を `pub(crate)` に変更し、`ClientConnection` / `ServerConnection` 経由でのみ呼び出し可能にする。

## 変更内容

- `Connection::send_request` / `Connection::send_response` を `pub` -> `pub(crate)` に変更
- `examples/wt_server` を `ServerConnection` 経由に移行
- `crates/tokio-s2n-quic` を `ClientConnection` / `ServerConnection` 経由に移行

## 完了条件

- [x] `Connection::send_request` と `Connection::send_response` が `pub(crate)` になっていること
- [x] `ClientConnection` / `ServerConnection` 経由でのみアクセス可能であること
- [x] `examples/wt_server` が `ServerConnection` を使用するように移行されていること
- [x] `cargo test --workspace` が全て pass すること
- [x] `examples/wt_server` が正常にコンパイルできること

## 関連 issue

- issues/closed/0081-refactor-client-server-wrapper.md