### PR TITLE
0093 リクエストの Host ヘッダー検証を :authority と同等に強化する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,10 @@
   - @voluntas
 - [CHANGE] `Event` enum の WebTransport バリアント 14 個を `Event::WebTransport(WebTransportEvent)` にネスト化する
   - @voluntas
+- [CHANGE] 重複した Host ヘッダーを持つリクエストを `H3_MESSAGE_ERROR` で拒否する (RFC 9110 Section 5.3)
+  - @voluntas
+- [CHANGE] `:authority` が無く Host ヘッダーのみで authority を運ぶリクエストの Host 値を uri-host[:port] 構文で検証し、不正値を `H3_MESSAGE_ERROR` で拒否する (RFC 9110 Section 7.2)
+  - @voluntas
 - [ADD] `VarInt::from_static` / `qpack::Header::from_static` / `frame::GoawayPayload::from_static` の doc に `compile_fail` ブロックを追加し、`const fn` 検査のリグレッションを CI (`cargo test --doc`) で防止する
   - @voluntas
 - [ADD] 構築時検査の `from_static` ↔ `new` 一貫性、`from_validated_parts` ↔ `new` 整合性、`Header::new` ↔ QPACK ラウンドトリップ完全性を検証する PBT を追加する

--- a/issues/closed/0093-change-host-header-validation.md
+++ b/issues/closed/0093-change-host-header-validation.md
@@ -2,8 +2,9 @@
 
 - Priority: Medium
 - Created: 2026-05-30
+- Completed: 2026-05-30
 - Model: Opus 4.8
-- Branch: feature/add-host-header-validation
+- Branch: feature/change-host-header-validation
 - Polished: 2026-05-30
 
 ## 目的
@@ -46,15 +47,18 @@ Medium。RFC 9114 / RFC 9110 が Host 構文不正の拒否を MUST として要
 
 ## 解決方法
 
-1. ヘッダーループの Host 取得 (`src/validation.rs:440-441`) を、`:authority` の重複検出 (`src/validation.rs:396-398`) と同じパターンに変更する。`host.is_some()` なら `H3_MESSAGE_ERROR` を返し、そうでなければ `host = Some(header.value())` とする。
-2. Host 非空チェック (`src/validation.rs:583-587`) の直後に、`authority.is_none() && host.is_some()` のとき `is_valid_authority(h)` を適用し、不正なら `H3_MESSAGE_ERROR` を返す。`:authority` と Host の両方が存在する場合は一致チェック (`src/validation.rs:570-573`) と `:authority` の検証 (`src/validation.rs:602-607`) で既に担保されるため、Host 単独経路のみ追加すればよい (重複検証を避ける)。
-   - `is_valid_authority` は内部の `is_valid_reg_name` (`src/validation.rs:213`) 経由で `@` (userinfo) を常に拒否する。`:authority` の userinfo 拒否は http/https 限定で別途 `src/validation.rs:591-597` にあるが、Host では scheme に依らず常に拒否される。Host に userinfo は不要なため妥当。
-3. 追加するコードコメントに、根拠として RFC 9110 Section 7.2 (`Host = uri-host [ ":" port ]`) と、uri-host の構文実体である RFC 3986 Section 3.2.2 (host = IP-literal / IPv4address / reg-name) を記載する。あわせて構文検証の `H3_MESSAGE_ERROR` は RFC の MUST ではなく堅牢性向上である旨を明記する。
-4. テストを追加する:
-   - `tests/test_validation.rs`: Host を 2 つ持つリクエストを `H3_MESSAGE_ERROR` で拒否すること (`:authority` 有無の両方で確認)。
-   - `tests/test_validation.rs`: `:authority` 不在で不正な Host (非数字ポート `example.com:notaport`、末尾コロン `example.com:`、ホスト名に不正文字) を `H3_MESSAGE_ERROR` で拒否すること。非 CONNECT と Extended CONNECT の両経路を含める。
-   - `tests/test_validation.rs`: `:authority` 不在で正当な Host (`example.com` / `example.com:8443` / `[::1]:443`) を受理すること。両経路を含める。
-   - `pbt/tests/prop_validation.rs`: 現状 `is_valid_authority` を対象とする構文検証 PBT は存在しない (既存 PBT は `:authority` に固定値を使うのみ)。authority 値を変化させる strategy を新規追加し、「`is_valid_authority(v)` が false ⇔ Host 単独リクエストが Err」「同じ `v` で `:authority` 経路も同一判定」の同値性を検証する。
+1. `validate_request_headers` (`src/validation.rs`) のヘッダーループで Host を取得する際、`:authority` の重複拒否と同じく `host.is_some()` なら `H3_MESSAGE_ERROR` を返すようにした。これにより重複 Host で `:authority` 整合チェックを最後の Host だけで通過させる迂回を塞いだ。
+2. Host 非空チェックの直後に、`authority.is_none()` かつ Host が存在する場合に `is_valid_authority(h)` を適用し、不正なら `H3_MESSAGE_ERROR` を返す処理を追加した。`:authority` と Host の両方が存在する場合は一致チェックと `:authority` 検証で担保されるため、Host 単独経路のみ追加検証する。ガード条件により plain CONNECT (`:authority` 必須) は対象外、非 CONNECT と Extended CONNECT の Host 単独経路は対象になる。
+3. `is_valid_authority` の doc コメントを `:authority` と Host 両用の用途へ更新し、Host 重複拒否 (RFC 9110 Section 5.3、ABNF は Section 7.2) と Host 単独構文検証 (RFC 9110 Section 7.2 / RFC 3986 Section 3.2.2) の根拠を記載した。いずれも RFC の MUST ではなく `:authority` と検証レベルを揃える堅牢性向上である旨も明記した。
+4. テストを追加した:
+   - `tests/test_validation.rs`: 重複 Host を `H3_MESSAGE_ERROR` で拒否すること (`:authority` 無しと、`:authority` 有りで先頭 Host を整合チェックから隠す迂回シナリオの両方)。
+   - `tests/test_validation.rs`: `:authority` 不在で不正な Host (非数字ポート / 末尾コロン / ホスト欠落 / reg-name 不正文字 / userinfo) を非 CONNECT と Extended CONNECT の両経路で拒否すること。
+   - `tests/test_validation.rs`: `:authority` 不在で正当な Host (`example.com` / `example.com:8443` / `[::1]:443`) を受理すること。
+   - `pbt/tests/prop_validation.rs`: authority 候補を生成する strategy を新規追加し、`:authority` 経路と Host 単独経路で検証結果が一致する同値性プロパティを検証した。charset は field-value として有効かつ userinfo・空値を含まないため、両経路で挙動が分かれる差分を踏まず `is_valid_authority` の結果だけが判定を分ける。
+
+## 補足
+
+当初はブランチ・カテゴリを `add` としていたが、従来受理していた重複 Host / 不正 Host を新たに拒否する後方互換のない挙動変更のため、`change` に変更した (CHANGES.md も `[CHANGE]`)。
 
 ## 関連
 

--- a/pbt/tests/prop_validation.rs
+++ b/pbt/tests/prop_validation.rs
@@ -435,3 +435,42 @@ proptest! {
         );
     }
 }
+
+/// authority 候補を生成する (host[:port] 構文の有効・無効を混在させる)。
+///
+/// 文字集合はすべて有効な field-value 文字に限定するため、Host 経路の
+/// field-value 検査では落ちず、authority 構文検査 (is_valid_authority) の
+/// 結果だけが Ok/Err を分ける。
+fn authority_candidate() -> impl Strategy<Value = Vec<u8>> {
+    proptest::collection::vec(prop::sample::select(b"ab01.:-[]".to_vec()), 1..16)
+}
+
+proptest! {
+    /// :authority 経路と Host 単独経路で authority 構文検証の結果が一致すること。
+    ///
+    /// Host は :authority の代替として同じ uri-host[:port] 構文で検証される (RFC 9110
+    /// Section 7.2)。charset は field-value として有効かつ userinfo (@) や空値を含まないため、
+    /// 両経路で挙動が分かれる差分 (userinfo 拒否 / 空値 / CONNECT) を踏まず、
+    /// is_valid_authority の結果だけが Ok/Err を分ける。それらの差分は単体テストで固定する。
+    #[test]
+    fn prop_host_only_matches_authority_validation(value in authority_candidate()) {
+        let with_authority = vec![
+            Header::new(b":method", b"GET").unwrap(),
+            Header::new(b":scheme", b"https").unwrap(),
+            Header::new(b":path", b"/").unwrap(),
+            Header::new(b":authority", &value).unwrap(),
+        ];
+        let with_host = vec![
+            Header::new(b":method", b"GET").unwrap(),
+            Header::new(b":scheme", b"https").unwrap(),
+            Header::new(b":path", b"/").unwrap(),
+            Header::new(b"host", &value).unwrap(),
+        ];
+        prop_assert_eq!(
+            validate_request_headers(&with_authority).is_ok(),
+            validate_request_headers(&with_host).is_ok(),
+            "value={:?}",
+            value,
+        );
+    }
+}

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -262,12 +262,12 @@ fn is_valid_ip_literal_content(content: &[u8]) -> bool {
         .all(|&b| b.is_ascii_hexdigit() || b == b':' || b == b'.')
 }
 
-/// 非 CONNECT リクエストの :authority が URI authority として妥当かを検証する
-/// (RFC 9114 Section 4.3.1, RFC 3986 Section 3.2)
+/// :authority (非 CONNECT / Extended CONNECT) または代替の Host ヘッダーが URI authority
+/// として妥当かを検証する (RFC 9114 Section 4.3.1, RFC 9110 Section 7.2, RFC 3986 Section 3.2)
 ///
 /// authority = host [ ":" port ]
 /// host = IP-literal / IPv4address / reg-name
-/// ポートはオプション。userinfo は別途チェック済みのためここでは検証しない。
+/// ポートはオプション。userinfo (@) はいずれの経路でも許可文字に含まれないため拒否される。
 fn is_valid_authority(value: &[u8]) -> bool {
     if value.is_empty() {
         return false;
@@ -437,7 +437,14 @@ pub fn validate_request_headers(headers: &[Header]) -> Result<(), Error> {
                 return Err(Error::StreamError(ErrorCode::MessageError));
             }
 
+            // Host は単一値フィールドで複数生成は禁止 (RFC 9110 Section 5.3、ABNF は
+            // Section 7.2)。:authority の重複拒否 (上記参照) と同じく拒否し、:authority との
+            // 一致チェックを最後の Host だけで通過させる迂回を防ぐ。受信側拒否は RFC の MUST
+            // ではなく堅牢性向上。
             if header.name() == b"host" {
+                if host.is_some() {
+                    return Err(Error::StreamError(ErrorCode::MessageError));
+                }
                 host = Some(header.value());
             }
         }
@@ -582,6 +589,17 @@ pub fn validate_request_headers(headers: &[Header]) -> Result<(), Error> {
     }
     if let Some(h) = host
         && h.is_empty()
+    {
+        return Err(Error::StreamError(ErrorCode::MessageError));
+    }
+
+    // :authority が無く Host のみで authority 情報を運ぶ場合、Host を :authority と同じ
+    // 構文 (uri-host[:port]) で検証する (RFC 9110 Section 7.2, RFC 3986 Section 3.2.2)。
+    // RFC の MUST ではなく :authority との検証レベルを揃える堅牢性向上。plain CONNECT は
+    // :authority 必須 (上記で None を拒否済み) のためこの分岐には入らない。
+    if authority.is_none()
+        && let Some(h) = host
+        && !is_valid_authority(h)
     {
         return Err(Error::StreamError(ErrorCode::MessageError));
     }

--- a/tests/test_validation.rs
+++ b/tests/test_validation.rs
@@ -287,6 +287,76 @@ fn test_authority_host_mismatch_is_malformed() {
 }
 
 #[test]
+fn test_duplicate_host_is_malformed() {
+    // Host は単一値フィールドのため重複は malformed (RFC 9110 Section 5.3)
+    let headers = vec![
+        wire_header(b":method", b"GET"),
+        wire_header(b":scheme", b"https"),
+        wire_header(b":path", b"/"),
+        wire_header(b"host", b"example.com"),
+        wire_header(b"host", b"other.com"),
+    ];
+    assert!(validate_request_headers(&headers).is_err());
+}
+
+#[test]
+fn test_duplicate_host_with_authority_is_malformed() {
+    // :authority と一致する Host を 2 つ目に置いて 1 つ目の不一致 Host を
+    // 整合チェックから隠す迂回を防ぐこと。重複 Host は一致チェックより前に拒否される。
+    let headers = vec![
+        wire_header(b":method", b"GET"),
+        wire_header(b":scheme", b"https"),
+        wire_header(b":path", b"/"),
+        wire_header(b":authority", b"origin.example"),
+        wire_header(b"host", b"attacker.example"),
+        wire_header(b"host", b"origin.example"),
+    ];
+    assert!(validate_request_headers(&headers).is_err());
+}
+
+#[test]
+fn test_host_only_with_invalid_syntax_is_malformed() {
+    // :authority が無く Host のみの場合、Host を uri-host[:port] で構文検証する
+    // (RFC 9110 Section 7.2)。field-value としては有効でも authority 構文に外れる値
+    // (非数字ポート / 末尾コロン / ホスト欠落 / reg-name 不正文字 / userinfo) を拒否する。
+    for invalid in [
+        b"example.com:notaport".as_slice(),
+        b"example.com:",
+        b":8443",
+        b"example.com/path",
+        b"user@example.com",
+    ] {
+        let headers = vec![
+            wire_header(b":method", b"GET"),
+            wire_header(b":scheme", b"https"),
+            wire_header(b":path", b"/"),
+            wire_header(b"host", invalid),
+        ];
+        assert!(
+            validate_request_headers(&headers).is_err(),
+            "不正な Host を拒否すること: {invalid:?}"
+        );
+    }
+}
+
+#[test]
+fn test_host_only_with_valid_syntax_is_valid() {
+    // :authority が無く Host のみでも正当な uri-host[:port] は受理する
+    for valid in [b"example.com".as_slice(), b"example.com:8443", b"[::1]:443"] {
+        let headers = vec![
+            wire_header(b":method", b"GET"),
+            wire_header(b":scheme", b"https"),
+            wire_header(b":path", b"/"),
+            wire_header(b"host", valid),
+        ];
+        assert!(
+            validate_request_headers(&headers).is_ok(),
+            "正当な Host を受理すること: {valid:?}"
+        );
+    }
+}
+
+#[test]
 fn test_duplicate_method_is_malformed() {
     let headers = vec![
         wire_header(b":method", b"GET"),
@@ -662,6 +732,19 @@ fn test_extended_connect_authority_host_mismatch_is_malformed() {
         wire_header(b":path", b"/webtransport"),
         wire_header(b":authority", b"example.com"),
         wire_header(b"host", b"other.com"),
+    ];
+    assert!(validate_request_headers(&headers).is_err());
+}
+
+#[test]
+fn test_extended_connect_host_only_with_invalid_syntax_is_malformed() {
+    // Extended CONNECT でも :authority が無く Host のみの場合は Host 構文を検証する
+    let headers = vec![
+        wire_header(b":method", b"CONNECT"),
+        wire_header(b":protocol", b"webtransport-h3"),
+        wire_header(b":scheme", b"https"),
+        wire_header(b":path", b"/webtransport"),
+        wire_header(b"host", b"example.com:notaport"),
     ];
     assert!(validate_request_headers(&headers).is_err());
 }


### PR DESCRIPTION
## 概要

`validate_request_headers` の Host ヘッダー検証が `:authority` より弱く、(1) 重複 Host を検出しない、(2) Host 単独経路で構文検証しない、という 2 つのギャップがあった。検証レベルを `:authority` と対等にする。

## 変更内容

- 重複した Host ヘッダーを `H3_MESSAGE_ERROR` で拒否し、`:authority` 整合チェックを最後の Host だけで通過させる迂回を塞ぐ (RFC 9110 Section 5.3)
- `:authority` が無く Host のみで authority を運ぶリクエストの Host 値を `is_valid_authority` で uri-host[:port] 構文検証する (RFC 9110 Section 7.2, RFC 3986 Section 3.2.2)。plain CONNECT は対象外、非 CONNECT / Extended CONNECT の Host 単独経路は対象
- `is_valid_authority` の doc コメントを `:authority` と Host の両用に更新する
- 迂回シナリオ・不正/正当な Host 構文の単体テストと、`:authority` 経路と Host 経路の同値性 PBT を追加する

## 後方互換性

従来 `is_valid_field_value` を通過していた重複 Host / 不正な Host 単独値を新たに拒否するため、受理範囲が狭まる (CHANGES.md は `[CHANGE]`)。

## 完了条件

- [x] 重複 Host を `H3_MESSAGE_ERROR` で拒否する
- [x] `:authority` 不在で Host 単独の不正構文を非 CONNECT / Extended CONNECT 両経路で拒否する
- [x] 既存の正常系の挙動を維持する
- [x] 追加テストが修正前は失敗し、修正後に `cargo test --workspace --tests` で通過する

## 関連 issue

- issues/closed/0093-change-host-header-validation.md