### PR TITLE
0082 Event enum の WebTransport バリアントを WebTransportEvent にネスト化する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,8 @@
   - @voluntas
 - [CHANGE] `Connection::send_request` / `Connection::send_response` を `pub(crate)` に変更し `ClientConnection` / `ServerConnection` 経由でのみ呼び出し可能にする
   - @voluntas
+- [CHANGE] `Event` enum の WebTransport バリアント 14 個を `Event::WebTransport(WebTransportEvent)` にネスト化する
+  - @voluntas
 - [ADD] `VarInt::from_static` / `qpack::Header::from_static` / `frame::GoawayPayload::from_static` の doc に `compile_fail` ブロックを追加し、`const fn` 検査のリグレッションを CI (`cargo test --doc`) で防止する
   - @voluntas
 - [ADD] 構築時検査の `from_static` ↔ `new` 一貫性、`from_validated_parts` ↔ `new` 整合性、`Header::new` ↔ QPACK ラウンドトリップ完全性を検証する PBT を追加する

--- a/issues/closed/0082-refactor-event-enum-nesting.md
+++ b/issues/closed/0082-refactor-event-enum-nesting.md
@@ -2,6 +2,7 @@
 
 - Priority: Low
 - Created: 2026-05-14
+- Completed: 2026-05-26
 - Polished: 2026-05-26
 - Model: deepseek-v4-pro
 - Branch: feature/change-event-enum-nesting
@@ -132,6 +133,15 @@ impl WebTransportEvent {
 - `tests/test_webtransport_draft_connect.rs`: 2 箇所の match パターン変更
 - 影響なし (確認済み): `examples/wt_server` (WebTransport Event を直接 match していない)
 - 影響なし (確認済み): `interop/` (本クレートの `Event` を使用していない)
+
+## 解決方法
+
+1. `src/event.rs` に `WebTransportEvent` enum を新設し、14 バリアントを `WebTransport` プレフィックスなしで移動
+2. `Event` enum に `WebTransport(WebTransportEvent)` バリアントを追加し、元の 14 バリアントを削除
+3. `WebTransportEvent::stream_id()` メソッドを追加し、`Event::stream_id()` から委譲
+4. `src/lib.rs` に `pub use event::WebTransportEvent` を追加
+5. `src/connection/mod.rs` の約 72 箇所のイベント生成・match パターンを全て更新
+6. `tests/test_webtransport_draft_connect.rs` の 2 箇所を更新
 
 ## CHANGES.md エントリ案
 

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -44,7 +44,7 @@ mod server;
 use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 
 use crate::error::{Error, ErrorCode};
-use crate::event::{Event, WtStreamReset};
+use crate::event::{Event, WebTransportEvent, WtStreamReset};
 use crate::limits::Limits;
 use crate::qpack::{
     DecodeOutput, DecoderStream, DecoderStreamReceiver, DynamicDecoder, DynamicEncoder,
@@ -824,10 +824,11 @@ impl Connection {
                 WtSessionState::Established | WtSessionState::Draining => {
                     // Draining 状態でも既存セッションのデータグラム受信は許可する
                     // (draft-ietf-webtrans-http3-15 Section 6)
-                    self.events.push_back(Event::WebTransportDatagram {
-                        session_id,
-                        payload: datagram.payload,
-                    });
+                    self.events
+                        .push_back(Event::WebTransport(WebTransportEvent::Datagram {
+                            session_id,
+                            payload: datagram.payload,
+                        }));
                 }
                 WtSessionState::Pending => {
                     // セッション未確立: バッファリング (Section 4.6)
@@ -1180,11 +1181,12 @@ impl Connection {
                     {
                         self.wt_uni_streams.remove(&stream_id);
                         let _ = session.take_buffered_stream_entry(stream_id);
-                        self.events
-                            .push_back(Event::WebTransportBufferedStreamRejected {
+                        self.events.push_back(Event::WebTransport(
+                            WebTransportEvent::BufferedStreamRejected {
                                 stream_id,
                                 error_code: WtErrorCode::BufferedStreamRejected as u64,
-                            });
+                            },
+                        ));
                     }
                 } else {
                     // WebTransport 単方向ストリーム: データフロー制御 (Section 5.4)
@@ -1201,10 +1203,11 @@ impl Connection {
                         }
                         session.add_received_data(data_len);
                     }
-                    self.events.push_back(Event::WebTransportUniStreamData {
-                        stream_id,
-                        data: data.to_vec(),
-                    });
+                    self.events
+                        .push_back(Event::WebTransport(WebTransportEvent::UniStreamData {
+                            stream_id,
+                            data: data.to_vec(),
+                        }));
                 }
             } else if self.pending_wt_uni_streams.contains_key(&stream_id) {
                 // セッション ID 未確定の WT 単方向ストリーム
@@ -1253,7 +1256,9 @@ impl Connection {
                         session.on_remote_stream_closed(false);
                     }
                     self.events
-                        .push_back(Event::WebTransportUniStreamEnd { stream_id });
+                        .push_back(Event::WebTransport(WebTransportEvent::UniStreamEnd {
+                            stream_id,
+                        }));
                 }
             }
 
@@ -1398,7 +1403,9 @@ impl Connection {
             // WebTransport 単方向ストリームの FIN (初回チャンクに FIN が付いている場合)
             if self.wt_uni_streams.remove(&stream_id).is_some() {
                 self.events
-                    .push_back(Event::WebTransportUniStreamEnd { stream_id });
+                    .push_back(Event::WebTransport(WebTransportEvent::UniStreamEnd {
+                        stream_id,
+                    }));
             }
             self.pending_wt_uni_streams.remove(&stream_id);
         }
@@ -1447,21 +1454,23 @@ impl Connection {
                     Err(()) => {
                         // セッション終了済み: WT_SESSION_GONE で拒否 (Section 6)
                         self.wt_uni_streams.remove(&stream_id);
-                        self.events
-                            .push_back(Event::WebTransportBufferedStreamRejected {
+                        self.events.push_back(Event::WebTransport(
+                            WebTransportEvent::BufferedStreamRejected {
                                 stream_id,
                                 error_code: WtErrorCode::SessionGone as u64,
-                            });
+                            },
+                        ));
                         return Ok(());
                     }
                 };
                 if outcome == AssocOutcome::BufferOverflow {
                     self.wt_uni_streams.remove(&stream_id);
-                    self.events
-                        .push_back(Event::WebTransportBufferedStreamRejected {
+                    self.events.push_back(Event::WebTransport(
+                        WebTransportEvent::BufferedStreamRejected {
                             stream_id,
                             error_code: WtErrorCode::BufferedStreamRejected as u64,
-                        });
+                        },
+                    ));
                     return Ok(());
                 }
 
@@ -1477,11 +1486,12 @@ impl Connection {
                         // バッファ上限超過: WT_BUFFERED_STREAM_REJECTED 相当
                         self.wt_uni_streams.remove(&stream_id);
                         let _ = session.take_buffered_stream_entry(stream_id);
-                        self.events
-                            .push_back(Event::WebTransportBufferedStreamRejected {
+                        self.events.push_back(Event::WebTransport(
+                            WebTransportEvent::BufferedStreamRejected {
                                 stream_id,
                                 error_code: WtErrorCode::BufferedStreamRejected as u64,
-                            });
+                            },
+                        ));
                         return Ok(());
                     }
                     return Ok(());
@@ -1502,10 +1512,11 @@ impl Connection {
                     session.add_received_stream(false);
                 }
 
-                self.events.push_back(Event::WebTransportUniStreamOpen {
-                    stream_id,
-                    session_id,
-                });
+                self.events
+                    .push_back(Event::WebTransport(WebTransportEvent::UniStreamOpen {
+                        stream_id,
+                        session_id,
+                    }));
                 // セッション ID の後にデータがあればイベントで通知
                 if !remaining.is_empty() {
                     // データフロー制御 (Section 5.4)
@@ -1522,10 +1533,11 @@ impl Connection {
                         }
                         session.add_received_data(data_len);
                     }
-                    self.events.push_back(Event::WebTransportUniStreamData {
-                        stream_id,
-                        data: remaining.to_vec(),
-                    });
+                    self.events
+                        .push_back(Event::WebTransport(WebTransportEvent::UniStreamData {
+                            stream_id,
+                            data: remaining.to_vec(),
+                        }));
                 }
                 Ok(())
             }
@@ -1635,11 +1647,12 @@ impl Connection {
                 {
                     self.wt_bidi_streams.remove(&stream_id);
                     let _ = session.take_buffered_stream_entry(stream_id);
-                    self.events
-                        .push_back(Event::WebTransportBufferedStreamRejected {
+                    self.events.push_back(Event::WebTransport(
+                        WebTransportEvent::BufferedStreamRejected {
                             stream_id,
                             error_code: WtErrorCode::BufferedStreamRejected as u64,
-                        });
+                        },
+                    ));
                     return Ok(());
                 }
                 if fin && let Some(session) = self.wt_sessions.get_mut(&session_id) {
@@ -1662,10 +1675,11 @@ impl Connection {
                     }
                     session.add_received_data(data_len);
                 }
-                self.events.push_back(Event::WebTransportBidiStreamData {
-                    stream_id,
-                    data: data.to_vec(),
-                });
+                self.events
+                    .push_back(Event::WebTransport(WebTransportEvent::BidiStreamData {
+                        stream_id,
+                        data: data.to_vec(),
+                    }));
             }
             if fin {
                 self.wt_bidi_streams.remove(&stream_id);
@@ -1674,7 +1688,9 @@ impl Connection {
                     session.on_remote_stream_closed(true);
                 }
                 self.events
-                    .push_back(Event::WebTransportBidiStreamEnd { stream_id });
+                    .push_back(Event::WebTransport(WebTransportEvent::BidiStreamEnd {
+                        stream_id,
+                    }));
             }
             return Ok(());
         }
@@ -1700,7 +1716,9 @@ impl Connection {
                         session.on_remote_stream_closed(true);
                     }
                     self.events
-                        .push_back(Event::WebTransportBidiStreamEnd { stream_id });
+                        .push_back(Event::WebTransport(WebTransportEvent::BidiStreamEnd {
+                            stream_id,
+                        }));
                 }
             }
             self.pending_wt_bidi_streams.remove(&stream_id);
@@ -1800,8 +1818,9 @@ impl Connection {
                         || session.state == WtSessionState::Pending)
                 {
                     session.state = WtSessionState::Draining;
-                    self.events
-                        .push_back(Event::WebTransportSessionDraining { session_id });
+                    self.events.push_back(Event::WebTransport(
+                        WebTransportEvent::SessionDraining { session_id },
+                    ));
                 }
             }
             Capsule::MaxData { .. }
@@ -1816,10 +1835,11 @@ impl Connection {
 
                 if fc_enabled {
                     // フロー制御有効: 上位層に通知して Session::process_capsule で処理
-                    self.events.push_back(Event::WebTransportCapsule {
-                        session_id,
-                        capsule: capsule.clone(),
-                    });
+                    self.events
+                        .push_back(Event::WebTransport(WebTransportEvent::Capsule {
+                            session_id,
+                            capsule: capsule.clone(),
+                        }));
                 }
                 // フロー制御無効時は無視 (Section 5.1)
             }
@@ -2029,13 +2049,14 @@ impl Connection {
                 });
             }
 
-            self.events.push_back(Event::WebTransportSessionClosed {
-                session_id,
-                reset_streams,
-                error_code,
-                close_error_code,
-                close_message,
-            });
+            self.events
+                .push_back(Event::WebTransport(WebTransportEvent::SessionClosed {
+                    session_id,
+                    reset_streams,
+                    error_code,
+                    close_error_code,
+                    close_message,
+                }));
         }
     }
 
@@ -2243,21 +2264,23 @@ impl Connection {
                     Err(()) => {
                         // セッション終了済み: WT_SESSION_GONE で拒否 (Section 6)
                         self.wt_bidi_streams.remove(&stream_id);
-                        self.events
-                            .push_back(Event::WebTransportBufferedStreamRejected {
+                        self.events.push_back(Event::WebTransport(
+                            WebTransportEvent::BufferedStreamRejected {
                                 stream_id,
                                 error_code: WtErrorCode::SessionGone as u64,
-                            });
+                            },
+                        ));
                         return Ok(());
                     }
                 };
                 if outcome == AssocOutcome::BufferOverflow {
                     self.wt_bidi_streams.remove(&stream_id);
-                    self.events
-                        .push_back(Event::WebTransportBufferedStreamRejected {
+                    self.events.push_back(Event::WebTransport(
+                        WebTransportEvent::BufferedStreamRejected {
                             stream_id,
                             error_code: WtErrorCode::BufferedStreamRejected as u64,
-                        });
+                        },
+                    ));
                     return Ok(());
                 }
 
@@ -2272,11 +2295,12 @@ impl Connection {
                     {
                         self.wt_bidi_streams.remove(&stream_id);
                         let _ = session.take_buffered_stream_entry(stream_id);
-                        self.events
-                            .push_back(Event::WebTransportBufferedStreamRejected {
+                        self.events.push_back(Event::WebTransport(
+                            WebTransportEvent::BufferedStreamRejected {
                                 stream_id,
                                 error_code: WtErrorCode::BufferedStreamRejected as u64,
-                            });
+                            },
+                        ));
                         return Ok(());
                     }
                     return Ok(());
@@ -2297,10 +2321,11 @@ impl Connection {
                     session.add_received_stream(true);
                 }
 
-                self.events.push_back(Event::WebTransportBidiStreamOpen {
-                    stream_id,
-                    session_id,
-                });
+                self.events
+                    .push_back(Event::WebTransport(WebTransportEvent::BidiStreamOpen {
+                        stream_id,
+                        session_id,
+                    }));
                 // session_id の後にデータがあればイベントで通知
                 if !payload.is_empty() {
                     // データフロー制御 (Section 5.4)
@@ -2317,10 +2342,11 @@ impl Connection {
                         }
                         session.add_received_data(data_len);
                     }
-                    self.events.push_back(Event::WebTransportBidiStreamData {
-                        stream_id,
-                        data: payload.to_vec(),
-                    });
+                    self.events
+                        .push_back(Event::WebTransport(WebTransportEvent::BidiStreamData {
+                            stream_id,
+                            data: payload.to_vec(),
+                        }));
                 }
                 Ok(())
             }
@@ -2561,8 +2587,9 @@ impl Connection {
                             if let Some(session) = self.wt_sessions.get_mut(&sid) {
                                 session.state = WtSessionState::Draining;
                             }
-                            self.events
-                                .push_back(Event::WebTransportSessionDraining { session_id: sid });
+                            self.events.push_back(Event::WebTransport(
+                                WebTransportEvent::SessionDraining { session_id: sid },
+                            ));
                         }
                     }
                 }
@@ -3017,11 +3044,12 @@ impl Connection {
                         if let Some(stream) = self.streams.get_mut(&stream_id) {
                             stream.set_connect();
                         }
-                        self.events
-                            .push_back(Event::WebTransportSessionEstablished {
+                        self.events.push_back(Event::WebTransport(
+                            WebTransportEvent::SessionEstablished {
                                 session_id: stream_id,
                                 flow_control_enabled: fc_enabled,
-                            });
+                            },
+                        ));
                         // バッファリングされていたストリームの Open / Data / End を順序保って配送
                         // フロー制御チェック: ストリーム数 + データ量の両方を FC 対象とする
                         // (draft-ietf-webtrans-http3-15 Section 4.6, 5.4, 5.6)
@@ -3045,15 +3073,15 @@ impl Connection {
                             session.associate_stream(buffered_stream_id);
                             // Open
                             buffered_events.push(if is_bidi {
-                                Event::WebTransportBidiStreamOpen {
+                                Event::WebTransport(WebTransportEvent::BidiStreamOpen {
                                     stream_id: buffered_stream_id,
                                     session_id: stream_id,
-                                }
+                                })
                             } else {
-                                Event::WebTransportUniStreamOpen {
+                                Event::WebTransport(WebTransportEvent::UniStreamOpen {
                                     stream_id: buffered_stream_id,
                                     session_id: stream_id,
-                                }
+                                })
                             });
                             // Data
                             if !entry_data.is_empty() {
@@ -3064,15 +3092,15 @@ impl Connection {
                                 }
                                 session.add_received_data(data_len);
                                 buffered_events.push(if is_bidi {
-                                    Event::WebTransportBidiStreamData {
+                                    Event::WebTransport(WebTransportEvent::BidiStreamData {
                                         stream_id: buffered_stream_id,
                                         data: entry_data,
-                                    }
+                                    })
                                 } else {
-                                    Event::WebTransportUniStreamData {
+                                    Event::WebTransport(WebTransportEvent::UniStreamData {
                                         stream_id: buffered_stream_id,
                                         data: entry_data,
-                                    }
+                                    })
                                 });
                             }
                             // End
@@ -3080,13 +3108,13 @@ impl Connection {
                                 session.on_remote_stream_closed(is_bidi);
                                 closed_buffered.push((buffered_stream_id, is_bidi));
                                 buffered_events.push(if is_bidi {
-                                    Event::WebTransportBidiStreamEnd {
+                                    Event::WebTransport(WebTransportEvent::BidiStreamEnd {
                                         stream_id: buffered_stream_id,
-                                    }
+                                    })
                                 } else {
-                                    Event::WebTransportUniStreamEnd {
+                                    Event::WebTransport(WebTransportEvent::UniStreamEnd {
                                         stream_id: buffered_stream_id,
-                                    }
+                                    })
                                 });
                             }
                         }
@@ -3104,10 +3132,12 @@ impl Connection {
                             // バッファリングされていたデータグラムを配送 (Section 4.6)
                             let buffered_datagrams = session.take_buffered_datagrams();
                             for payload in buffered_datagrams {
-                                self.events.push_back(Event::WebTransportDatagram {
-                                    session_id: stream_id,
-                                    payload,
-                                });
+                                self.events.push_back(Event::WebTransport(
+                                    WebTransportEvent::Datagram {
+                                        session_id: stream_id,
+                                        payload,
+                                    },
+                                ));
                             }
                         }
                     }
@@ -3179,7 +3209,7 @@ impl Connection {
 
     /// WebTransport セッションの受信データ消費を通知する
     ///
-    /// アプリケーション層が `WebTransportBidiStreamData` / `WebTransportUniStreamData`
+    /// アプリケーション層が `WebTransportEvent::BidiStreamData` / `WebTransportEvent::UniStreamData`
     /// イベントのデータを処理した後に呼ぶ。消費量に基づいて WT_MAX_DATA の
     /// ウィンドウ更新を判定し、必要に応じてカプセルを生成する。
     /// (draft-ietf-webtrans-http3-15 Section 5.6)
@@ -3610,10 +3640,10 @@ impl Connection {
 
             session.state = WtSessionState::Established;
             self.events
-                .push_back(Event::WebTransportSessionEstablished {
+                .push_back(Event::WebTransport(WebTransportEvent::SessionEstablished {
                     session_id: stream_id,
                     flow_control_enabled: fc_enabled_server,
-                });
+                }));
             // バッファリングされていたストリームの Open / Data / End を順序保って配送
             // フロー制御チェック: ストリーム数 + データ量の両方を FC 対象とする
             // (draft-ietf-webtrans-http3-15 Section 4.6, 5.4, 5.6)
@@ -3634,15 +3664,15 @@ impl Connection {
                 session.add_received_stream(is_bidi);
                 session.associate_stream(buffered_stream_id);
                 buffered_events.push(if is_bidi {
-                    Event::WebTransportBidiStreamOpen {
+                    Event::WebTransport(WebTransportEvent::BidiStreamOpen {
                         stream_id: buffered_stream_id,
                         session_id: stream_id,
-                    }
+                    })
                 } else {
-                    Event::WebTransportUniStreamOpen {
+                    Event::WebTransport(WebTransportEvent::UniStreamOpen {
                         stream_id: buffered_stream_id,
                         session_id: stream_id,
-                    }
+                    })
                 });
                 if !entry_data.is_empty() {
                     let data_len = entry_data.len() as u64;
@@ -3652,28 +3682,28 @@ impl Connection {
                     }
                     session.add_received_data(data_len);
                     buffered_events.push(if is_bidi {
-                        Event::WebTransportBidiStreamData {
+                        Event::WebTransport(WebTransportEvent::BidiStreamData {
                             stream_id: buffered_stream_id,
                             data: entry_data,
-                        }
+                        })
                     } else {
-                        Event::WebTransportUniStreamData {
+                        Event::WebTransport(WebTransportEvent::UniStreamData {
                             stream_id: buffered_stream_id,
                             data: entry_data,
-                        }
+                        })
                     });
                 }
                 if entry_fin {
                     session.on_remote_stream_closed(is_bidi);
                     closed_buffered.push((buffered_stream_id, is_bidi));
                     buffered_events.push(if is_bidi {
-                        Event::WebTransportBidiStreamEnd {
+                        Event::WebTransport(WebTransportEvent::BidiStreamEnd {
                             stream_id: buffered_stream_id,
-                        }
+                        })
                     } else {
-                        Event::WebTransportUniStreamEnd {
+                        Event::WebTransport(WebTransportEvent::UniStreamEnd {
                             stream_id: buffered_stream_id,
-                        }
+                        })
                     });
                 }
             }
@@ -3691,10 +3721,11 @@ impl Connection {
                 // バッファリングされていたデータグラムを配送 (Section 4.6)
                 let buffered_datagrams = session.take_buffered_datagrams();
                 for payload in buffered_datagrams {
-                    self.events.push_back(Event::WebTransportDatagram {
-                        session_id: stream_id,
-                        payload,
-                    });
+                    self.events
+                        .push_back(Event::WebTransport(WebTransportEvent::Datagram {
+                            session_id: stream_id,
+                            payload,
+                        }));
                 }
             }
         }
@@ -3788,7 +3819,7 @@ impl Connection {
     /// `final_size` は RFC 9000 Section 19.4 で定義される RESET_STREAM の Final Size。
     /// `RESET_STREAM_AT` (draft-ietf-quic-reliable-stream-reset) で運ばれた reliable size
     /// 以上の値であり、QUIC 層から渡される。WebTransport データストリームについては
-    /// `Event::WebTransportStreamReset::final_size` として上位層へ伝達される。
+    /// `WebTransportEvent::StreamReset` の `final_size` として上位層へ伝達される。
     pub fn stream_reset(
         &mut self,
         stream_id: u64,
@@ -3835,12 +3866,13 @@ impl Connection {
             if let Some(session) = self.wt_sessions.get_mut(&session_id) {
                 session.disassociate_stream(stream_id);
             }
-            self.events.push_back(Event::WebTransportStreamReset {
-                session_id,
-                stream_id,
-                error_code,
-                final_size,
-            });
+            self.events
+                .push_back(Event::WebTransport(WebTransportEvent::StreamReset {
+                    session_id,
+                    stream_id,
+                    error_code,
+                    final_size,
+                }));
         } else {
             // 非 WebTransport ストリーム: 汎用イベントを発行
             self.events.push_back(Event::StreamReset {
@@ -3882,11 +3914,12 @@ impl Connection {
             .copied()
             .or_else(|| self.wt_bidi_streams.get(&stream_id).copied())
         {
-            self.events.push_back(Event::WebTransportStreamStopSending {
-                session_id,
-                stream_id,
-                error_code,
-            });
+            self.events
+                .push_back(Event::WebTransport(WebTransportEvent::StreamStopSending {
+                    session_id,
+                    stream_id,
+                    error_code,
+                }));
         } else {
             self.events.push_back(Event::StopSending {
                 stream_id,
@@ -4309,24 +4342,24 @@ mod tests {
         conn.feed_stream(2, &[0x40, 0x54, 0x04, 0xAA, 0xBB], false)
             .unwrap();
 
-        // WebTransportUniStreamOpen イベント
+        // WebTransportEvent::UniStreamOpen イベント
         let event = conn.poll_event().unwrap().unwrap();
         assert!(matches!(
             event,
-            Event::WebTransportUniStreamOpen {
+            Event::WebTransport(WebTransportEvent::UniStreamOpen {
                 stream_id: 2,
                 session_id: 4,
-            }
+            })
         ));
 
-        // WebTransportUniStreamData イベント
+        // WebTransportEvent::UniStreamData イベント
         let event = conn.poll_event().unwrap().unwrap();
         assert!(matches!(
             event,
-            Event::WebTransportUniStreamData {
+            Event::WebTransport(WebTransportEvent::UniStreamData {
                 stream_id: 2,
                 ref data,
-            } if data == &[0xAA, 0xBB]
+            }) if data == &[0xAA, 0xBB]
         ));
     }
 
@@ -4337,17 +4370,20 @@ mod tests {
         // 初回: ストリームタイプ + セッション ID のみ
         conn.feed_stream(2, &[0x40, 0x54, 0x04], false).unwrap();
         let event = conn.poll_event().unwrap().unwrap();
-        assert!(matches!(event, Event::WebTransportUniStreamOpen { .. }));
+        assert!(matches!(
+            event,
+            Event::WebTransport(WebTransportEvent::UniStreamOpen { .. })
+        ));
 
         // 後続データ
         conn.feed_stream(2, &[0xCC, 0xDD], false).unwrap();
         let event = conn.poll_event().unwrap().unwrap();
         assert!(matches!(
             event,
-            Event::WebTransportUniStreamData {
+            Event::WebTransport(WebTransportEvent::UniStreamData {
                 stream_id: 2,
                 ref data,
-            } if data == &[0xCC, 0xDD]
+            }) if data == &[0xCC, 0xDD]
         ));
     }
 
@@ -4362,7 +4398,7 @@ mod tests {
         let event = conn.poll_event().unwrap().unwrap();
         assert!(matches!(
             event,
-            Event::WebTransportUniStreamEnd { stream_id: 2 }
+            Event::WebTransport(WebTransportEvent::UniStreamEnd { stream_id: 2 })
         ));
     }
 
@@ -4393,10 +4429,10 @@ mod tests {
         let event = conn.poll_event().unwrap().unwrap();
         assert!(matches!(
             event,
-            Event::WebTransportUniStreamOpen {
+            Event::WebTransport(WebTransportEvent::UniStreamOpen {
                 stream_id: 2,
                 session_id: 4,
-            }
+            })
         ));
     }
 
@@ -4413,10 +4449,10 @@ mod tests {
         let event = conn.poll_event().unwrap().unwrap();
         assert!(matches!(
             event,
-            Event::WebTransportUniStreamOpen {
+            Event::WebTransport(WebTransportEvent::UniStreamOpen {
                 stream_id: 2,
                 session_id: 4,
-            }
+            })
         ));
     }
 
@@ -4468,19 +4504,19 @@ mod tests {
         let event = conn.poll_event().unwrap().unwrap();
         assert!(matches!(
             event,
-            Event::WebTransportBidiStreamOpen {
+            Event::WebTransport(WebTransportEvent::BidiStreamOpen {
                 stream_id: 1,
                 session_id: 0,
-            }
+            })
         ));
 
         let event = conn.poll_event().unwrap().unwrap();
         assert!(matches!(
             event,
-            Event::WebTransportBidiStreamData {
+            Event::WebTransport(WebTransportEvent::BidiStreamData {
                 stream_id: 1,
                 ref data,
-            } if data == &[0xAA, 0xBB]
+            }) if data == &[0xAA, 0xBB]
         ));
     }
 
@@ -4491,16 +4527,19 @@ mod tests {
 
         conn.feed_stream(1, &[0x40, 0x41, 0x00], false).unwrap();
         let event = conn.poll_event().unwrap().unwrap();
-        assert!(matches!(event, Event::WebTransportBidiStreamOpen { .. }));
+        assert!(matches!(
+            event,
+            Event::WebTransport(WebTransportEvent::BidiStreamOpen { .. })
+        ));
 
         conn.feed_stream(1, &[0xCC, 0xDD], false).unwrap();
         let event = conn.poll_event().unwrap().unwrap();
         assert!(matches!(
             event,
-            Event::WebTransportBidiStreamData {
+            Event::WebTransport(WebTransportEvent::BidiStreamData {
                 stream_id: 1,
                 ref data,
-            } if data == &[0xCC, 0xDD]
+            }) if data == &[0xCC, 0xDD]
         ));
     }
 
@@ -4515,7 +4554,7 @@ mod tests {
         let event = conn.poll_event().unwrap().unwrap();
         assert!(matches!(
             event,
-            Event::WebTransportBidiStreamEnd { stream_id: 1 }
+            Event::WebTransport(WebTransportEvent::BidiStreamEnd { stream_id: 1 })
         ));
     }
 
@@ -4566,10 +4605,10 @@ mod tests {
         let event = conn.poll_event().unwrap().unwrap();
         assert!(matches!(
             event,
-            Event::WebTransportBidiStreamOpen {
+            Event::WebTransport(WebTransportEvent::BidiStreamOpen {
                 stream_id: 1,
                 session_id: 4,
-            }
+            })
         ));
     }
 
@@ -4587,10 +4626,10 @@ mod tests {
         let event = conn.poll_event().unwrap().unwrap();
         assert!(matches!(
             event,
-            Event::WebTransportBidiStreamOpen {
+            Event::WebTransport(WebTransportEvent::BidiStreamOpen {
                 stream_id: 1,
                 session_id: 4,
-            }
+            })
         ));
     }
 
@@ -4603,10 +4642,10 @@ mod tests {
         let event = conn.poll_event().unwrap().unwrap();
         assert!(matches!(
             event,
-            Event::WebTransportBidiStreamOpen {
+            Event::WebTransport(WebTransportEvent::BidiStreamOpen {
                 stream_id: 1,
                 session_id: 4,
-            }
+            })
         ));
     }
 
@@ -4629,19 +4668,19 @@ mod tests {
         let event = conn.poll_event().unwrap().unwrap();
         assert!(matches!(
             event,
-            Event::WebTransportBidiStreamOpen {
+            Event::WebTransport(WebTransportEvent::BidiStreamOpen {
                 stream_id: 0,
                 session_id: 0,
-            }
+            })
         ));
 
         let event = conn.poll_event().unwrap().unwrap();
         assert!(matches!(
             event,
-            Event::WebTransportBidiStreamData {
+            Event::WebTransport(WebTransportEvent::BidiStreamData {
                 stream_id: 0,
                 ref data,
-            } if data == &[0xAA, 0xBB]
+            }) if data == &[0xAA, 0xBB]
         ));
     }
 
@@ -4674,10 +4713,10 @@ mod tests {
         let event = conn.poll_event().unwrap().unwrap();
         assert!(matches!(
             event,
-            Event::WebTransportBidiStreamOpen {
+            Event::WebTransport(WebTransportEvent::BidiStreamOpen {
                 stream_id: 0,
                 session_id: 0,
-            }
+            })
         ));
     }
 
@@ -4714,10 +4753,10 @@ mod tests {
         let event = conn.poll_event().unwrap().unwrap();
         assert!(matches!(
             event,
-            Event::WebTransportBidiStreamOpen {
+            Event::WebTransport(WebTransportEvent::BidiStreamOpen {
                 stream_id: 0,
                 session_id: 0,
-            }
+            })
         ));
     }
 
@@ -5127,11 +5166,11 @@ mod tests {
         // クライアントが 200 OK を受信
         client.feed_stream(stream_id, &resp_data, false).unwrap();
 
-        // WebTransportSessionEstablished イベントが発火すること
+        // WebTransportEvent::SessionEstablished イベントが発火すること
         let events = client.drain_events().unwrap();
         assert!(events.iter().any(|e| matches!(
             e,
-            Event::WebTransportSessionEstablished { session_id, .. } if *session_id == stream_id
+            Event::WebTransport(WebTransportEvent::SessionEstablished { session_id, .. }) if *session_id == stream_id
         )));
 
         // セッションが Established 状態であること
@@ -5269,10 +5308,10 @@ mod tests {
         // CONNECT stream を FIN で閉じる (セッション終了)
         client.feed_stream(stream_id, &[], true).unwrap();
 
-        // WebTransportSessionClosed イベントが発火すること
+        // WebTransportEvent::SessionClosed イベントが発火すること
         let events = client.drain_events().unwrap();
         let closed_event = events.iter().find(|e| {
-            matches!(e, Event::WebTransportSessionClosed { session_id: sid, .. } if *sid == session_id)
+            matches!(e, Event::WebTransport(WebTransportEvent::SessionClosed { session_id: sid, .. }) if *sid == session_id)
         });
         assert!(closed_event.is_some());
 
@@ -5309,11 +5348,11 @@ mod tests {
         // CONNECT stream を RESET_STREAM で閉じる
         client.stream_reset(stream_id, 0, 0).unwrap();
 
-        // WebTransportSessionClosed イベントが発火すること
+        // WebTransportEvent::SessionClosed イベントが発火すること
         let events = client.drain_events().unwrap();
         assert!(events.iter().any(|e| matches!(
             e,
-            Event::WebTransportSessionClosed { session_id: sid, .. } if *sid == stream_id
+            Event::WebTransport(WebTransportEvent::SessionClosed { session_id: sid, .. }) if *sid == stream_id
         )));
 
         assert_eq!(client.wt_sessions[&stream_id].state, WtSessionState::Closed);
@@ -5396,10 +5435,10 @@ mod tests {
         let event = client.poll_event().unwrap().unwrap();
         assert!(matches!(
             event,
-            Event::WebTransportBufferedStreamRejected {
+            Event::WebTransport(WebTransportEvent::BufferedStreamRejected {
                 stream_id: 3,
                 error_code,
-            } if error_code == WtErrorCode::SessionGone as u64
+            }) if error_code == WtErrorCode::SessionGone as u64
         ));
     }
 
@@ -5441,7 +5480,10 @@ mod tests {
             last = Some(ev);
         }
         match last {
-            Some(Event::WebTransportBufferedStreamRejected { stream_id, .. }) => {
+            Some(Event::WebTransport(WebTransportEvent::BufferedStreamRejected {
+                stream_id,
+                ..
+            })) => {
                 assert_eq!(stream_id, overflow_stream_id);
             }
             other => panic!("expected BufferedStreamRejected, got {other:?}"),
@@ -5484,7 +5526,7 @@ mod tests {
     #[test]
     fn test_stream_reset_propagates_to_wt_uni_data_stream() {
         // 既知 WebTransport セッションに属する単方向データストリームの RESET_STREAM は
-        // セッションを終了させず、WebTransportStreamReset イベントとして通知する
+        // セッションを終了させず、WebTransportEvent::StreamReset イベントとして通知する
         // (draft-ietf-webtrans-http3-15 Section 4.4)
         let mut conn = make_server_with_established_wt_session(4);
         // セッション 4 に紐づく WT uni stream 2 を作成
@@ -5498,12 +5540,12 @@ mod tests {
         let event = conn.poll_event().unwrap().unwrap();
         assert!(matches!(
             event,
-            Event::WebTransportStreamReset {
+            Event::WebTransport(WebTransportEvent::StreamReset {
                 session_id: 4,
                 stream_id: 2,
                 error_code: 0x42,
                 final_size: 3,
-            }
+            })
         ));
         // セッションは終了していないこと
         assert!(conn.wt_sessions.contains_key(&4));
@@ -5531,11 +5573,11 @@ mod tests {
 
         conn.stream_reset(0, 0x99, 0).unwrap();
 
-        // WebTransportSessionClosed が発行される
+        // WebTransportEvent::SessionClosed が発行される
         let event = conn.poll_event().unwrap().unwrap();
         assert!(matches!(
             event,
-            Event::WebTransportSessionClosed { session_id: 0, .. }
+            Event::WebTransport(WebTransportEvent::SessionClosed { session_id: 0, .. })
         ));
         assert_eq!(
             conn.wt_sessions.get(&0).unwrap().state,
@@ -5546,7 +5588,7 @@ mod tests {
     #[test]
     fn test_stop_sending_propagates_to_wt_bidi_data_stream() {
         // 既知 WebTransport セッションに属する双方向データストリームの STOP_SENDING は
-        // セッションを終了させず WebTransportStreamStopSending として通知する
+        // セッションを終了させず WebTransportEvent::StreamStopSending として通知する
         let mut conn = make_server_with_established_wt_session(4);
         // signal value 0x41 + session_id = 4 で WT bidi stream 8 を作成
         conn.feed_stream(8, &[0x40, 0x41, 0x04], false).unwrap();
@@ -5557,11 +5599,11 @@ mod tests {
         let event = conn.poll_event().unwrap().unwrap();
         assert!(matches!(
             event,
-            Event::WebTransportStreamStopSending {
+            Event::WebTransport(WebTransportEvent::StreamStopSending {
                 session_id: 4,
                 stream_id: 8,
                 error_code: 0x55,
-            }
+            })
         ));
         assert!(matches!(
             conn.wt_sessions.get(&4).unwrap().state,
@@ -5626,13 +5668,13 @@ mod tests {
         conn.stream_reset(0, 0x99, 0).unwrap();
 
         let event = conn.poll_event().unwrap().unwrap();
-        let Event::WebTransportSessionClosed {
+        let Event::WebTransport(WebTransportEvent::SessionClosed {
             session_id,
             reset_streams,
             ..
-        } = event
+        }) = event
         else {
-            panic!("WebTransportSessionClosed が発火していない");
+            panic!("WebTransportEvent::SessionClosed が発火していない");
         };
         assert_eq!(session_id, 0);
         assert_eq!(reset_streams.len(), 2);
@@ -5648,7 +5690,7 @@ mod tests {
     #[test]
     fn test_wt_data_stream_reset_event_carries_final_size() {
         // WT データストリームの RESET_STREAM 受信時、final_size が
-        // WebTransportStreamReset イベントに反映される
+        // WebTransportEvent::StreamReset イベントに反映される
         let mut conn = make_server_with_established_wt_session(4);
         conn.feed_stream(2, &[0x40, 0x54, 0x04], false).unwrap();
         while conn.poll_event().unwrap().is_some() {}
@@ -5656,14 +5698,14 @@ mod tests {
         conn.stream_reset(2, 0xab, 42).unwrap();
 
         let event = conn.poll_event().unwrap().unwrap();
-        let Event::WebTransportStreamReset {
+        let Event::WebTransport(WebTransportEvent::StreamReset {
             session_id,
             stream_id,
             error_code,
             final_size,
-        } = event
+        }) = event
         else {
-            panic!("WebTransportStreamReset が発火していない: {event:?}");
+            panic!("WebTransportEvent::StreamReset が発火していない: {event:?}");
         };
         assert_eq!(session_id, 4);
         assert_eq!(stream_id, 2);
@@ -5705,7 +5747,7 @@ mod tests {
         let event = conn.poll_event().unwrap().unwrap();
         assert!(matches!(
             event,
-            Event::WebTransportSessionDraining { session_id: 0 }
+            Event::WebTransport(WebTransportEvent::SessionDraining { session_id: 0 })
         ));
         // send_datagram は WtSessionDraining を返す
         let err = conn.send_datagram(0, b"hello").unwrap_err();

--- a/src/event.rs
+++ b/src/event.rs
@@ -22,6 +22,189 @@ pub struct WtStreamReset {
     pub reliable_size: u64,
 }
 
+/// WebTransport イベント
+///
+/// WebTransport 関連のイベントを集約した enum。
+/// `Event::WebTransport(WebTransportEvent)` として使用する。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WebTransportEvent {
+    /// 双方向ストリーム開始
+    /// (draft-ietf-webtrans-http3-15 Section 4.3)
+    BidiStreamOpen {
+        /// QUIC ストリーム ID
+        stream_id: u64,
+        /// WebTransport セッション ID
+        session_id: u64,
+    },
+    /// 双方向ストリームデータ受信
+    BidiStreamData {
+        /// QUIC ストリーム ID
+        stream_id: u64,
+        /// データ
+        data: Vec<u8>,
+    },
+    /// 双方向ストリーム終了 (FIN 受信)
+    BidiStreamEnd {
+        /// QUIC ストリーム ID
+        stream_id: u64,
+    },
+    /// 単方向ストリーム開始
+    /// (draft-ietf-webtrans-http3-15 Section 4.2)
+    UniStreamOpen {
+        /// QUIC ストリーム ID
+        stream_id: u64,
+        /// WebTransport セッション ID
+        session_id: u64,
+    },
+    /// 単方向ストリームデータ受信
+    UniStreamData {
+        /// QUIC ストリーム ID
+        stream_id: u64,
+        /// データ
+        data: Vec<u8>,
+    },
+    /// 単方向ストリーム終了 (FIN 受信)
+    UniStreamEnd {
+        /// QUIC ストリーム ID
+        stream_id: u64,
+    },
+    /// セッション終了
+    /// (draft-ietf-webtrans-http3-15 Section 6)
+    ///
+    /// セッションが終了した。`reset_streams` に含まれる全ストリームに対して
+    /// `error_code` を使用して `RESET_STREAM_AT` (reliable_size を伴う) と
+    /// STOP_SENDING を送信すること。`reset_stream_at` transport parameter が
+    /// ネゴシエートされていない経路では通常の `RESET_STREAM` にフォールバックする。
+    SessionClosed {
+        /// セッション ID (CONNECT ストリーム ID)
+        session_id: u64,
+        /// リセットすべきストリーム情報の一覧 (stream_id と reliable_size)
+        reset_streams: Vec<WtStreamReset>,
+        /// RESET_STREAM / STOP_SENDING に使用するエラーコード
+        /// (WT_SESSION_GONE / WT_ALPN_ERROR 等)
+        error_code: u64,
+        /// WT_CLOSE_SESSION カプセルのアプリケーションエラーコード
+        /// (draft-ietf-webtrans-http3-15 Section 6)
+        /// WT_CLOSE_SESSION なしの終了 (FIN / RESET_STREAM) の場合は 0
+        close_error_code: u32,
+        /// WT_CLOSE_SESSION カプセルのエラーメッセージ
+        /// (draft-ietf-webtrans-http3-15 Section 6)
+        /// WT_CLOSE_SESSION なしの終了の場合は空文字列
+        close_message: String,
+    },
+    /// セッション確立
+    /// (draft-ietf-webtrans-http3-15 Section 3)
+    ///
+    /// CONNECT ストリームに 200 OK が返された。
+    /// バッファリングされていたストリーム/データグラムがあれば配送される。
+    SessionEstablished {
+        /// セッション ID (CONNECT ストリーム ID)
+        session_id: u64,
+        /// フロー制御が有効かどうか (Section 5.1)
+        ///
+        /// 両端が SETTINGS でフロー制御を宣言した場合に `true`。
+        /// `true` の場合、接続層がストリーム数/データ量の超過を検知し、
+        /// WT_MAX_STREAMS / WT_MAX_DATA カプセルの生成を行う。
+        flow_control_enabled: bool,
+    },
+    /// セッション draining
+    /// (draft-ietf-webtrans-http3-15 Section 4.7)
+    ///
+    /// WT_DRAIN_SESSION カプセルを受信した。
+    /// Section 4.7 では MAY continue だが、本実装はアプリ層の早期終了を促すため
+    /// 新規ストリームやデータグラムの送信を拒否する。
+    /// セッションは即座に終了しないが、グレースフルシャットダウンを開始する。
+    SessionDraining {
+        /// セッション ID (CONNECT ストリーム ID)
+        session_id: u64,
+    },
+    /// フロー制御カプセル受信
+    /// (draft-ietf-webtrans-http3-15 Section 5.6)
+    ///
+    /// CONNECT ストリーム上でフロー制御カプセルを受信した。
+    /// 上位層は `webtransport::Session::process_capsule` に渡すこと。
+    Capsule {
+        /// WebTransport セッション ID
+        session_id: u64,
+        /// 受信した Capsule
+        capsule: crate::webtransport::Capsule,
+    },
+    /// データグラム受信
+    /// (draft-ietf-webtrans-http3-15 Section 4.5)
+    ///
+    /// QUIC DATAGRAM フレームから WebTransport データグラムを受信した。
+    Datagram {
+        /// WebTransport セッション ID
+        session_id: u64,
+        /// データグラムペイロード
+        payload: Vec<u8>,
+    },
+    /// データストリームのリセット受信
+    /// (draft-ietf-webtrans-http3-15 Section 4.4)
+    ///
+    /// WebTransport セッションに属するデータストリームに対して RESET_STREAM を
+    /// 受信した。アプリケーション層はセッション ID と application error code を
+    /// 元にアプリへ通知すること。
+    StreamReset {
+        /// WebTransport セッション ID
+        session_id: u64,
+        /// QUIC ストリーム ID
+        stream_id: u64,
+        /// QUIC application error code
+        error_code: u64,
+        /// QUIC RESET_STREAM の final size (RFC 9000 Section 19.4)
+        ///
+        /// `reset_stream_at` transport parameter がネゴシエートされている場合、
+        /// この値は stream header (stream type / signal value + session_id varint)
+        /// のバイト数以上であることが期待される (draft-ietf-webtrans-http3-15
+        /// Section 4.4)。
+        final_size: u64,
+    },
+    /// データストリームへの STOP_SENDING 受信
+    /// (draft-ietf-webtrans-http3-15 Section 4.4)
+    StreamStopSending {
+        /// WebTransport セッション ID
+        session_id: u64,
+        /// QUIC ストリーム ID
+        stream_id: u64,
+        /// QUIC application error code
+        error_code: u64,
+    },
+    /// バッファリング拒否
+    /// (draft-ietf-webtrans-http3-15 Section 4.6)
+    ///
+    /// バッファリング上限を超えたため、`error_code` を使用して
+    /// RESET_STREAM / STOP_SENDING を送信すること。
+    BufferedStreamRejected {
+        /// 拒否されたストリーム ID
+        stream_id: u64,
+        /// RESET_STREAM / STOP_SENDING に使用するエラーコード (WT_BUFFERED_STREAM_REJECTED)
+        error_code: u64,
+    },
+}
+
+impl WebTransportEvent {
+    /// ストリーム ID を取得 (存在する場合)
+    pub fn stream_id(&self) -> Option<u64> {
+        match self {
+            Self::BidiStreamOpen { stream_id, .. }
+            | Self::BidiStreamData { stream_id, .. }
+            | Self::BidiStreamEnd { stream_id }
+            | Self::UniStreamOpen { stream_id, .. }
+            | Self::UniStreamData { stream_id, .. }
+            | Self::UniStreamEnd { stream_id }
+            | Self::StreamReset { stream_id, .. }
+            | Self::StreamStopSending { stream_id, .. }
+            | Self::BufferedStreamRejected { stream_id, .. } => Some(*stream_id),
+            Self::SessionClosed { session_id, .. }
+            | Self::SessionEstablished { session_id, .. }
+            | Self::SessionDraining { session_id }
+            | Self::Capsule { session_id, .. }
+            | Self::Datagram { session_id, .. } => Some(*session_id),
+        }
+    }
+}
+
 /// HTTP/3 イベント
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Event {
@@ -85,159 +268,8 @@ pub enum Event {
         /// サーバー受信なら push ID。
         id: VarInt,
     },
-    /// WebTransport 双方向ストリーム開始
-    /// (draft-ietf-webtrans-http3-15 Section 4.3)
-    WebTransportBidiStreamOpen {
-        /// QUIC ストリーム ID
-        stream_id: u64,
-        /// WebTransport セッション ID
-        session_id: u64,
-    },
-    /// WebTransport 双方向ストリームデータ受信
-    WebTransportBidiStreamData {
-        /// QUIC ストリーム ID
-        stream_id: u64,
-        /// データ
-        data: Vec<u8>,
-    },
-    /// WebTransport 双方向ストリーム終了 (FIN 受信)
-    WebTransportBidiStreamEnd {
-        /// QUIC ストリーム ID
-        stream_id: u64,
-    },
-    /// WebTransport 単方向ストリーム開始
-    /// (draft-ietf-webtrans-http3-15 Section 4.2)
-    WebTransportUniStreamOpen {
-        /// QUIC ストリーム ID
-        stream_id: u64,
-        /// WebTransport セッション ID
-        session_id: u64,
-    },
-    /// WebTransport 単方向ストリームデータ受信
-    WebTransportUniStreamData {
-        /// QUIC ストリーム ID
-        stream_id: u64,
-        /// データ
-        data: Vec<u8>,
-    },
-    /// WebTransport 単方向ストリーム終了 (FIN 受信)
-    WebTransportUniStreamEnd {
-        /// QUIC ストリーム ID
-        stream_id: u64,
-    },
-    /// WebTransport セッション終了
-    /// (draft-ietf-webtrans-http3-15 Section 6)
-    ///
-    /// セッションが終了した。`reset_streams` に含まれる全ストリームに対して
-    /// `error_code` を使用して `RESET_STREAM_AT` (reliable_size を伴う) と
-    /// STOP_SENDING を送信すること。`reset_stream_at` transport parameter が
-    /// ネゴシエートされていない経路では通常の `RESET_STREAM` にフォールバックする。
-    WebTransportSessionClosed {
-        /// セッション ID (CONNECT ストリーム ID)
-        session_id: u64,
-        /// リセットすべきストリーム情報の一覧 (stream_id と reliable_size)
-        reset_streams: Vec<WtStreamReset>,
-        /// RESET_STREAM / STOP_SENDING に使用するエラーコード
-        /// (WT_SESSION_GONE / WT_ALPN_ERROR 等)
-        error_code: u64,
-        /// WT_CLOSE_SESSION カプセルのアプリケーションエラーコード
-        /// (draft-ietf-webtrans-http3-15 Section 6)
-        /// WT_CLOSE_SESSION なしの終了 (FIN / RESET_STREAM) の場合は 0
-        close_error_code: u32,
-        /// WT_CLOSE_SESSION カプセルのエラーメッセージ
-        /// (draft-ietf-webtrans-http3-15 Section 6)
-        /// WT_CLOSE_SESSION なしの終了の場合は空文字列
-        close_message: String,
-    },
-    /// WebTransport セッション確立
-    /// (draft-ietf-webtrans-http3-15 Section 3)
-    ///
-    /// CONNECT ストリームに 200 OK が返された。
-    /// バッファリングされていたストリーム/データグラムがあれば配送される。
-    WebTransportSessionEstablished {
-        /// セッション ID (CONNECT ストリーム ID)
-        session_id: u64,
-        /// フロー制御が有効かどうか (Section 5.1)
-        ///
-        /// 両端が SETTINGS でフロー制御を宣言した場合に `true`。
-        /// `true` の場合、接続層がストリーム数/データ量の超過を検知し、
-        /// WT_MAX_STREAMS / WT_MAX_DATA カプセルの生成を行う。
-        flow_control_enabled: bool,
-    },
-    /// WebTransport セッション draining
-    /// (draft-ietf-webtrans-http3-15 Section 4.7)
-    ///
-    /// WT_DRAIN_SESSION カプセルを受信した。
-    /// Section 4.7 では MAY continue だが、本実装はアプリ層の早期終了を促すため
-    /// 新規ストリームやデータグラムの送信を拒否する。
-    /// セッションは即座に終了しないが、グレースフルシャットダウンを開始する。
-    WebTransportSessionDraining {
-        /// セッション ID (CONNECT ストリーム ID)
-        session_id: u64,
-    },
-    /// WebTransport フロー制御カプセル受信
-    /// (draft-ietf-webtrans-http3-15 Section 5.6)
-    ///
-    /// CONNECT ストリーム上でフロー制御カプセルを受信した。
-    /// 上位層は `webtransport::Session::process_capsule` に渡すこと。
-    WebTransportCapsule {
-        /// WebTransport セッション ID
-        session_id: u64,
-        /// 受信した Capsule
-        capsule: crate::webtransport::Capsule,
-    },
-    /// WebTransport データグラム受信
-    /// (draft-ietf-webtrans-http3-15 Section 4.5)
-    ///
-    /// QUIC DATAGRAM フレームから WebTransport データグラムを受信した。
-    WebTransportDatagram {
-        /// WebTransport セッション ID
-        session_id: u64,
-        /// データグラムペイロード
-        payload: Vec<u8>,
-    },
-    /// WebTransport データストリームのリセット受信
-    /// (draft-ietf-webtrans-http3-15 Section 4.4)
-    ///
-    /// WebTransport セッションに属するデータストリームに対して RESET_STREAM を
-    /// 受信した。アプリケーション層はセッション ID と application error code を
-    /// 元にアプリへ通知すること。
-    WebTransportStreamReset {
-        /// WebTransport セッション ID
-        session_id: u64,
-        /// QUIC ストリーム ID
-        stream_id: u64,
-        /// QUIC application error code
-        error_code: u64,
-        /// QUIC RESET_STREAM の final size (RFC 9000 Section 19.4)
-        ///
-        /// `reset_stream_at` transport parameter がネゴシエートされている場合、
-        /// この値は stream header (stream type / signal value + session_id varint)
-        /// のバイト数以上であることが期待される (draft-ietf-webtrans-http3-15
-        /// Section 4.4)。
-        final_size: u64,
-    },
-    /// WebTransport データストリームへの STOP_SENDING 受信
-    /// (draft-ietf-webtrans-http3-15 Section 4.4)
-    WebTransportStreamStopSending {
-        /// WebTransport セッション ID
-        session_id: u64,
-        /// QUIC ストリーム ID
-        stream_id: u64,
-        /// QUIC application error code
-        error_code: u64,
-    },
-    /// WebTransport バッファリング拒否
-    /// (draft-ietf-webtrans-http3-15 Section 4.6)
-    ///
-    /// バッファリング上限を超えたため、`error_code` を使用して
-    /// RESET_STREAM / STOP_SENDING を送信すること。
-    WebTransportBufferedStreamRejected {
-        /// 拒否されたストリーム ID
-        stream_id: u64,
-        /// RESET_STREAM / STOP_SENDING に使用するエラーコード (WT_BUFFERED_STREAM_REJECTED)
-        error_code: u64,
-    },
+    /// WebTransport イベント
+    WebTransport(WebTransportEvent),
     /// 接続エラー
     ConnectionError {
         /// エラーコード
@@ -257,21 +289,8 @@ impl Event {
             | Self::Data { stream_id, .. }
             | Self::StreamEnd { stream_id }
             | Self::StreamReset { stream_id, .. }
-            | Self::StopSending { stream_id, .. }
-            | Self::WebTransportBidiStreamOpen { stream_id, .. }
-            | Self::WebTransportBidiStreamData { stream_id, .. }
-            | Self::WebTransportBidiStreamEnd { stream_id }
-            | Self::WebTransportUniStreamOpen { stream_id, .. }
-            | Self::WebTransportUniStreamData { stream_id, .. }
-            | Self::WebTransportUniStreamEnd { stream_id }
-            | Self::WebTransportStreamReset { stream_id, .. }
-            | Self::WebTransportStreamStopSending { stream_id, .. }
-            | Self::WebTransportBufferedStreamRejected { stream_id, .. } => Some(*stream_id),
-            Self::WebTransportSessionClosed { session_id, .. }
-            | Self::WebTransportSessionEstablished { session_id, .. }
-            | Self::WebTransportSessionDraining { session_id }
-            | Self::WebTransportCapsule { session_id, .. }
-            | Self::WebTransportDatagram { session_id, .. } => Some(*session_id),
+            | Self::StopSending { stream_id, .. } => Some(*stream_id),
+            Self::WebTransport(wt) => wt.stream_id(),
             _ => None,
         }
     }
@@ -291,5 +310,26 @@ mod tests {
             wt_settings: None,
         };
         assert_eq!(event.stream_id(), None);
+    }
+
+    #[test]
+    fn test_webtransport_event_stream_id() {
+        // stream_id フィールドを持つバリアント
+        let wt = WebTransportEvent::BidiStreamOpen {
+            stream_id: 10,
+            session_id: 0,
+        };
+        assert_eq!(wt.stream_id(), Some(10));
+
+        // session_id フィールドを持つバリアント
+        let wt = WebTransportEvent::SessionEstablished {
+            session_id: 20,
+            flow_control_enabled: false,
+        };
+        assert_eq!(wt.stream_id(), Some(20));
+
+        // Event::WebTransport 経由で取得
+        let event = Event::WebTransport(WebTransportEvent::UniStreamEnd { stream_id: 30 });
+        assert_eq!(event.stream_id(), Some(30));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ pub mod webtransport;
 // 公開 API
 pub use connection::{ClientConnection, Connection, H3InitData, Role, ServerConnection};
 pub use error::{Error, ErrorCode, FrameDecodeError, QpackError};
-pub use event::Event;
+pub use event::{Event, WebTransportEvent};
 pub use frame::{
     DataPayload, Frame, FrameHeader, FrameType, GoawayPayload, HeadersPayload, SettingsPayload,
     UnknownFrame, UnknownFrameError,

--- a/tests/test_webtransport_draft_connect.rs
+++ b/tests/test_webtransport_draft_connect.rs
@@ -12,7 +12,8 @@
 use shiguredo_http3::qpack::Encoder;
 use shiguredo_http3::webtransport::DraftVersion;
 use shiguredo_http3::{
-    Error, ErrorCode, Event, Header, ServerConnection, Settings, VarInt, webtransport,
+    Error, ErrorCode, Event, Header, ServerConnection, Settings, VarInt, WebTransportEvent,
+    webtransport,
 };
 
 fn vi(value: u64) -> VarInt {
@@ -780,12 +781,12 @@ mod wt_protocol_without_available_protocols {
         let frame = build_headers_frame(&response);
         client.feed_stream(stream_id, &frame, false).unwrap();
 
-        // セッションは Established に遷移せず、WebTransportSessionClosed が発火する
+        // セッションは Established に遷移せず、WebTransportEvent::SessionClosed が発火する
         let mut session_closed = false;
         let mut session_established = false;
         while let Some(ev) = client.poll_event().unwrap() {
             match ev {
-                Event::WebTransportSessionClosed { error_code, .. } => {
+                Event::WebTransport(WebTransportEvent::SessionClosed { error_code, .. }) => {
                     session_closed = true;
                     assert_eq!(
                         error_code,
@@ -793,7 +794,7 @@ mod wt_protocol_without_available_protocols {
                         "WT_ALPN_ERROR で閉じられるべき"
                     );
                 }
-                Event::WebTransportSessionEstablished { .. } => {
+                Event::WebTransport(WebTransportEvent::SessionEstablished { .. }) => {
                     session_established = true;
                 }
                 _ => {}


### PR DESCRIPTION
## 概要

`Event` enum の WebTransport バリアント 14 個を `Event::WebTransport(WebTransportEvent)` にネスト化し、関心の分離を明確にする。

## 変更内容

- `WebTransportEvent` enum を新設し 14 バリアントを `WebTransport` プレフィックスなしで集約
- `Event::stream_id()` を `WebTransportEvent::stream_id()` に委譲
- `connection/mod.rs` の約 72 箇所のイベント生成・match パターンを更新
- `lib.rs` に `pub use event::WebTransportEvent` を追加

## 完了条件

- [x] WebTransport イベント 14 個が `WebTransportEvent` enum に集約されていること
- [x] `Event::WebTransport(WebTransportEvent)` バリアントが追加されていること
- [x] `impl Event::stream_id()` と新設 `impl WebTransportEvent::stream_id()` が正しく動作すること
- [x] `connection/mod.rs` の全 match 分岐が更新されていること
- [x] `cargo test --workspace` が全て pass すること
- [x] 相互運用テストが pass すること

## 関連 issue

- issues/closed/0082-refactor-event-enum-nesting.md