### PR TITLE
PBT を proptest から noprop に置き換える

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -312,6 +312,8 @@
   - @voluntas
 - [UPDATE] `s2n-tls` を 0.3.42 に更新する
   - @voluntas
+- [UPDATE] PBT を proptest から noprop に置き換え、pbt クレートの全プロパティテストを命令形のプロパティクロージャに書き換える
+  - @voluntas
 - [FIX] `fuzz/fuzz_targets/fuzz_settings.rs` が `Settings::from_payload` の `Result` 戻り値に追従しておらず fuzz crate がコンパイルできなかった問題を修正する
   - @voluntas
 - [FIX] CI の共通 workspace job から `interop/h3` / `interop/wt` を除外し、相互運用テストは macOS 専用 step でのみ実行する

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,21 +210,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bit-set"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
-dependencies = [
- "bit-vec 0.8.0",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
-
-[[package]]
 name = "bit-vec"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1918,6 +1903,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
+name = "noprop"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73026775e276cb339c67cdf71b2a8c067991fbe1cfbf25e17c7420afe6f829f7"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2085,7 +2076,7 @@ dependencies = [
 name = "pbt"
 version = "0.0.0"
 dependencies = [
- "proptest",
+ "noprop",
  "shiguredo_http3",
 ]
 
@@ -2285,16 +2276,12 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
- "bit-set",
- "bit-vec 0.8.0",
  "bitflags 2.13.1",
  "num-traits",
  "rand 0.9.5",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
- "rusty-fork",
- "tempfile",
  "unarray",
 ]
 
@@ -2376,12 +2363,6 @@ dependencies = [
  "smallvec",
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
@@ -2765,18 +2746,6 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
-
-[[package]]
-name = "rusty-fork"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
-dependencies = [
- "fnv",
- "quick-error",
- "tempfile",
- "wait-timeout",
-]
 
 [[package]]
 name = "ryu"
@@ -3898,15 +3867,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
-name = "wait-timeout"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4243,7 +4203,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
 dependencies = [
- "bit-vec 0.9.1",
+ "bit-vec",
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,8 @@ shiguredo_http3 = { path = "." }
 [dependencies]
 
 [features]
+
+# noprop は panic 必須 (パニックでケース失敗を検出するため)
+# test プロファイルは dev プロファイルの panic 設定を引き継ぐため dev 側に指定する
+[profile.dev]
+panic = "unwind"

--- a/pbt/Cargo.toml
+++ b/pbt/Cargo.toml
@@ -6,5 +6,6 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
-proptest = "1.11"
+# PBT (Property-Based Testing) は noprop を使用する
+noprop = "0.2"
 shiguredo_http3.workspace = true

--- a/pbt/src/lib.rs
+++ b/pbt/src/lib.rs
@@ -57,48 +57,54 @@ fn encode_qpack_string(buf: &mut Vec<u8>, data: &[u8]) {
 }
 
 pub mod strategies {
-    use proptest::prelude::*;
+    use noprop::TestCaseContext;
     use shiguredo_http3::VarInt;
 
     /// RFC 9000 Section 16: VarInt の値域 (0..=2^62 - 1)
-    pub fn valid_varint() -> impl Strategy<Value = VarInt> {
-        (0u64..=VarInt::MAX.get())
-            .prop_map(|v| VarInt::new(v).expect("value is within VarInt::MAX"))
+    pub fn valid_varint(ctx: &mut TestCaseContext) -> VarInt {
+        VarInt::new(noprop::sample_u64_in(ctx, 0..=VarInt::MAX.get()))
+            .expect("value is within VarInt::MAX")
     }
 
     /// `VarInt::new` / `VarInt::try_from` が必ず `Err` を返す入力 (PBT の
     /// negative path 用)
-    pub fn invalid_varint_u64() -> impl Strategy<Value = u64> {
-        (VarInt::MAX.get() + 1)..=u64::MAX
+    pub fn invalid_varint_u64(ctx: &mut TestCaseContext) -> u64 {
+        noprop::sample_u64_in(ctx, (VarInt::MAX.get() + 1)..=u64::MAX)
     }
 
     /// RFC 9114 Section 4.2 / RFC 9110 Section 5.1: 小文字 token-char のみで
     /// 構成された valid な field name (1..64 byte)
-    pub fn valid_header_name() -> impl Strategy<Value = Vec<u8>> {
-        (1usize..64)
-            .prop_flat_map(|len| prop::collection::vec(prop::char::range('a', 'z'), len))
-            .prop_map(|chars| chars.into_iter().map(|c| c as u8).collect())
+    pub fn valid_header_name(ctx: &mut TestCaseContext) -> Vec<u8> {
+        let len = noprop::sample_usize_in(ctx, 1..64);
+        let mut name = Vec::new();
+        for _ in 0..len {
+            // 小文字英字 (a-z) から 1 文字ずつサンプリングする
+            name.push(b'a' + noprop::sample_usize_in(ctx, 0..26) as u8);
+        }
+        name
     }
 
     /// RFC 9110 Section 5.5 の field-content に従い、両端は field-vchar
     /// (0x21-0x7E)、間には SP (0x20) も許す。空文字列も valid。
     /// (obs-text 0x80-0xFF は QPACK Huffman デコードとの整合性を保つため除外)
-    pub fn valid_header_value() -> impl Strategy<Value = Vec<u8>> {
-        (0usize..256)
-            .prop_flat_map(|len| prop::collection::vec(0x20u8..=0x7e, len))
-            .prop_map(|middle| {
-                if middle.is_empty() {
-                    return Vec::new();
-                }
-                let mut v = middle;
-                if v[0] == 0x20 {
-                    v[0] = 0x21;
-                }
-                let last = v.len() - 1;
-                if v[last] == 0x20 {
-                    v[last] = 0x21;
-                }
-                v
-            })
+    pub fn valid_header_value(ctx: &mut TestCaseContext) -> Vec<u8> {
+        let len = noprop::sample_usize_in(ctx, 0..256);
+        let mut middle = Vec::new();
+        for _ in 0..len {
+            // field-content: 0x20-0x7E からサンプリングする
+            middle.push(0x20 + noprop::sample_usize_in(ctx, 0..=0x5e) as u8);
+        }
+        if middle.is_empty() {
+            return Vec::new();
+        }
+        let mut v = middle;
+        if v[0] == 0x20 {
+            v[0] = 0x21;
+        }
+        let last = v.len() - 1;
+        if v[last] == 0x20 {
+            v[last] = 0x21;
+        }
+        v
     }
 }

--- a/pbt/tests/prop_capsule/main.rs
+++ b/pbt/tests/prop_capsule/main.rs
@@ -1,84 +1,85 @@
 //! Property-Based Testing for WebTransport Capsule Protocol
 //! (draft-ietf-webtrans-http3-15 Section 5.6, 6)
 
-use proptest::prelude::*;
 use shiguredo_http3::webtransport::{Capsule, CapsuleValidationError, MAX_STREAMS_LIMIT};
 
 // =============================================================================
-// Strategy ヘルパー
+// 生成ヘルパー
 // =============================================================================
 
 /// 有効な可変長整数の最大値
 const MAX_VARINT: u64 = (1 << 62) - 1;
 
-prop_compose! {
-    /// CloseSession Capsule を生成 (メッセージは最大 1024 バイトの ASCII)
-    fn close_session_capsule()(
-        error_code in any::<u32>(),
-        msg_len in 0usize..=1024,
-    )(
-        error_code in Just(error_code),
-        msg in prop::collection::vec(0x20u8..0x7f, msg_len),
-    ) -> Capsule {
-        let message = String::from_utf8(msg).unwrap_or_default();
-        Capsule::CloseSession { error_code, message }
+/// CloseSession Capsule を生成 (メッセージは最大 1024 バイトの ASCII)
+fn close_session_capsule(ctx: &mut noprop::TestCaseContext) -> Capsule {
+    let error_code = noprop::sample_u32(ctx);
+    let msg_len = noprop::sample_usize_in(ctx, 0..=1024);
+    let mut msg = Vec::new();
+    for _ in 0..msg_len {
+        msg.push(0x20 + noprop::sample_usize_in(ctx, 0..=0x5f) as u8);
+    }
+    let message = String::from_utf8(msg).unwrap_or_default();
+    Capsule::CloseSession {
+        error_code,
+        message,
     }
 }
 
-prop_compose! {
-    /// MaxData Capsule を生成
-    fn max_data_capsule()(maximum in 0u64..=MAX_VARINT) -> Capsule {
-        Capsule::MaxData { maximum }
+/// MaxData Capsule を生成
+fn max_data_capsule(ctx: &mut noprop::TestCaseContext) -> Capsule {
+    let maximum = noprop::sample_u64_in(ctx, 0..=MAX_VARINT);
+    Capsule::MaxData { maximum }
+}
+
+/// MaxStreams Capsule を生成
+fn max_streams_capsule(ctx: &mut noprop::TestCaseContext) -> Capsule {
+    let bidirectional = noprop::sample_bool(ctx);
+    let maximum = noprop::sample_u64_in(ctx, 0..=MAX_VARINT);
+    Capsule::MaxStreams {
+        bidirectional,
+        maximum,
     }
 }
 
-prop_compose! {
-    /// MaxStreams Capsule を生成
-    fn max_streams_capsule()(
-        bidirectional in any::<bool>(),
-        maximum in 0u64..=MAX_VARINT,
-    ) -> Capsule {
-        Capsule::MaxStreams { bidirectional, maximum }
+/// DataBlocked Capsule を生成
+fn data_blocked_capsule(ctx: &mut noprop::TestCaseContext) -> Capsule {
+    let maximum = noprop::sample_u64_in(ctx, 0..=MAX_VARINT);
+    Capsule::DataBlocked { maximum }
+}
+
+/// StreamsBlocked Capsule を生成
+fn streams_blocked_capsule(ctx: &mut noprop::TestCaseContext) -> Capsule {
+    let bidirectional = noprop::sample_bool(ctx);
+    let maximum = noprop::sample_u64_in(ctx, 0..=MAX_VARINT);
+    Capsule::StreamsBlocked {
+        bidirectional,
+        maximum,
     }
 }
 
-prop_compose! {
-    /// DataBlocked Capsule を生成
-    fn data_blocked_capsule()(maximum in 0u64..=MAX_VARINT) -> Capsule {
-        Capsule::DataBlocked { maximum }
+/// 全ての既知の Capsule 型を生成する
+fn any_known_capsule(ctx: &mut noprop::TestCaseContext) -> Capsule {
+    match noprop::sample_weighted_index(ctx, &[1u32; 6]) {
+        0 => close_session_capsule(ctx),
+        1 => Capsule::DrainSession,
+        2 => max_data_capsule(ctx),
+        3 => max_streams_capsule(ctx),
+        4 => data_blocked_capsule(ctx),
+        _ => streams_blocked_capsule(ctx),
     }
-}
-
-prop_compose! {
-    /// StreamsBlocked Capsule を生成
-    fn streams_blocked_capsule()(
-        bidirectional in any::<bool>(),
-        maximum in 0u64..=MAX_VARINT,
-    ) -> Capsule {
-        Capsule::StreamsBlocked { bidirectional, maximum }
-    }
-}
-
-/// 全ての既知の Capsule 型を生成する Strategy
-fn any_known_capsule() -> impl Strategy<Value = Capsule> {
-    prop_oneof![
-        close_session_capsule(),
-        Just(Capsule::DrainSession),
-        max_data_capsule(),
-        max_streams_capsule(),
-        data_blocked_capsule(),
-        streams_blocked_capsule(),
-    ]
 }
 
 // =============================================================================
 // (a) Capsule encode/decode ラウンドトリップ
 // =============================================================================
 
-proptest! {
-    /// Property: 任意の既知の Capsule を encode → decode すると元と一致する
-    #[test]
-    fn prop_capsule_roundtrip(capsule in any_known_capsule()) {
+/// Property: 任意の既知の Capsule を encode → decode すると元と一致する
+#[test]
+fn prop_capsule_roundtrip() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_CAPSULE_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let capsule = any_known_capsule(ctx);
         let mut buf = Vec::new();
         capsule.encode(&mut buf);
 
@@ -86,33 +87,32 @@ proptest! {
             .expect("decode should not error for valid encoded capsule")
             .expect("decode should not be incomplete for valid encoded capsule");
 
-        prop_assert_eq!(
-            &decoded, &capsule,
-            "ラウンドトリップで Capsule が変化した"
-        );
-        prop_assert_eq!(
-            consumed, buf.len(),
-            "消費バイト数がバッファ長と不一致"
-        );
-    }
+        assert_eq!(&decoded, &capsule, "ラウンドトリップで Capsule が変化した");
+        assert_eq!(consumed, buf.len(), "消費バイト数がバッファ長と不一致");
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // (b) encode_as_data_frame ラウンドトリップ
 // =============================================================================
 
-proptest! {
-    /// Property: encode_as_data_frame の出力を decode_frame で DATA として取り出し、
-    /// そのペイロードを Capsule::decode すると元と一致する
-    #[test]
-    fn prop_capsule_data_frame_roundtrip(capsule in any_known_capsule()) {
+/// Property: encode_as_data_frame の出力を decode_frame で DATA として取り出し、
+/// そのペイロードを Capsule::decode すると元と一致する
+#[test]
+fn prop_capsule_data_frame_roundtrip() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_CAPSULE_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let capsule = any_known_capsule(ctx);
         let mut buf = Vec::new();
         capsule.encode_as_data_frame(&mut buf);
 
         // DATA フレームとしてデコード
-        let (frame, consumed) = shiguredo_http3::frame::decode_frame(&buf)
-            .expect("decode_frame should succeed");
-        prop_assert_eq!(consumed, buf.len(), "consumed != buf.len()");
+        let (frame, consumed) =
+            shiguredo_http3::frame::decode_frame(&buf).expect("decode_frame should succeed");
+        assert_eq!(consumed, buf.len(), "consumed != buf.len()");
 
         // DATA フレームからペイロードを取り出す
         match frame {
@@ -120,30 +120,29 @@ proptest! {
                 let (decoded, cap_consumed) = Capsule::decode(payload.data())
                     .expect("Capsule::decode should not error")
                     .expect("Capsule::decode should not be incomplete");
-                prop_assert_eq!(
-                    &decoded, &capsule,
-                    "カプセルがラウンドトリップで変化した"
-                );
-                prop_assert_eq!(
-                    cap_consumed, payload.len(),
-                    "カプセル消費バイト数が不一致"
-                );
+                assert_eq!(&decoded, &capsule, "カプセルがラウンドトリップで変化した");
+                assert_eq!(cap_consumed, payload.len(), "カプセル消費バイト数が不一致");
             }
             other => {
-                prop_assert!(false, "DATA フレームでない: {:?}", other);
+                panic!("DATA フレームでない: {:?}", other);
             }
         }
-    }
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // (c) エンコードバイト列の消費量が encode の出力長と一致
 // =============================================================================
 
-proptest! {
-    /// Property: decode の consumed がバッファ長と一致する
-    #[test]
-    fn prop_capsule_consumed_equals_buffer_length(capsule in any_known_capsule()) {
+/// Property: decode の consumed がバッファ長と一致する
+#[test]
+fn prop_capsule_consumed_equals_buffer_length() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_CAPSULE_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let capsule = any_known_capsule(ctx);
         let mut buf = Vec::new();
         capsule.encode(&mut buf);
 
@@ -151,115 +150,153 @@ proptest! {
             .expect("decode should not error")
             .expect("decode should not be incomplete");
 
-        prop_assert_eq!(
-            consumed,
-            buf.len(),
-            "consumed != buf.len()"
-        );
-    }
+        assert_eq!(consumed, buf.len(), "consumed != buf.len()");
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // (c) validate_max_streams の単調増加制約
 // =============================================================================
 
-proptest! {
-    /// Property: maximum > current_max かつ maximum <= MAX_STREAMS_LIMIT なら Ok
-    #[test]
-    fn prop_validate_max_streams_ok(
-        current_max in 0u64..=MAX_STREAMS_LIMIT,
-        delta in 1u64..1000,
-    ) {
-        let maximum = current_max.saturating_add(delta).min(MAX_STREAMS_LIMIT);
-        prop_assume!(maximum > current_max);
+/// Property: maximum > current_max かつ maximum <= MAX_STREAMS_LIMIT なら Ok
+#[test]
+fn prop_validate_max_streams_ok() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_CAPSULE_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let (current_max, maximum) = noprop::sample_with_rejection(ctx, 64, |ctx| {
+            let current_max = noprop::sample_u64_in(ctx, 0..=MAX_STREAMS_LIMIT);
+            let delta = noprop::sample_u64_in(ctx, 1..1000);
+            let maximum = current_max.saturating_add(delta).min(MAX_STREAMS_LIMIT);
+            (maximum > current_max).then_some((current_max, maximum))
+        });
         let result = Capsule::validate_max_streams(maximum, current_max);
-        prop_assert!(
+        assert!(
             result.is_ok(),
-            "maximum > current_max かつ上限以下なのに Err: maximum={}, current_max={}", maximum, current_max
+            "maximum > current_max かつ上限以下なのに Err: maximum={}, current_max={}",
+            maximum,
+            current_max
         );
-    }
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: maximum <= current_max なら MaxStreamsDecreased
-    /// (draft-16: "does not increase")
-    #[test]
-    fn prop_validate_max_streams_not_increased(
-        current_max in 1u64..=MAX_STREAMS_LIMIT,
-        delta in 0u64..1000,
-    ) {
+/// Property: maximum <= current_max なら MaxStreamsDecreased
+/// (draft-16: "does not increase")
+#[test]
+fn prop_validate_max_streams_not_increased() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_CAPSULE_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let current_max = noprop::sample_u64_in(ctx, 1..=MAX_STREAMS_LIMIT);
+        let delta = noprop::sample_u64_in(ctx, 0..1000);
         let maximum = current_max.saturating_sub(delta);
-        prop_assume!(maximum <= current_max);
+        // saturating_sub により maximum <= current_max は常に成り立つ
 
         let result = Capsule::validate_max_streams(maximum, current_max);
-        prop_assert_eq!(
+        assert_eq!(
             result,
             Err(CapsuleValidationError::MaxStreamsDecreased),
-            "maximum <= current_max なのに MaxStreamsDecreased でない: maximum={}, current_max={}", maximum, current_max
+            "maximum <= current_max なのに MaxStreamsDecreased でない: maximum={}, current_max={}",
+            maximum,
+            current_max
         );
-    }
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: maximum > MAX_STREAMS_LIMIT なら MaxStreamsExceedsLimit
-    #[test]
-    fn prop_validate_max_streams_exceeds_limit(
-        excess in 1u64..1000,
-    ) {
+/// Property: maximum > MAX_STREAMS_LIMIT なら MaxStreamsExceedsLimit
+#[test]
+fn prop_validate_max_streams_exceeds_limit() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_CAPSULE_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let excess = noprop::sample_u64_in(ctx, 1..1000);
         let maximum = MAX_STREAMS_LIMIT + excess;
         let result = Capsule::validate_max_streams(maximum, 0);
-        prop_assert_eq!(
+        assert_eq!(
             result,
             Err(CapsuleValidationError::MaxStreamsExceedsLimit),
-            "maximum > MAX_STREAMS_LIMIT なのに MaxStreamsExceedsLimit でない: maximum={}", maximum
+            "maximum > MAX_STREAMS_LIMIT なのに MaxStreamsExceedsLimit でない: maximum={}",
+            maximum
         );
-    }
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // (d) validate_max_data の単調増加制約
 // =============================================================================
 
-proptest! {
-    /// Property: maximum > current_max なら Ok
-    #[test]
-    fn prop_validate_max_data_ok(
-        current_max in 0u64..=MAX_VARINT / 2,
-        delta in 1u64..1000,
-    ) {
+/// Property: maximum > current_max なら Ok
+#[test]
+fn prop_validate_max_data_ok() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_CAPSULE_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let current_max = noprop::sample_u64_in(ctx, 0..=MAX_VARINT / 2);
+        let delta = noprop::sample_u64_in(ctx, 1..1000);
         let maximum = current_max.saturating_add(delta);
+        // current_max は MAX_VARINT / 2 以下で delta は 1000 未満のため
+        // saturating_add は飽和せず maximum > current_max が常に成り立つ
         let result = Capsule::validate_max_data(maximum, current_max);
-        prop_assert!(
+        assert!(
             result.is_ok(),
-            "maximum > current_max なのに Err: maximum={}, current_max={}", maximum, current_max
+            "maximum > current_max なのに Err: maximum={}, current_max={}",
+            maximum,
+            current_max
         );
-    }
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: maximum <= current_max なら MaxDataDecreased
-    /// (draft-16: "does not increase")
-    #[test]
-    fn prop_validate_max_data_not_increased(
-        current_max in 1u64..=MAX_VARINT,
-        delta in 0u64..1000,
-    ) {
+/// Property: maximum <= current_max なら MaxDataDecreased
+/// (draft-16: "does not increase")
+#[test]
+fn prop_validate_max_data_not_increased() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_CAPSULE_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let current_max = noprop::sample_u64_in(ctx, 1..=MAX_VARINT);
+        let delta = noprop::sample_u64_in(ctx, 0..1000);
         let maximum = current_max.saturating_sub(delta);
-        prop_assume!(maximum <= current_max);
+        // saturating_sub により maximum <= current_max は常に成り立つ
 
         let result = Capsule::validate_max_data(maximum, current_max);
-        prop_assert_eq!(
+        assert_eq!(
             result,
             Err(CapsuleValidationError::MaxDataDecreased),
-            "maximum <= current_max なのに MaxDataDecreased でない: maximum={}, current_max={}", maximum, current_max
+            "maximum <= current_max なのに MaxDataDecreased でない: maximum={}, current_max={}",
+            maximum,
+            current_max
         );
-    }
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: maximum > MAX_VARINT なら MaxDataExceedsLimit
-    #[test]
-    fn prop_validate_max_data_exceeds_limit(
-        excess in 1u64..1000,
-    ) {
+/// Property: maximum > MAX_VARINT なら MaxDataExceedsLimit
+#[test]
+fn prop_validate_max_data_exceeds_limit() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_CAPSULE_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let excess = noprop::sample_u64_in(ctx, 1..1000);
         let maximum = MAX_VARINT + excess;
         let result = Capsule::validate_max_data(maximum, 0);
-        prop_assert_eq!(
+        assert_eq!(
             result,
             Err(CapsuleValidationError::MaxDataExceedsLimit),
-            "maximum > MAX_VARINT なのに MaxDataExceedsLimit でない: maximum={}", maximum
+            "maximum > MAX_VARINT なのに MaxDataExceedsLimit でない: maximum={}",
+            maximum
         );
-    }
+        Ok(())
+    })?;
+    Ok(())
 }

--- a/pbt/tests/prop_connection.rs
+++ b/pbt/tests/prop_connection.rs
@@ -2,7 +2,6 @@
 //!
 //! get_stream_data のループ終了性とデータ完全性を検証する。
 
-use proptest::prelude::*;
 use shiguredo_http3::{ClientConnection, Header};
 
 /// リクエスト送信後の take_stream_data ループ用ヘルパー
@@ -34,10 +33,13 @@ fn drain_stream_data(
 // get_stream_data Termination Properties
 // =============================================================================
 
-proptest! {
-    /// Property: 任意サイズのボディで get_stream_data ループが有限回で終了する
-    #[test]
-    fn prop_get_stream_data_terminates(body_len in 0usize..8192) {
+/// Property: 任意サイズのボディで get_stream_data ループが有限回で終了する
+#[test]
+fn prop_get_stream_data_terminates() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_CONNECTION_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let body_len = noprop::sample_usize_in(ctx, 0..8192);
         let body = vec![0xABu8; body_len];
 
         let mut client = ClientConnection::with_default_settings();
@@ -51,21 +53,32 @@ proptest! {
         ];
 
         // ボディ付きリクエストを送信 (fin=false でヘッダーのみ先に送信)
-        let stream_id = client.send_request(&request_headers, false).expect("test must succeed");
-        client.send_body(stream_id, &body, true).expect("test must succeed");
+        let stream_id = client
+            .send_request(&request_headers, false)
+            .expect("test must succeed");
+        client
+            .send_body(stream_id, &body, true)
+            .expect("test must succeed");
 
         let (_collected, iterations) = drain_stream_data(&mut client, stream_id, 10);
 
-        prop_assert!(
+        assert!(
             iterations < 10,
             "get_stream_data ループが 10 回以内に終了しなかった (iterations={})",
             iterations
         );
-    }
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: ループで収集したデータ長が元のフレームデータ長と一致する (データ欠損なし)
-    #[test]
-    fn prop_get_stream_data_all_data_collected(body_len in 0usize..8192) {
+/// Property: ループで収集したデータ長が元のフレームデータ長と一致する (データ欠損なし)
+#[test]
+fn prop_get_stream_data_all_data_collected() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_CONNECTION_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let body_len = noprop::sample_usize_in(ctx, 0..8192);
         let body = vec![0xCDu8; body_len];
 
         let mut client = ClientConnection::with_default_settings();
@@ -78,28 +91,39 @@ proptest! {
             Header::new(b":authority", b"example.com").expect("test must succeed"),
         ];
 
-        let stream_id = client.send_request(&request_headers, false).expect("test must succeed");
-        client.send_body(stream_id, &body, true).expect("test must succeed");
+        let stream_id = client
+            .send_request(&request_headers, false)
+            .expect("test must succeed");
+        client
+            .send_body(stream_id, &body, true)
+            .expect("test must succeed");
 
         let (collected, _iterations) = drain_stream_data(&mut client, stream_id, 10);
 
         // 収集データにはフレームヘッダーも含まれるため、ボディ長以上であることを検証
-        prop_assert!(
+        assert!(
             collected.len() >= body_len,
             "収集データ長 {} がボディ長 {} より小さい",
             collected.len(),
             body_len
         );
-    }
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: FIN 交付後に get_stream_data が None を返す
-    ///
-    /// drain_stream_data はデータ交付 → FIN 交付 → None の順でループを抜けるため、
-    /// ここでの検証対象は「FIN 交付後の None」である。
-    /// (FIN はデータ全消費後の追加呼び出しで交付されるため、全データ消費直後の
-    ///  get_stream_data は (空, fin=true) を返す)
-    #[test]
-    fn prop_get_stream_data_returns_none_after_consume(body_len in 0usize..8192) {
+/// Property: FIN 交付後に get_stream_data が None を返す
+///
+/// drain_stream_data はデータ交付 → FIN 交付 → None の順でループを抜けるため、
+/// ここでの検証対象は「FIN 交付後の None」である。
+/// (FIN はデータ全消費後の追加呼び出しで交付されるため、全データ消費直後の
+///  get_stream_data は (空, fin=true) を返す)
+#[test]
+fn prop_get_stream_data_returns_none_after_consume() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_CONNECTION_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let body_len = noprop::sample_usize_in(ctx, 0..8192);
         let body = vec![0xEFu8; body_len];
 
         let mut client = ClientConnection::with_default_settings();
@@ -112,18 +136,24 @@ proptest! {
             Header::new(b":authority", b"example.com").expect("test must succeed"),
         ];
 
-        let stream_id = client.send_request(&request_headers, false).expect("test must succeed");
-        client.send_body(stream_id, &body, true).expect("test must succeed");
+        let stream_id = client
+            .send_request(&request_headers, false)
+            .expect("test must succeed");
+        client
+            .send_body(stream_id, &body, true)
+            .expect("test must succeed");
 
         // データと FIN をすべて消費
         let (_collected, _iterations) = drain_stream_data(&mut client, stream_id, 10);
 
         // FIN 交付後は None が返ることを検証
         let result = client.get_stream_data(stream_id);
-        prop_assert!(
+        assert!(
             result.is_none(),
             "FIN 交付後に get_stream_data が None ではなく {:?} を返した",
             result.map(|(d, f)| (d.len(), f))
         );
-    }
+        Ok(())
+    })?;
+    Ok(())
 }

--- a/pbt/tests/prop_datagram/main.rs
+++ b/pbt/tests/prop_datagram/main.rs
@@ -1,122 +1,111 @@
 //! Property-Based Testing for WebTransport Datagram
 //! (RFC 9297, draft-ietf-webtrans-http3-15 Section 4.5)
 
-use proptest::prelude::*;
 use shiguredo_http3::VarInt;
 use shiguredo_http3::webtransport::Datagram;
 
 // =============================================================================
-// Strategy ヘルパー
+// 生成ヘルパー
 // =============================================================================
 
-prop_compose! {
-    /// 有効なセッション ID (client-initiated bidirectional stream ID: 4 の倍数)
-    fn valid_session_id()(id in 0u64..250_000) -> u64 {
-        id * 4
-    }
+/// 有効なセッション ID (client-initiated bidirectional stream ID: 4 の倍数)
+fn valid_session_id(ctx: &mut noprop::TestCaseContext) -> u64 {
+    noprop::sample_u64_in(ctx, 0..250_000) * 4
 }
 
-prop_compose! {
-    /// 有効なペイロードを生成
-    fn valid_payload()(
-        len in 0usize..512,
-    )(
-        data in prop::collection::vec(any::<u8>(), len)
-    ) -> Vec<u8> {
-        data
-    }
+/// 有効なペイロードを生成
+fn valid_payload(ctx: &mut noprop::TestCaseContext) -> Vec<u8> {
+    let len = noprop::sample_usize_in(ctx, 0..512);
+    noprop::sample_bytes_vec(ctx, len)
 }
 
 // =============================================================================
 // (a) Datagram encode/decode ラウンドトリップ
 // =============================================================================
 
-proptest! {
-    /// Property: 有効な session_id と任意のペイロードで encode → decode が元と一致する
-    #[test]
-    fn prop_datagram_roundtrip(
-        session_id in valid_session_id(),
-        payload in valid_payload(),
-    ) {
+/// Property: 有効な session_id と任意のペイロードで encode → decode が元と一致する
+#[test]
+fn prop_datagram_roundtrip() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_DATAGRAM_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let session_id = valid_session_id(ctx);
+        let payload = valid_payload(ctx);
         let datagram = Datagram::new(session_id, payload.clone()).expect("test must succeed");
 
         let mut buf = Vec::new();
         datagram.encode(&mut buf);
 
-        let (decoded, consumed) = Datagram::decode(&buf)
-            .expect("decode should succeed for valid encoded datagram");
+        let (decoded, consumed) =
+            Datagram::decode(&buf).expect("decode should succeed for valid encoded datagram");
 
-        prop_assert_eq!(
-            decoded.session_id, session_id,
-            "session_id が一致しない"
-        );
-        prop_assert_eq!(
-            decoded.payload, payload,
-            "payload が一致しない"
-        );
-        prop_assert_eq!(
-            consumed,
-            buf.len(),
-            "消費バイト数がバッファ長と不一致"
-        );
-    }
+        assert_eq!(decoded.session_id, session_id, "session_id が一致しない");
+        assert_eq!(decoded.payload, payload, "payload が一致しない");
+        assert_eq!(consumed, buf.len(), "消費バイト数がバッファ長と不一致");
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // (b) quarter_stream_id == session_id / 4
 // =============================================================================
 
-proptest! {
-    /// Property: quarter_stream_id() は常に session_id / 4 を返す
-    #[test]
-    fn prop_quarter_stream_id_equals_session_id_div_4(
-        session_id in valid_session_id(),
-    ) {
+/// Property: quarter_stream_id() は常に session_id / 4 を返す
+#[test]
+fn prop_quarter_stream_id_equals_session_id_div_4() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_DATAGRAM_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let session_id = valid_session_id(ctx);
         let datagram = Datagram::new(session_id, vec![]).expect("test must succeed");
         let qsi = datagram.quarter_stream_id();
 
-        prop_assert_eq!(
-            qsi,
-            session_id / 4,
-            "quarter_stream_id != session_id / 4"
-        );
-    }
+        assert_eq!(qsi, session_id / 4, "quarter_stream_id != session_id / 4");
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // (c) decode が返す session_id は常に 4 の倍数
 // =============================================================================
 
-proptest! {
-    /// Property: decode で復元された session_id は常に 4 の倍数である
-    /// (quarter_stream_id * 4 で復元されるため)
-    #[test]
-    fn prop_decoded_session_id_always_multiple_of_4(
-        session_id in valid_session_id(),
-        payload in valid_payload(),
-    ) {
+/// Property: decode で復元された session_id は常に 4 の倍数である
+/// (quarter_stream_id * 4 で復元されるため)
+#[test]
+fn prop_decoded_session_id_always_multiple_of_4() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_DATAGRAM_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let session_id = valid_session_id(ctx);
+        let payload = valid_payload(ctx);
         let datagram = Datagram::new(session_id, payload).expect("test must succeed");
 
         let mut buf = Vec::new();
         datagram.encode(&mut buf);
 
-        let (decoded, _) = Datagram::decode(&buf)
-            .expect("decode should succeed");
+        let (decoded, _) = Datagram::decode(&buf).expect("decode should succeed");
 
-        prop_assert!(
+        assert!(
             decoded.session_id % 4 == 0,
             "decode された session_id ({}) が 4 の倍数でない",
             decoded.session_id,
         );
-    }
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: 任意の varint 値を Quarter Stream ID として直接エンコードした場合でも
-    ///           decode の結果の session_id は 4 の倍数
-    #[test]
-    fn prop_arbitrary_qsi_decodes_to_multiple_of_4(
-        qsi in 0u64..=(VarInt::MAX.get() / 4),
-        payload in valid_payload(),
-    ) {
+/// Property: 任意の varint 値を Quarter Stream ID として直接エンコードした場合でも
+///           decode の結果の session_id は 4 の倍数
+#[test]
+fn prop_arbitrary_qsi_decodes_to_multiple_of_4() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_DATAGRAM_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let qsi = noprop::sample_u64_in(ctx, 0..=(VarInt::MAX.get() / 4));
+        let payload = valid_payload(ctx);
         // Quarter Stream ID を直接エンコードする
         let mut buf = Vec::new();
         shiguredo_http3::varint::encode_into_vec(
@@ -125,16 +114,18 @@ proptest! {
         );
         buf.extend_from_slice(&payload);
 
-        let (decoded, consumed) = Datagram::decode(&buf)
-            .expect("decode should succeed for valid varint + payload");
+        let (decoded, consumed) =
+            Datagram::decode(&buf).expect("decode should succeed for valid varint + payload");
 
-        prop_assert_eq!(
+        assert_eq!(
             decoded.session_id,
             qsi * 4,
             "session_id ({}) != qsi * 4 ({})",
             decoded.session_id,
             qsi * 4,
         );
-        prop_assert_eq!(consumed, buf.len());
-    }
+        assert_eq!(consumed, buf.len());
+        Ok(())
+    })?;
+    Ok(())
 }

--- a/pbt/tests/prop_frame.rs
+++ b/pbt/tests/prop_frame.rs
@@ -1,16 +1,16 @@
 //! Property-Based Testing for HTTP/3 Frames (RFC 9114)
 
-use proptest::prelude::*;
 use shiguredo_http3::VarInt;
 use shiguredo_http3::frame::{
     DataPayload, Frame, FrameType, GoawayPayload, HeadersPayload, SettingsPayload, UnknownFrame,
     decode_frame, encode_frame, encoded_frame_len,
 };
 
-prop_compose! {
-    /// 有効なフレームタイプを生成
-    fn valid_frame_type()(
-        frame_type in prop::sample::select(vec![
+/// 有効なフレームタイプを生成
+fn valid_frame_type(ctx: &mut noprop::TestCaseContext) -> FrameType {
+    noprop::sample_choice(
+        ctx,
+        &[
             FrameType::Data,
             FrameType::Headers,
             FrameType::CancelPush,
@@ -18,131 +18,140 @@ prop_compose! {
             FrameType::PushPromise,
             FrameType::Goaway,
             FrameType::MaxPushId,
-        ])
-    ) -> FrameType {
-        frame_type
-    }
+        ],
+    )
 }
 
-prop_compose! {
-    /// 有効なペイロードデータを生成
-    fn valid_payload()(
-        len in 0usize..1024,
-    )(
-        data in prop::collection::vec(any::<u8>(), len)
-    ) -> Vec<u8> {
-        data
-    }
+/// 有効なペイロードデータを生成
+fn valid_payload(ctx: &mut noprop::TestCaseContext) -> Vec<u8> {
+    let len = noprop::sample_usize_in(ctx, 0..1024);
+    noprop::sample_bytes_vec(ctx, len)
 }
 
-prop_compose! {
-    /// 有効なストリーム ID を生成 (GOAWAY 用)
-    fn valid_goaway_id()(id in (0u64..1000).prop_map(|x| x * 4)) -> u64 {
-        id // クライアント開始双方向ストリームは 4 の倍数
-    }
+/// 有効なストリーム ID を生成 (GOAWAY 用)
+fn valid_goaway_id(ctx: &mut noprop::TestCaseContext) -> u64 {
+    // クライアント開始双方向ストリームは 4 の倍数
+    noprop::sample_u64_in(ctx, 0..1000) * 4
 }
 
-prop_compose! {
-    /// 有効な QPACK エンコード済みヘッダーを生成
-    fn valid_encoded_headers()(
-        len in 2usize..256,
-    )(
-        data in prop::collection::vec(any::<u8>(), len)
-    ) -> Vec<u8> {
-        let mut result = vec![0x00, 0x00]; // RIC=0, Delta Base=0
-        result.extend(data.into_iter().skip(2));
-        result
-    }
+/// 有効な QPACK エンコード済みヘッダーを生成
+fn valid_encoded_headers(ctx: &mut noprop::TestCaseContext) -> Vec<u8> {
+    let len = noprop::sample_usize_in(ctx, 2..256);
+    let data = noprop::sample_bytes_vec(ctx, len);
+    let mut result = vec![0x00, 0x00]; // RIC=0, Delta Base=0
+    result.extend(data.into_iter().skip(2));
+    result
 }
 
-prop_compose! {
-    /// 有効な SETTINGS エントリを生成
-    ///
-    /// 重複 ID を除外し、bool 値 ID (0x08 / 0x33 / 0x2b603742) は値域を 0/1 に制限する。
-    /// H3 コア (0x01 / 0x06 / 0x07 / 0x08 / 0x33) と WebTransport 拡張 ID を網羅する。
-    /// [`shiguredo_http3::Setting::from_wire`] で構築可能な値のみを返す。
-    fn valid_settings_entries()(
-        entries in prop::collection::vec(
-            (
-                prop::sample::select(vec![
-                    0x01u64, 0x06, 0x07, 0x08, 0x33,
-                    0x2b61, 0x2b64, 0x2b65, 0x14e9cd29, 0x2c7cf000,
-                    0x2b603742, 0xc671706a,
-                ]),
-                0u64..65536,
-            ),
-            0..8
-        )
-    ) -> Vec<shiguredo_http3::Setting> {
-        use shiguredo_http3::{Setting, VarInt};
-        let mut seen = std::collections::HashSet::new();
-        entries
-            .into_iter()
-            .filter(|(k, _)| seen.insert(*k))
-            .map(|(id, value)| {
-                let normalized = if matches!(id, 0x08 | 0x33 | 0x2b603742) {
-                    value & 1
-                } else {
-                    value
-                };
-                Setting::from_wire(VarInt::new(id).expect("test must succeed"), VarInt::new(normalized).expect("test must succeed"))
-                    .expect("test must succeed")
-            })
-            .collect()
+/// 有効な SETTINGS エントリを生成
+///
+/// 重複 ID を除外し、bool 値 ID (0x08 / 0x33 / 0x2b603742) は値域を 0/1 に制限する。
+/// H3 コア (0x01 / 0x06 / 0x07 / 0x08 / 0x33) と WebTransport 拡張 ID を網羅する。
+/// [`shiguredo_http3::Setting::from_wire`] で構築可能な値のみを返す。
+fn valid_settings_entries(ctx: &mut noprop::TestCaseContext) -> Vec<shiguredo_http3::Setting> {
+    use shiguredo_http3::{Setting, VarInt};
+    let ids = [
+        0x01u64, 0x06, 0x07, 0x08, 0x33, 0x2b61, 0x2b64, 0x2b65, 0x14e9cd29, 0x2c7cf000,
+        0x2b603742, 0xc671706a,
+    ];
+    let count = noprop::sample_usize_in(ctx, 0..8);
+    let mut seen = std::collections::HashSet::new();
+    let mut entries = Vec::new();
+    for _ in 0..count {
+        let id = noprop::sample_choice(ctx, &ids);
+        // 重複 ID はスキップする
+        if !seen.insert(id) {
+            continue;
+        }
+        let value = noprop::sample_u64_in(ctx, 0..65536);
+        let normalized = if matches!(id, 0x08 | 0x33 | 0x2b603742) {
+            value & 1
+        } else {
+            value
+        };
+        entries.push(
+            Setting::from_wire(
+                VarInt::new(id).expect("test must succeed"),
+                VarInt::new(normalized).expect("test must succeed"),
+            )
+            .expect("test must succeed"),
+        );
     }
+    entries
 }
 
 // =============================================================================
 // Frame Type Properties
 // =============================================================================
 
-proptest! {
-    /// Property: from_type は既知のタイプに対して Some を返す
-    #[test]
-    fn prop_known_frame_type_recognized(frame_type in valid_frame_type()) {
+/// Property: from_type は既知のタイプに対して Some を返す
+#[test]
+fn prop_known_frame_type_recognized() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_FRAME_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let frame_type = valid_frame_type(ctx);
         let type_value = frame_type as u64;
         let parsed = FrameType::from_type(type_value);
 
-        prop_assert!(
+        assert!(
             parsed.is_some(),
             "Frame type {:?} (0x{:02x}) should be recognized",
-            frame_type, type_value
+            frame_type,
+            type_value
         );
-        prop_assert_eq!(parsed.expect("test must succeed"), frame_type);
-    }
+        assert_eq!(parsed.expect("test must succeed"), frame_type);
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: HTTP/2 専用フレームタイプは is_http2_only で検出される
-    #[test]
-    fn prop_http2_frame_types_detected(
-        frame_type in prop::sample::select(vec![0x02u64, 0x06, 0x08, 0x09])
-    ) {
-        prop_assert!(
+/// Property: HTTP/2 専用フレームタイプは is_http2_only で検出される
+#[test]
+fn prop_http2_frame_types_detected() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_FRAME_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let frame_type = noprop::sample_choice(ctx, &[0x02u64, 0x06, 0x08, 0x09]);
+        assert!(
             FrameType::is_http2_only(frame_type),
             "Frame type 0x{:02x} should be HTTP/2 only",
             frame_type
         );
-    }
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: 有効な HTTP/3 フレームタイプは HTTP/2 専用ではない
-    #[test]
-    fn prop_http3_frame_types_not_http2_only(frame_type in valid_frame_type()) {
+/// Property: 有効な HTTP/3 フレームタイプは HTTP/2 専用ではない
+#[test]
+fn prop_http3_frame_types_not_http2_only() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_FRAME_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let frame_type = valid_frame_type(ctx);
         let type_value = frame_type as u64;
-        prop_assert!(
+        assert!(
             !FrameType::is_http2_only(type_value),
             "HTTP/3 frame type 0x{:02x} should not be HTTP/2 only",
             type_value
         );
-    }
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // DATA Frame Properties
 // =============================================================================
 
-proptest! {
-    /// Property: DATA フレームのエンコード/デコードラウンドトリップ
-    #[test]
-    fn prop_data_frame_roundtrip(payload in valid_payload()) {
+/// Property: DATA フレームのエンコード/デコードラウンドトリップ
+#[test]
+fn prop_data_frame_roundtrip() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_FRAME_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let payload = valid_payload(ctx);
         let frame = Frame::Data(DataPayload::new(payload.clone()));
 
         let mut buf = vec![0u8; encoded_frame_len(&frame).expect("test must succeed")];
@@ -150,51 +159,60 @@ proptest! {
 
         let (decoded, decoded_len) = decode_frame(&buf[..encoded_len]).expect("test must succeed");
 
-        prop_assert_eq!(encoded_len, decoded_len, "Encoded/decoded length mismatch");
+        assert_eq!(encoded_len, decoded_len, "Encoded/decoded length mismatch");
 
         if let Frame::Data(data) = decoded {
-            prop_assert_eq!(
-                data.data(), payload.as_slice(),
-                "DATA payload mismatch"
-            );
+            assert_eq!(data.data(), payload.as_slice(), "DATA payload mismatch");
         } else {
-            prop_assert!(false, "Expected DATA frame");
+            panic!("Expected DATA frame");
         }
-    }
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: DATA フレームの長さはペイロード長と一致
-    #[test]
-    fn prop_data_frame_length_matches_payload(payload in valid_payload()) {
+/// Property: DATA フレームの長さはペイロード長と一致
+#[test]
+fn prop_data_frame_length_matches_payload() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_FRAME_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let payload = valid_payload(ctx);
         let frame = Frame::Data(DataPayload::new(payload.clone()));
 
         // FrameType::Data は 0x00 (1 バイト VarInt) で構築不能ではないため、
         // ランタイム値の `VarInt::new` を使って整合性を取る (const 文脈ではないので
         // `from_static` は使わない)。
-        let expected_len = shiguredo_http3::VarInt::new(FrameType::Data as u64)
+        let expected_len = VarInt::new(FrameType::Data as u64)
             .expect("test must succeed")
             .encoded_len()
-            + shiguredo_http3::VarInt::new(payload.len() as u64)
+            + VarInt::new(payload.len() as u64)
                 .expect("test must succeed")
                 .encoded_len()
             + payload.len();
 
         let actual_len = encoded_frame_len(&frame).expect("test must succeed");
 
-        prop_assert_eq!(
+        assert_eq!(
             actual_len, expected_len,
             "Frame length calculation mismatch"
         );
-    }
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // HEADERS Frame Properties
 // =============================================================================
 
-proptest! {
-    /// Property: HEADERS フレームのエンコード/デコードラウンドトリップ
-    #[test]
-    fn prop_headers_frame_roundtrip(encoded_block in valid_encoded_headers()) {
+/// Property: HEADERS フレームのエンコード/デコードラウンドトリップ
+#[test]
+fn prop_headers_frame_roundtrip() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_FRAME_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let encoded_block = valid_encoded_headers(ctx);
         let frame = Frame::Headers(HeadersPayload::new(encoded_block.clone()));
 
         let mut buf = vec![0u8; encoded_frame_len(&frame).expect("test must succeed")];
@@ -202,27 +220,33 @@ proptest! {
 
         let (decoded, decoded_len) = decode_frame(&buf[..encoded_len]).expect("test must succeed");
 
-        prop_assert_eq!(encoded_len, decoded_len);
+        assert_eq!(encoded_len, decoded_len);
 
         if let Frame::Headers(headers) = decoded {
-            prop_assert_eq!(
-                headers.encoded_field_section(), encoded_block.as_slice(),
+            assert_eq!(
+                headers.encoded_field_section(),
+                encoded_block.as_slice(),
                 "HEADERS encoded block mismatch"
             );
         } else {
-            prop_assert!(false, "Expected HEADERS frame");
+            panic!("Expected HEADERS frame");
         }
-    }
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // SETTINGS Frame Properties
 // =============================================================================
 
-proptest! {
-    /// Property: SETTINGS フレームのエンコード/デコードラウンドトリップ
-    #[test]
-    fn prop_settings_frame_roundtrip(entries in valid_settings_entries()) {
+/// Property: SETTINGS フレームのエンコード/デコードラウンドトリップ
+#[test]
+fn prop_settings_frame_roundtrip() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_FRAME_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let entries = valid_settings_entries(ctx);
         // valid_settings_entries() は重複 ID を除外済みのため `add` は必ず Ok
         let mut payload = SettingsPayload::new();
         for setting in &entries {
@@ -235,35 +259,37 @@ proptest! {
 
         let (decoded, decoded_len) = decode_frame(&buf[..encoded_len]).expect("test must succeed");
 
-        prop_assert_eq!(encoded_len, decoded_len);
+        assert_eq!(encoded_len, decoded_len);
 
         if let Frame::Settings(settings) = decoded {
-            prop_assert_eq!(settings.settings().len(), entries.len());
+            assert_eq!(settings.settings().len(), entries.len());
             for (orig, decoded) in entries.iter().zip(settings.settings().iter()) {
-                prop_assert_eq!(orig, decoded);
+                assert_eq!(orig, decoded);
             }
         } else {
-            prop_assert!(false, "Expected SETTINGS frame");
+            panic!("Expected SETTINGS frame");
         }
-    }
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: 空の SETTINGS フレームは有効
-    #[test]
-    fn prop_empty_settings_frame_valid(_dummy in Just(())) {
-        let frame = Frame::Settings(SettingsPayload::new());
+/// Property: 空の SETTINGS フレームは有効
+#[test]
+fn prop_empty_settings_frame_valid() {
+    let frame = Frame::Settings(SettingsPayload::new());
 
-        let mut buf = vec![0u8; encoded_frame_len(&frame).expect("test must succeed")];
-        let encoded_len = encode_frame(&mut buf, &frame).expect("test must succeed");
+    let mut buf = vec![0u8; encoded_frame_len(&frame).expect("test must succeed")];
+    let encoded_len = encode_frame(&mut buf, &frame).expect("test must succeed");
 
-        let (decoded, decoded_len) = decode_frame(&buf[..encoded_len]).expect("test must succeed");
+    let (decoded, decoded_len) = decode_frame(&buf[..encoded_len]).expect("test must succeed");
 
-        prop_assert_eq!(encoded_len, decoded_len);
+    assert_eq!(encoded_len, decoded_len);
 
-        if let Frame::Settings(settings) = decoded {
-            prop_assert!(settings.is_empty());
-        } else {
-            prop_assert!(false, "Expected SETTINGS frame");
-        }
+    if let Frame::Settings(settings) = decoded {
+        assert!(settings.is_empty());
+    } else {
+        panic!("Expected SETTINGS frame");
     }
 }
 
@@ -271,11 +297,14 @@ proptest! {
 // GOAWAY Frame Properties
 // =============================================================================
 
-proptest! {
-    /// Property: GOAWAY フレームのエンコード/デコードラウンドトリップ
-    #[test]
-    fn prop_goaway_frame_roundtrip(id in valid_goaway_id()) {
-        let id = VarInt::new(id).expect("test must succeed");
+/// Property: GOAWAY フレームのエンコード/デコードラウンドトリップ
+#[test]
+fn prop_goaway_frame_roundtrip() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_FRAME_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let raw_id = valid_goaway_id(ctx);
+        let id = VarInt::new(raw_id).expect("test must succeed");
         let frame = Frame::Goaway(GoawayPayload::new(id));
 
         let mut buf = vec![0u8; encoded_frame_len(&frame).expect("test must succeed")];
@@ -283,36 +312,37 @@ proptest! {
 
         let (decoded, decoded_len) = decode_frame(&buf[..encoded_len]).expect("test must succeed");
 
-        prop_assert_eq!(encoded_len, decoded_len);
+        assert_eq!(encoded_len, decoded_len);
 
         if let Frame::Goaway(goaway) = decoded {
-            prop_assert_eq!(
-                goaway.id(), id,
-                "GOAWAY id mismatch"
-            );
+            assert_eq!(goaway.id(), id, "GOAWAY id mismatch");
         } else {
-            prop_assert!(false, "Expected GOAWAY frame");
+            panic!("Expected GOAWAY frame");
         }
-    }
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // Unknown Frame Properties
 // =============================================================================
 
-proptest! {
-    /// Property: 未知のフレームタイプはペイロードとともに保存される
-    ///
-    /// VarInt 全領域 (0..=2^62-1, RFC 9000 Section 16) から既知タイプと
-    /// HTTP/2 専用 ID (RFC 9114 Section 7.2 / Section 11.2.1 Table 2) を除いて生成する。
-    #[test]
-    fn prop_unknown_frame_preserved(
-        unknown_type in (0u64..(1u64 << 62)).prop_filter(
-            "既知 / HTTP/2 専用フレームタイプを除外",
-            |t| FrameType::from_type(*t).is_none() && !FrameType::is_http2_only(*t),
-        ),
-        payload in valid_payload(),
-    ) {
+/// Property: 未知のフレームタイプはペイロードとともに保存される
+///
+/// VarInt 全領域 (0..=2^62-1, RFC 9000 Section 16) から既知タイプと
+/// HTTP/2 専用 ID (RFC 9114 Section 7.2 / Section 11.2.1 Table 2) を除いて生成する。
+#[test]
+fn prop_unknown_frame_preserved() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_FRAME_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        // 既知 / HTTP/2 専用フレームタイプを除外
+        let unknown_type = noprop::sample_with_rejection(ctx, 256, |ctx| {
+            let t = noprop::sample_u64_in(ctx, 0..(1u64 << 62));
+            (FrameType::from_type(t).is_none() && !FrameType::is_http2_only(t)).then_some(t)
+        });
+        let payload = valid_payload(ctx);
         let frame_type = VarInt::new(unknown_type).expect("test must succeed");
         let unknown = UnknownFrame::new(frame_type, payload.clone())
             .expect("生成範囲は既知タイプでも HTTP/2 専用でもない");
@@ -323,49 +353,61 @@ proptest! {
 
         let (decoded, decoded_len) = decode_frame(&buf[..encoded_len]).expect("test must succeed");
 
-        prop_assert_eq!(encoded_len, decoded_len);
+        assert_eq!(encoded_len, decoded_len);
 
         if let Frame::Unknown(decoded_unknown) = decoded {
-            prop_assert_eq!(decoded_unknown.frame_type(), frame_type);
-            prop_assert_eq!(decoded_unknown.payload(), payload.as_slice());
+            assert_eq!(decoded_unknown.frame_type(), frame_type);
+            assert_eq!(decoded_unknown.payload(), payload.as_slice());
         } else {
-            prop_assert!(false, "Expected Unknown frame");
+            panic!("Expected Unknown frame");
         }
-    }
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // Frame Length Properties
 // =============================================================================
 
-proptest! {
-    /// Property: encoded_frame_len は常に実際のエンコード長と一致
-    #[test]
-    fn prop_encoded_frame_len_accurate(payload in valid_payload()) {
+/// Property: encoded_frame_len は常に実際のエンコード長と一致
+#[test]
+fn prop_encoded_frame_len_accurate() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_FRAME_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let payload = valid_payload(ctx);
         let frame = Frame::Data(DataPayload::new(payload));
 
         let predicted_len = encoded_frame_len(&frame).expect("test must succeed");
         let mut buf = vec![0u8; predicted_len + 100]; // 余裕を持たせる
         let actual_len = encode_frame(&mut buf, &frame).expect("test must succeed");
 
-        prop_assert_eq!(
+        assert_eq!(
             predicted_len, actual_len,
             "encoded_frame_len prediction mismatch"
         );
-    }
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // Construct-Time Validation Consistency
 // =============================================================================
 
-proptest! {
-    /// Property: GoawayPayload::from_static と new(VarInt::new(id)) が同じ値を返す
-    /// (`const fn` 検査とランタイム検査のロジック一致)
-    #[test]
-    fn prop_goaway_from_static_matches_new(value in 0u64..=VarInt::MAX.get()) {
+/// Property: GoawayPayload::from_static と new(VarInt::new(id)) が同じ値を返す
+/// (`const fn` 検査とランタイム検査のロジック一致)
+#[test]
+fn prop_goaway_from_static_matches_new() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_FRAME_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let value = noprop::sample_u64_in(ctx, 0..=VarInt::MAX.get());
         let via_new = GoawayPayload::new(VarInt::new(value).expect("test must succeed"));
         let via_static = GoawayPayload::from_static(value);
-        prop_assert_eq!(via_new, via_static);
-    }
+        assert_eq!(via_new, via_static);
+        Ok(())
+    })?;
+    Ok(())
 }

--- a/pbt/tests/prop_qpack/integer.rs
+++ b/pbt/tests/prop_qpack/integer.rs
@@ -2,46 +2,63 @@
 //!
 //! 境界値テストは tests/test_qpack_integer.rs を参照。
 
-use proptest::prelude::*;
 use shiguredo_http3::qpack::integer;
 
 // RFC 9204 Section 4.1.1: 62 ビットまでデコード可能 (MUST)
 const MAX_DECODABLE_VALUE: u64 = (1u64 << 62) - 1;
 
-proptest! {
-    /// Property: encode -> decode のラウンドトリップで値が一致する (スライス版)
-    #[test]
-    fn prop_integer_roundtrip_slice(
-        prefix_bits in 1u8..=8,
-        value in 0u64..=MAX_DECODABLE_VALUE,
-        raw_prefix in any::<u8>(),
-    ) {
+/// prefix_bits (1..=8) を生成する
+fn sample_prefix_bits(ctx: &mut noprop::TestCaseContext) -> u8 {
+    noprop::sample_usize_in(ctx, 1..=8) as u8
+}
+
+/// Property: encode -> decode のラウンドトリップで値が一致する (スライス版)
+#[test]
+fn prop_integer_roundtrip_slice() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_QPACK_INTEGER_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let prefix_bits = sample_prefix_bits(ctx);
+        let value = noprop::sample_u64_in(ctx, 0..=MAX_DECODABLE_VALUE);
+        let raw_prefix = noprop::sample_u8(ctx);
+
         let prefix_mask = 0xFFu8.checked_shl(prefix_bits as u32).unwrap_or(0);
         let prefix = raw_prefix & prefix_mask;
 
         let mut buf = vec![0u8; 16];
-        let Some(encoded_len) = integer::encode_integer(&mut buf, value, prefix_bits, prefix) else {
-            return Err(TestCaseError::reject("バッファが小さすぎる"));
-        };
+        // 16 バイトバッファは 62 ビット値の最大エンコード長 (9 バイト) に対して十分
+        let encoded_len = integer::encode_integer(&mut buf, value, prefix_bits, prefix)
+            .expect("16 バイトバッファはエンコードに十分");
 
-        let (decoded_value, decoded_len) = integer::decode_integer(&buf[..encoded_len], prefix_bits)
-            .map_err(|e| TestCaseError::fail(format!("デコード失敗: {:?}", e)))?;
+        let (decoded_value, decoded_len) =
+            integer::decode_integer(&buf[..encoded_len], prefix_bits)
+                .map_err(|e| format!("デコード失敗: {:?}", e))?;
 
-        prop_assert_eq!(decoded_value, value, "値が一致しない");
-        prop_assert_eq!(decoded_len, encoded_len, "長さが一致しない");
+        assert_eq!(decoded_value, value, "値が一致しない");
+        assert_eq!(decoded_len, encoded_len, "長さが一致しない");
 
         // prefix ビット外のビットが保存されていること
         let first_byte_prefix = buf[0] & prefix_mask;
-        prop_assert_eq!(first_byte_prefix, prefix & prefix_mask, "prefix ビットが壊れている");
-    }
+        assert_eq!(
+            first_byte_prefix,
+            prefix & prefix_mask,
+            "prefix ビットが壊れている"
+        );
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: encode -> decode のラウンドトリップで値が一致する (Vec 版)
-    #[test]
-    fn prop_integer_roundtrip_vec(
-        prefix_bits in 1u8..=8,
-        value in 0u64..=MAX_DECODABLE_VALUE,
-        raw_prefix in any::<u8>(),
-    ) {
+/// Property: encode -> decode のラウンドトリップで値が一致する (Vec 版)
+#[test]
+fn prop_integer_roundtrip_vec() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_QPACK_INTEGER_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let prefix_bits = sample_prefix_bits(ctx);
+        let value = noprop::sample_u64_in(ctx, 0..=MAX_DECODABLE_VALUE);
+        let raw_prefix = noprop::sample_u8(ctx);
+
         let prefix_mask = 0xFFu8.checked_shl(prefix_bits as u32).unwrap_or(0);
         let prefix = raw_prefix & prefix_mask;
 
@@ -49,44 +66,63 @@ proptest! {
         integer::encode_integer_to_vec(&mut buf, value, prefix_bits, prefix);
 
         let (decoded_value, decoded_len) = integer::decode_integer(&buf, prefix_bits)
-            .map_err(|e| TestCaseError::fail(format!("デコード失敗: {:?}", e)))?;
+            .map_err(|e| format!("デコード失敗: {:?}", e))?;
 
-        prop_assert_eq!(decoded_value, value, "値が一致しない");
-        prop_assert_eq!(decoded_len, buf.len(), "長さが一致しない");
-    }
+        assert_eq!(decoded_value, value, "値が一致しない");
+        assert_eq!(decoded_len, buf.len(), "長さが一致しない");
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: スライス版と Vec 版のエンコード結果が一致する
-    #[test]
-    fn prop_slice_and_vec_encode_match(
-        prefix_bits in 1u8..=8,
-        value in 0u64..=MAX_DECODABLE_VALUE,
-        raw_prefix in any::<u8>(),
-    ) {
+/// Property: スライス版と Vec 版のエンコード結果が一致する
+#[test]
+fn prop_slice_and_vec_encode_match() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_QPACK_INTEGER_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let prefix_bits = sample_prefix_bits(ctx);
+        let value = noprop::sample_u64_in(ctx, 0..=MAX_DECODABLE_VALUE);
+        let raw_prefix = noprop::sample_u8(ctx);
+
         let prefix_mask = 0xFFu8.checked_shl(prefix_bits as u32).unwrap_or(0);
         let prefix = raw_prefix & prefix_mask;
 
         let mut slice_buf = vec![0u8; 16];
-        let Some(encoded_len) = integer::encode_integer(&mut slice_buf, value, prefix_bits, prefix) else {
-            return Err(TestCaseError::reject("バッファが小さすぎる"));
-        };
+        let encoded_len = integer::encode_integer(&mut slice_buf, value, prefix_bits, prefix)
+            .expect("16 バイトバッファはエンコードに十分");
 
         let mut vec_buf = Vec::new();
         integer::encode_integer_to_vec(&mut vec_buf, value, prefix_bits, prefix);
 
-        prop_assert_eq!(&slice_buf[..encoded_len], &vec_buf[..], "エンコード結果が一致しない");
-    }
+        assert_eq!(
+            &slice_buf[..encoded_len],
+            &vec_buf[..],
+            "エンコード結果が一致しない"
+        );
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: prefix_bits の上限値 (2^N - 1) 未満の値は 1 バイトでエンコードされる
-    #[test]
-    fn prop_small_value_single_byte(
-        prefix_bits in 1u8..=8,
-    ) {
+/// Property: prefix_bits の上限値 (2^N - 1) 未満の値は 1 バイトでエンコードされる
+#[test]
+fn prop_small_value_single_byte() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_QPACK_INTEGER_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let prefix_bits = sample_prefix_bits(ctx);
         let max_prefix = (1u64 << prefix_bits) - 1;
         let value = max_prefix - 1;
         let mut buf = vec![0u8; 16];
         let encoded_len = integer::encode_integer(&mut buf, value, prefix_bits, 0x00)
             .expect("エンコードは成功するはず");
 
-        prop_assert_eq!(encoded_len, 1, "max_prefix 未満の値は 1 バイトでエンコードされるべき");
-    }
+        assert_eq!(
+            encoded_len, 1,
+            "max_prefix 未満の値は 1 バイトでエンコードされるべき"
+        );
+        Ok(())
+    })?;
+    Ok(())
 }

--- a/pbt/tests/prop_qpack/main.rs
+++ b/pbt/tests/prop_qpack/main.rs
@@ -4,7 +4,6 @@ mod integer;
 
 use pbt::strategies::{valid_header_name, valid_header_value};
 use pbt::wire_header;
-use proptest::prelude::*;
 use shiguredo_http3::qpack::{
     DecodeOutput, Decoder, DecoderInstruction, DecoderStream, DecoderStreamReceiver,
     DynamicDecoder, DynamicEncoder, DynamicEntry, DynamicTable, Encoder, EncoderInstruction,
@@ -17,149 +16,171 @@ const DYNAMIC_TABLE_CAPACITY: u64 = 4096;
 /// エントリオーバーヘッド (RFC 9204 Section 3.2.1)
 const ENTRY_OVERHEAD: u64 = 32;
 
-prop_compose! {
-    /// 有効なストリーム ID を生成
-    fn valid_stream_id()(id in 0u64..1000) -> u64 {
-        id
-    }
+/// 有効なストリーム ID を生成
+fn valid_stream_id(ctx: &mut noprop::TestCaseContext) -> u64 {
+    noprop::sample_u64_in(ctx, 0..1000)
 }
 
-prop_compose! {
-    /// 有効なインクリメント値を生成
-    fn valid_increment()(inc in 1u64..1000) -> u64 {
-        inc
-    }
+/// 有効なインクリメント値を生成
+fn valid_increment(ctx: &mut noprop::TestCaseContext) -> u64 {
+    noprop::sample_u64_in(ctx, 1..1000)
 }
 
 // =============================================================================
 // Dynamic Table Properties
 // =============================================================================
 
-proptest! {
-    /// Property: エントリサイズは常に 32 + name_len + value_len
-    #[test]
-    fn prop_entry_size_formula(
-        name in valid_header_name(),
-        value in valid_header_value(),
-    ) {
+/// Property: エントリサイズは常に 32 + name_len + value_len
+#[test]
+fn prop_entry_size_formula() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_QPACK_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let name = valid_header_name(ctx);
+        let value = valid_header_value(ctx);
         let entry = DynamicEntry::new(name.clone(), value.clone(), 0);
         let expected_size = ENTRY_OVERHEAD + name.len() as u64 + value.len() as u64;
 
-        prop_assert_eq!(
-            entry.size(), expected_size,
+        assert_eq!(
+            entry.size(),
+            expected_size,
             "Entry size should be 32 + {} + {} = {}",
-            name.len(), value.len(), expected_size
+            name.len(),
+            value.len(),
+            expected_size
         );
-    }
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: テーブルサイズは容量を超えない
-    #[test]
-    fn prop_table_size_within_capacity(
-        capacity in 64u64..4096,
-        entries in prop::collection::vec(
-            (valid_header_name(), valid_header_value()),
-            1..20
-        ),
-    ) {
+/// Property: テーブルサイズは容量を超えない
+#[test]
+fn prop_table_size_within_capacity() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_QPACK_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let capacity = noprop::sample_u64_in(ctx, 64..4096);
+        let entry_count = noprop::sample_usize_in(ctx, 1..20);
         let mut table = DynamicTable::with_capacity(capacity);
 
-        for (name, value) in entries {
+        for _ in 0..entry_count {
+            let name = valid_header_name(ctx);
+            let value = valid_header_value(ctx);
             let _ = table.insert(name, value);
         }
 
-        prop_assert!(
+        assert!(
             table.current_size() <= table.max_capacity(),
             "Table size {} exceeds capacity {}",
-            table.current_size(), table.max_capacity()
+            table.current_size(),
+            table.max_capacity()
         );
-    }
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: 挿入後の insert_count は単調増加
-    #[test]
-    fn prop_insert_count_monotonic(
-        capacity in 256u64..4096,
-        entries in prop::collection::vec(
-            (valid_header_name(), valid_header_value()),
-            1..10
-        ),
-    ) {
+/// Property: 挿入後の insert_count は単調増加
+#[test]
+fn prop_insert_count_monotonic() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_QPACK_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let capacity = noprop::sample_u64_in(ctx, 256..4096);
+        let entry_count = noprop::sample_usize_in(ctx, 1..10);
         let mut table = DynamicTable::with_capacity(capacity);
         let mut prev_count = table.insert_count();
 
-        for (name, value) in entries {
+        for _ in 0..entry_count {
+            let name = valid_header_name(ctx);
+            let value = valid_header_value(ctx);
             if table.insert(name, value).is_some() {
                 let new_count = table.insert_count();
-                prop_assert!(
+                assert!(
                     new_count > prev_count,
                     "Insert count should increase: {} -> {}",
-                    prev_count, new_count
+                    prev_count,
+                    new_count
                 );
                 prev_count = new_count;
             }
         }
-    }
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: 容量変更後もサイズ不変式が維持される
-    #[test]
-    fn prop_capacity_change_maintains_invariant(
-        initial_capacity in 256u64..4096,
-        new_capacity in 64u64..2048,
-        entries in prop::collection::vec(
-            (valid_header_name(), valid_header_value()),
-            1..10
-        ),
-    ) {
+/// Property: 容量変更後もサイズ不変式が維持される
+#[test]
+fn prop_capacity_change_maintains_invariant() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_QPACK_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let initial_capacity = noprop::sample_u64_in(ctx, 256..4096);
+        let new_capacity = noprop::sample_u64_in(ctx, 64..2048);
+        let entry_count = noprop::sample_usize_in(ctx, 1..10);
         let mut table = DynamicTable::with_capacity(initial_capacity);
 
-        for (name, value) in entries {
+        for _ in 0..entry_count {
+            let name = valid_header_name(ctx);
+            let value = valid_header_value(ctx);
             let _ = table.insert(name, value);
         }
 
         table.set_capacity(new_capacity);
 
-        prop_assert!(
+        assert!(
             table.current_size() <= table.max_capacity(),
             "After capacity change: size {} > capacity {}",
-            table.current_size(), table.max_capacity()
+            table.current_size(),
+            table.max_capacity()
         );
-    }
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: 絶対インデックスは一意
-    #[test]
-    fn prop_absolute_index_unique(
-        capacity in 1024u64..4096,
-        entries in prop::collection::vec(
-            (valid_header_name(), valid_header_value()),
-            2..10
-        ),
-    ) {
+/// Property: 絶対インデックスは一意
+#[test]
+fn prop_absolute_index_unique() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_QPACK_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let capacity = noprop::sample_u64_in(ctx, 1024..4096);
+        let entry_count = noprop::sample_usize_in(ctx, 2..10);
         let mut table = DynamicTable::with_capacity(capacity);
         let mut indices = Vec::new();
 
-        for (name, value) in entries {
+        for _ in 0..entry_count {
+            let name = valid_header_name(ctx);
+            let value = valid_header_value(ctx);
             if let Some(idx) = table.insert(name, value) {
-                prop_assert!(
-                    !indices.contains(&idx),
-                    "Duplicate absolute index: {}",
-                    idx
-                );
+                assert!(!indices.contains(&idx), "Duplicate absolute index: {}", idx);
                 indices.push(idx);
             }
         }
-    }
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // Encoder Stream Properties
 // =============================================================================
 
-proptest! {
-    /// Property: Set Capacity 命令のラウンドトリップ
-    #[test]
-    fn prop_set_capacity_roundtrip(capacity in 1u64..=4096) {
+/// Property: Set Capacity 命令のラウンドトリップ
+#[test]
+fn prop_set_capacity_roundtrip() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_QPACK_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let capacity = noprop::sample_u64_in(ctx, 1..=4096);
         let mut sender = EncoderStream::new();
         sender.set_max_table_capacity(4096);
-        sender.encode_set_capacity(capacity).expect("test must succeed");
+        sender
+            .encode_set_capacity(capacity)
+            .expect("test must succeed");
         let encoded = sender.get_data().to_vec();
 
         let mut receiver = EncoderStreamReceiver::new();
@@ -169,22 +190,30 @@ proptest! {
         let mut table = DynamicTable::new();
         let instruction = receiver.process(&mut table).expect("test must succeed");
 
-        prop_assert_eq!(
+        assert_eq!(
             instruction,
             Some(EncoderInstruction::SetDynamicTableCapacity { capacity }),
-            "Roundtrip failed for capacity {}", capacity
+            "Roundtrip failed for capacity {}",
+            capacity
         );
-    }
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: Insert with Literal Name 命令のラウンドトリップ
-    #[test]
-    fn prop_insert_literal_roundtrip(
-        name in valid_header_name(),
-        value in valid_header_value(),
-    ) {
+/// Property: Insert with Literal Name 命令のラウンドトリップ
+#[test]
+fn prop_insert_literal_roundtrip() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_QPACK_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let name = valid_header_name(ctx);
+        let value = valid_header_value(ctx);
         let mut sender = EncoderStream::new();
         sender.set_max_table_capacity(4096);
-        sender.encode_insert_with_literal_name(&name, &value).expect("test must succeed");
+        sender
+            .encode_insert_with_literal_name(&name, &value)
+            .expect("test must succeed");
         let encoded = sender.get_data().to_vec();
 
         let mut receiver = EncoderStreamReceiver::new();
@@ -195,16 +224,23 @@ proptest! {
         let instruction = receiver.process(&mut table).expect("test must succeed");
 
         if let Some(EncoderInstruction::InsertWithLiteralName { name: n, value: v }) = instruction {
-            prop_assert_eq!(n, name, "Name mismatch");
-            prop_assert_eq!(v, value, "Value mismatch");
+            assert_eq!(n, name, "Name mismatch");
+            assert_eq!(v, value, "Value mismatch");
         } else {
-            prop_assert!(false, "Expected InsertWithLiteralName instruction");
+            panic!("Expected InsertWithLiteralName instruction");
         }
-    }
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: Duplicate 命令のラウンドトリップ
-    #[test]
-    fn prop_duplicate_roundtrip(index in 0u64..10) {
+/// Property: Duplicate 命令のラウンドトリップ
+#[test]
+fn prop_duplicate_roundtrip() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_QPACK_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let index = noprop::sample_u64_in(ctx, 0..10);
         let mut sender = EncoderStream::new();
         sender.set_max_table_capacity(4096);
         sender.encode_duplicate(index).expect("test must succeed");
@@ -222,21 +258,28 @@ proptest! {
 
         let instruction = receiver.process(&mut table).expect("test must succeed");
 
-        prop_assert_eq!(
+        assert_eq!(
             instruction,
-            Some(EncoderInstruction::Duplicate { relative_index: index }),
+            Some(EncoderInstruction::Duplicate {
+                relative_index: index
+            }),
         );
-    }
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // Decoder Stream Properties
 // =============================================================================
 
-proptest! {
-    /// Property: Section Acknowledgment 命令のラウンドトリップ
-    #[test]
-    fn prop_section_ack_roundtrip(stream_id in valid_stream_id()) {
+/// Property: Section Acknowledgment 命令のラウンドトリップ
+#[test]
+fn prop_section_ack_roundtrip() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_QPACK_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let stream_id = valid_stream_id(ctx);
         let mut sender = DecoderStream::new();
         sender.encode_section_acknowledgment(stream_id);
         let encoded = sender.get_data().to_vec();
@@ -245,15 +288,22 @@ proptest! {
         receiver.receive(&encoded);
         let instruction = receiver.process(u64::MAX).expect("test must succeed");
 
-        prop_assert_eq!(
+        assert_eq!(
             instruction,
             Some(DecoderInstruction::SectionAcknowledgment { stream_id }),
         );
-    }
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: Stream Cancellation 命令のラウンドトリップ
-    #[test]
-    fn prop_stream_cancel_roundtrip(stream_id in valid_stream_id()) {
+/// Property: Stream Cancellation 命令のラウンドトリップ
+#[test]
+fn prop_stream_cancel_roundtrip() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_QPACK_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let stream_id = valid_stream_id(ctx);
         let mut sender = DecoderStream::new();
         sender.encode_stream_cancellation(stream_id);
         let encoded = sender.get_data().to_vec();
@@ -262,15 +312,22 @@ proptest! {
         receiver.receive(&encoded);
         let instruction = receiver.process(u64::MAX).expect("test must succeed");
 
-        prop_assert_eq!(
+        assert_eq!(
             instruction,
             Some(DecoderInstruction::StreamCancellation { stream_id }),
         );
-    }
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: Insert Count Increment 命令のラウンドトリップ
-    #[test]
-    fn prop_insert_count_increment_roundtrip(increment in valid_increment()) {
+/// Property: Insert Count Increment 命令のラウンドトリップ
+#[test]
+fn prop_insert_count_increment_roundtrip() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_QPACK_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let increment = valid_increment(ctx);
         let mut sender = DecoderStream::new();
         sender.encode_insert_count_increment(increment);
         let encoded = sender.get_data().to_vec();
@@ -279,22 +336,28 @@ proptest! {
         receiver.receive(&encoded);
         let instruction = receiver.process(u64::MAX).expect("test must succeed");
 
-        prop_assert_eq!(
+        assert_eq!(
             instruction,
             Some(DecoderInstruction::InsertCountIncrement { increment }),
         );
-    }
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: Known Received Count は累積される
-    #[test]
-    fn prop_known_received_count_accumulates(
-        increments in prop::collection::vec(valid_increment(), 1..5),
-    ) {
+/// Property: Known Received Count は累積される
+#[test]
+fn prop_known_received_count_accumulates() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_QPACK_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let inc_count = noprop::sample_usize_in(ctx, 1..5);
         let mut sender = DecoderStream::new();
         let mut receiver = DecoderStreamReceiver::new();
 
         let mut expected_count = 0u64;
-        for inc in increments {
+        for _ in 0..inc_count {
+            let inc = valid_increment(ctx);
             sender.encode_insert_count_increment(inc);
             receiver.receive(sender.get_data());
             sender.consume_data(sender.get_data().len());
@@ -302,32 +365,38 @@ proptest! {
             let _ = receiver.process(u64::MAX).expect("test must succeed");
             expected_count += inc;
 
-            prop_assert_eq!(
-                receiver.known_received_count(), expected_count,
+            assert_eq!(
+                receiver.known_received_count(),
+                expected_count,
                 "Known received count should be {}",
                 expected_count
             );
         }
-    }
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // Encoder/Decoder Integration Properties
 // =============================================================================
 
-proptest! {
-    /// Property: エンコーダーストリームの連続命令処理
-    #[test]
-    fn prop_encoder_stream_sequential(
-        name in valid_header_name(),
-        value in valid_header_value(),
-    ) {
+/// Property: エンコーダーストリームの連続命令処理
+#[test]
+fn prop_encoder_stream_sequential() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_QPACK_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let name = valid_header_name(ctx);
+        let value = valid_header_value(ctx);
         let mut sender = EncoderStream::new();
         sender.set_max_table_capacity(4096);
 
         // 複数の命令をエンコード
         sender.encode_set_capacity(1024).expect("test must succeed");
-        sender.encode_insert_with_literal_name(&name, &value).expect("test must succeed");
+        sender
+            .encode_insert_with_literal_name(&name, &value)
+            .expect("test must succeed");
 
         let encoded = sender.get_data().to_vec();
 
@@ -340,27 +409,38 @@ proptest! {
         // 最初の命令: Set Capacity
         let inst1 = receiver.process(&mut table).expect("test must succeed");
         if let Some(EncoderInstruction::SetDynamicTableCapacity { capacity }) = inst1 {
-            prop_assert_eq!(capacity, 1024);
+            assert_eq!(capacity, 1024);
         } else {
-            prop_assert!(false, "Expected SetDynamicTableCapacity instruction");
+            panic!("Expected SetDynamicTableCapacity instruction");
         }
 
         // 2 番目の命令: Insert with Literal Name
         let inst2 = receiver.process(&mut table).expect("test must succeed");
-        let is_insert_literal = matches!(inst2, Some(EncoderInstruction::InsertWithLiteralName { .. }));
-        prop_assert!(is_insert_literal, "Expected InsertWithLiteralName instruction");
+        let is_insert_literal = matches!(
+            inst2,
+            Some(EncoderInstruction::InsertWithLiteralName { .. })
+        );
+        assert!(
+            is_insert_literal,
+            "Expected InsertWithLiteralName instruction"
+        );
 
         // テーブルにエントリが追加されている
-        prop_assert_eq!(table.len(), 1);
-    }
+        assert_eq!(table.len(), 1);
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: デコーダーストリームの連続命令処理
-    #[test]
-    fn prop_decoder_stream_sequential(
-        stream_id1 in valid_stream_id(),
-        stream_id2 in valid_stream_id(),
-        increment in valid_increment(),
-    ) {
+/// Property: デコーダーストリームの連続命令処理
+#[test]
+fn prop_decoder_stream_sequential() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_QPACK_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let stream_id1 = valid_stream_id(ctx);
+        let stream_id2 = valid_stream_id(ctx);
+        let increment = valid_increment(ctx);
         let mut sender = DecoderStream::new();
 
         sender.encode_section_acknowledgment(stream_id1);
@@ -373,88 +453,102 @@ proptest! {
         receiver.receive(&encoded);
 
         let inst1 = receiver.process(u64::MAX).expect("test must succeed");
-        prop_assert_eq!(
+        assert_eq!(
             inst1,
-            Some(DecoderInstruction::SectionAcknowledgment { stream_id: stream_id1 })
+            Some(DecoderInstruction::SectionAcknowledgment {
+                stream_id: stream_id1
+            })
         );
 
         let inst2 = receiver.process(u64::MAX).expect("test must succeed");
-        prop_assert_eq!(
+        assert_eq!(
             inst2,
-            Some(DecoderInstruction::StreamCancellation { stream_id: stream_id2 })
+            Some(DecoderInstruction::StreamCancellation {
+                stream_id: stream_id2
+            })
         );
 
         let inst3 = receiver.process(u64::MAX).expect("test must succeed");
-        prop_assert_eq!(
+        assert_eq!(
             inst3,
             Some(DecoderInstruction::InsertCountIncrement { increment })
         );
 
         // バッファが空
         let inst4 = receiver.process(u64::MAX).expect("test must succeed");
-        prop_assert!(inst4.is_none());
-    }
+        assert!(inst4.is_none());
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // Huffman Encoding Properties
 // =============================================================================
 
-prop_compose! {
-    /// ASCII 印字可能文字列を生成
-    fn printable_ascii()(
-        len in 1usize..128,
-    )(
-        data in prop::collection::vec(0x20u8..0x7f, len)
-    ) -> Vec<u8> {
-        data
+/// ASCII 印字可能文字列を生成
+fn printable_ascii(ctx: &mut noprop::TestCaseContext) -> Vec<u8> {
+    let len = noprop::sample_usize_in(ctx, 1..128);
+    let mut data = Vec::new();
+    for _ in 0..len {
+        data.push(0x20 + noprop::sample_usize_in(ctx, 0..0x5f) as u8);
     }
+    data
 }
 
-proptest! {
-    /// Property: Huffman エンコード/デコードのラウンドトリップ
-    #[test]
-    fn prop_huffman_roundtrip(data in printable_ascii()) {
+/// Property: Huffman エンコード/デコードのラウンドトリップ
+#[test]
+fn prop_huffman_roundtrip() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_QPACK_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let data = printable_ascii(ctx);
         let encoded_len = huffman::encoded_len(&data);
         let mut encoded = vec![0u8; encoded_len];
         huffman::encode(&mut encoded, &data);
 
         let decoded = huffman::decode(&encoded).expect("test must succeed");
-        prop_assert_eq!(decoded, data);
-    }
+        assert_eq!(decoded, data);
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: Huffman encoded_len は実際のエンコード長と一致
-    #[test]
-    fn prop_huffman_encoded_len_accurate(data in printable_ascii()) {
+/// Property: Huffman encoded_len は実際のエンコード長と一致
+#[test]
+fn prop_huffman_encoded_len_accurate() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_QPACK_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let data = printable_ascii(ctx);
         let predicted_len = huffman::encoded_len(&data);
         let mut encoded = vec![0u8; predicted_len + 10];
         let actual_len = huffman::encode(&mut encoded, &data).expect("test must succeed");
 
-        prop_assert_eq!(predicted_len, actual_len);
-    }
-
+        assert_eq!(predicted_len, actual_len);
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // Encoder/Decoder Properties
 // =============================================================================
 
-prop_compose! {
-    /// 静的テーブルに存在するヘッダー名を生成
-    fn static_header_name()(
-        idx in 0usize..STATIC_TABLE_LEN
-    ) -> Vec<u8> {
-        use shiguredo_http3::qpack::STATIC_TABLE;
-        STATIC_TABLE[idx].name().to_vec()
-    }
+/// 静的テーブルに存在するヘッダー名を生成
+fn static_header_name(ctx: &mut noprop::TestCaseContext) -> Vec<u8> {
+    use shiguredo_http3::qpack::STATIC_TABLE;
+    let idx = noprop::sample_usize_in(ctx, 0..STATIC_TABLE_LEN);
+    STATIC_TABLE[idx].name().to_vec()
 }
 
-proptest! {
-    /// Property: Encoder/Decoder ラウンドトリップ (静的テーブルのみ)
-    #[test]
-    fn prop_encoder_decoder_roundtrip_static(
-        value in valid_header_value(),
-    ) {
+/// Property: Encoder/Decoder ラウンドトリップ (静的テーブルのみ)
+#[test]
+fn prop_encoder_decoder_roundtrip_static() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_QPACK_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let value = valid_header_value(ctx);
         let mut encoder = Encoder::new();
         let decoder = Decoder::new();
 
@@ -464,46 +558,68 @@ proptest! {
         ];
 
         let mut buf = vec![0u8; 1024];
-        let encoded_len = encoder.encode(&mut buf, &headers, 0).expect("test must succeed");
+        let encoded_len = encoder
+            .encode(&mut buf, &headers, 0)
+            .expect("test must succeed");
 
-        let decoded = decoder.decode(&buf[..encoded_len]).expect("test must succeed");
+        let decoded = decoder
+            .decode(&buf[..encoded_len])
+            .expect("test must succeed");
 
-        prop_assert_eq!(decoded.len(), 2);
-        prop_assert_eq!(&decoded[0].name(), b":method");
-        prop_assert_eq!(&decoded[0].value(), b"GET");
-        prop_assert_eq!(&decoded[1].name(), b":path");
-        prop_assert_eq!(&decoded[1].value(), &value);
-    }
+        assert_eq!(decoded.len(), 2);
+        assert_eq!(&decoded[0].name(), b":method");
+        assert_eq!(&decoded[0].value(), b"GET");
+        assert_eq!(&decoded[1].name(), b":path");
+        assert_eq!(&decoded[1].value(), &value);
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: Encoder/Decoder ラウンドトリップ (カスタムヘッダー)
-    #[test]
-    fn prop_encoder_decoder_roundtrip_literal(
-        name in valid_header_name(),
-        value in valid_header_value(),
-    ) {
+/// Property: Encoder/Decoder ラウンドトリップ (カスタムヘッダー)
+#[test]
+fn prop_encoder_decoder_roundtrip_literal() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_QPACK_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let name = valid_header_name(ctx);
+        let value = valid_header_value(ctx);
         let mut encoder = Encoder::new();
         let decoder = Decoder::new();
 
         let headers = vec![wire_header(&name, &value)];
 
         let mut buf = vec![0u8; 1024];
-        let encoded_len = encoder.encode(&mut buf, &headers, 0).expect("test must succeed");
+        let encoded_len = encoder
+            .encode(&mut buf, &headers, 0)
+            .expect("test must succeed");
 
-        let decoded = decoder.decode(&buf[..encoded_len]).expect("test must succeed");
+        let decoded = decoder
+            .decode(&buf[..encoded_len])
+            .expect("test must succeed");
 
-        prop_assert_eq!(decoded.len(), 1);
-        prop_assert_eq!(&decoded[0].name(), &name);
-        prop_assert_eq!(&decoded[0].value(), &value);
-    }
+        assert_eq!(decoded.len(), 1);
+        assert_eq!(&decoded[0].name(), &name);
+        assert_eq!(&decoded[0].value(), &value);
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: 複数ヘッダーのラウンドトリップ
-    #[test]
-    fn prop_encoder_decoder_multiple_headers(
-        headers_data in prop::collection::vec(
-            (valid_header_name(), valid_header_value()),
-            1..5
-        ),
-    ) {
+/// Property: 複数ヘッダーのラウンドトリップ
+#[test]
+fn prop_encoder_decoder_multiple_headers() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_QPACK_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let header_count = noprop::sample_usize_in(ctx, 1..5);
+        let mut headers_data = Vec::new();
+        for _ in 0..header_count {
+            let name = valid_header_name(ctx);
+            let value = valid_header_value(ctx);
+            headers_data.push((name, value));
+        }
+
         let mut encoder = Encoder::new();
         let decoder = Decoder::new();
 
@@ -513,175 +629,226 @@ proptest! {
             .collect();
 
         let mut buf = vec![0u8; 4096];
-        let encoded_len = encoder.encode(&mut buf, &headers, 0).expect("test must succeed");
+        let encoded_len = encoder
+            .encode(&mut buf, &headers, 0)
+            .expect("test must succeed");
 
-        let decoded = decoder.decode(&buf[..encoded_len]).expect("test must succeed");
+        let decoded = decoder
+            .decode(&buf[..encoded_len])
+            .expect("test must succeed");
 
-        prop_assert_eq!(decoded.len(), headers.len());
+        assert_eq!(decoded.len(), headers.len());
         for (orig, dec) in headers_data.iter().zip(decoded.iter()) {
-            prop_assert_eq!(&dec.name(), &orig.0);
-            prop_assert_eq!(&dec.value(), &orig.1);
+            assert_eq!(&dec.name(), &orig.0);
+            assert_eq!(&dec.value(), &orig.1);
         }
-    }
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // Static Table Properties
 // =============================================================================
 
-proptest! {
-    /// Property: 静的テーブル検索の一貫性 (完全一致)
-    #[test]
-    fn prop_static_table_find_exact(idx in 0usize..STATIC_TABLE_LEN) {
+/// Property: 静的テーブル検索の一貫性 (完全一致)
+#[test]
+fn prop_static_table_find_exact() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_QPACK_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
         use shiguredo_http3::qpack::STATIC_TABLE;
+        let idx = noprop::sample_usize_in(ctx, 0..STATIC_TABLE_LEN);
         let entry = &STATIC_TABLE[idx];
 
         let (exact, name_only) = find_static_entry(entry.name(), entry.value());
 
         // 完全一致が見つかる場合、name_only も Some
         if exact.is_some() {
-            prop_assert!(name_only.is_some());
+            assert!(name_only.is_some());
         }
-    }
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: 静的テーブル検索は常に有効なインデックスを返す
-    #[test]
-    fn prop_static_table_find_valid_index(
-        name in static_header_name(),
-        value in valid_header_value(),
-    ) {
+/// Property: 静的テーブル検索は常に有効なインデックスを返す
+#[test]
+fn prop_static_table_find_valid_index() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_QPACK_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let name = static_header_name(ctx);
+        let value = valid_header_value(ctx);
         let (exact, name_only) = find_static_entry(&name, &value);
 
         if let Some(idx) = exact {
-            prop_assert!(idx < STATIC_TABLE_LEN);
+            assert!(idx < STATIC_TABLE_LEN);
         }
         if let Some(idx) = name_only {
-            prop_assert!(idx < STATIC_TABLE_LEN);
+            assert!(idx < STATIC_TABLE_LEN);
         }
-    }
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // Dynamic Table Additional Properties
 // =============================================================================
 
-proptest! {
-    /// Property: 動的テーブルの find_entry は挿入したエントリを見つける
-    #[test]
-    fn prop_dynamic_table_find_inserted(
-        name in valid_header_name(),
-        value in valid_header_value(),
-    ) {
+/// Property: 動的テーブルの find_entry は挿入したエントリを見つける
+#[test]
+fn prop_dynamic_table_find_inserted() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_QPACK_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let name = valid_header_name(ctx);
+        let value = valid_header_value(ctx);
         let mut table = DynamicTable::with_capacity(4096);
-        let idx = table.insert(name.clone(), value.clone()).expect("test must succeed");
+        let idx = table
+            .insert(name.clone(), value.clone())
+            .expect("test must succeed");
 
         let (exact, name_only) = table.find_entry(&name, &value);
 
-        prop_assert_eq!(exact, Some(idx));
-        prop_assert_eq!(name_only, Some(idx));
-    }
+        assert_eq!(exact, Some(idx));
+        assert_eq!(name_only, Some(idx));
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: 動的テーブルの find_entry は名前のみ一致も検出
-    #[test]
-    fn prop_dynamic_table_find_name_only(
-        name in valid_header_name(),
-        value1 in valid_header_value(),
-        value2 in valid_header_value(),
-    ) {
+/// Property: 動的テーブルの find_entry は名前のみ一致も検出
+#[test]
+fn prop_dynamic_table_find_name_only() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_QPACK_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let name = valid_header_name(ctx);
+        let value1 = valid_header_value(ctx);
+        let value2 = valid_header_value(ctx);
         let mut table = DynamicTable::with_capacity(4096);
-        let idx = table.insert(name.clone(), value1.clone()).expect("test must succeed");
+        let idx = table
+            .insert(name.clone(), value1.clone())
+            .expect("test must succeed");
 
         // 異なる値で検索
         let (exact, name_only) = table.find_entry(&name, &value2);
 
         if value1 == value2 {
-            prop_assert_eq!(exact, Some(idx));
+            assert_eq!(exact, Some(idx));
         } else {
-            prop_assert!(exact.is_none());
+            assert!(exact.is_none());
         }
-        prop_assert_eq!(name_only, Some(idx));
-    }
+        assert_eq!(name_only, Some(idx));
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: 動的テーブルの duplicate は同じ内容のエントリを作成
-    #[test]
-    fn prop_dynamic_table_duplicate_content(
-        name in valid_header_name(),
-        value in valid_header_value(),
-    ) {
+/// Property: 動的テーブルの duplicate は同じ内容のエントリを作成
+#[test]
+fn prop_dynamic_table_duplicate_content() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_QPACK_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let name = valid_header_name(ctx);
+        let value = valid_header_value(ctx);
         let mut table = DynamicTable::with_capacity(4096);
-        table.insert(name.clone(), value.clone()).expect("test must succeed");
+        table
+            .insert(name.clone(), value.clone())
+            .expect("test must succeed");
 
         // relative_index 0 は最新エントリ
         let dup_idx = table.duplicate(0).expect("test must succeed");
 
         let original = table.get_by_absolute_index(0).expect("test must succeed");
-        let duplicated = table.get_by_absolute_index(dup_idx).expect("test must succeed");
+        let duplicated = table
+            .get_by_absolute_index(dup_idx)
+            .expect("test must succeed");
 
-        prop_assert_eq!(&original.name, &duplicated.name);
-        prop_assert_eq!(&original.value, &duplicated.value);
-        prop_assert_ne!(original.absolute_index, duplicated.absolute_index);
-    }
+        assert_eq!(&original.name, &duplicated.name);
+        assert_eq!(&original.value, &duplicated.value);
+        assert_ne!(original.absolute_index, duplicated.absolute_index);
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: エビクション後も取得可能なエントリは有効
-    #[test]
-    fn prop_dynamic_table_eviction_valid(
-        entries in prop::collection::vec(
-            (valid_header_name(), valid_header_value()),
-            5..15
-        ),
-    ) {
+/// Property: エビクション後も取得可能なエントリは有効
+#[test]
+fn prop_dynamic_table_eviction_valid() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_QPACK_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let entry_count = noprop::sample_usize_in(ctx, 5..15);
         // 小さな容量で強制的にエビクションを発生させる
         let mut table = DynamicTable::with_capacity(128);
 
-        for (name, value) in &entries {
-            let _ = table.insert(name.clone(), value.clone());
+        for _ in 0..entry_count {
+            let name = valid_header_name(ctx);
+            let value = valid_header_value(ctx);
+            let _ = table.insert(name, value);
         }
 
         // 残っているエントリはすべて有効
         for entry in table.iter() {
             let retrieved = table.get_by_absolute_index(entry.absolute_index);
-            prop_assert!(retrieved.is_some());
-            prop_assert_eq!(&retrieved.expect("test must succeed").name, &entry.name);
+            assert!(retrieved.is_some());
+            assert_eq!(&retrieved.expect("test must succeed").name, &entry.name);
         }
-    }
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: 動的テーブルの相対インデックス変換が正しい
-    #[test]
-    fn prop_dynamic_table_relative_index(
-        entries in prop::collection::vec(
-            (valid_header_name(), valid_header_value()),
-            2..5
-        ),
-    ) {
+/// Property: 動的テーブルの相対インデックス変換が正しい
+#[test]
+fn prop_dynamic_table_relative_index() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_QPACK_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let entry_count = noprop::sample_usize_in(ctx, 2..5);
         let mut table = DynamicTable::with_capacity(4096);
 
-        for (name, value) in &entries {
-            table.insert(name.clone(), value.clone());
+        for _ in 0..entry_count {
+            let name = valid_header_name(ctx);
+            let value = valid_header_value(ctx);
+            table.insert(name, value);
         }
 
         let insert_count = table.insert_count();
 
         // 相対インデックス 0 は最新エントリ (absolute = insert_count - 1)
         let newest = table.get_by_relative_index_encoder(0);
-        prop_assert!(newest.is_some());
-        prop_assert_eq!(newest.expect("test must succeed").absolute_index, insert_count - 1);
-    }
+        assert!(newest.is_some());
+        assert_eq!(
+            newest.expect("test must succeed").absolute_index,
+            insert_count - 1
+        );
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // Insert with Name Reference Properties
 // =============================================================================
 
-proptest! {
-    /// Property: Insert with Name Reference (静的テーブル) のラウンドトリップ
-    #[test]
-    fn prop_insert_with_name_ref_static_roundtrip(
-        static_idx in 0u64..10,
-        value in valid_header_value(),
-    ) {
+/// Property: Insert with Name Reference (静的テーブル) のラウンドトリップ
+#[test]
+fn prop_insert_with_name_ref_static_roundtrip() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_QPACK_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let static_idx = noprop::sample_u64_in(ctx, 0..10);
+        let value = valid_header_value(ctx);
         let mut sender = EncoderStream::new();
         sender.set_max_table_capacity(4096);
-        sender.encode_insert_with_name_ref(true, static_idx, &value).expect("test must succeed");
+        sender
+            .encode_insert_with_name_ref(true, static_idx, &value)
+            .expect("test must succeed");
         let encoded = sender.get_data().to_vec();
 
         let mut receiver = EncoderStreamReceiver::new();
@@ -697,26 +864,33 @@ proptest! {
             value: v,
         }) = instruction
         {
-            prop_assert!(is_static);
-            prop_assert_eq!(name_index, static_idx);
-            prop_assert_eq!(v, value);
+            assert!(is_static);
+            assert_eq!(name_index, static_idx);
+            assert_eq!(v, value);
         } else {
-            prop_assert!(false, "Expected InsertWithNameReference instruction");
+            panic!("Expected InsertWithNameReference instruction");
         }
-    }
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: エンコーダーストリーム命令の分割受信 (RFC 9204 Section 4.2)
-    ///
-    /// QUIC stream は byte stream なので命令が任意の位置で分割される。
-    /// 部分受信時は Ok(None) を返し、完全なデータが揃うまで待機する。
-    #[test]
-    fn prop_encoder_stream_partial_receive(
-        name in valid_header_name(),
-        value in valid_header_value(),
-    ) {
+/// Property: エンコーダーストリーム命令の分割受信 (RFC 9204 Section 4.2)
+///
+/// QUIC stream は byte stream なので命令が任意の位置で分割される。
+/// 部分受信時は Ok(None) を返し、完全なデータが揃うまで待機する。
+#[test]
+fn prop_encoder_stream_partial_receive() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_QPACK_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let name = valid_header_name(ctx);
+        let value = valid_header_value(ctx);
         let mut sender = EncoderStream::new();
         sender.set_max_table_capacity(4096);
-        sender.encode_insert_with_literal_name(&name, &value).expect("test must succeed");
+        sender
+            .encode_insert_with_literal_name(&name, &value)
+            .expect("test must succeed");
         let encoded = sender.get_data().to_vec();
 
         // 1 バイトずつ受信
@@ -730,26 +904,39 @@ proptest! {
 
             if i < encoded.len() - 1 {
                 // 途中は Ok(None) でなければならない
-                prop_assert_eq!(
-                    result.expect("test must succeed"), None,
+                assert_eq!(
+                    result.expect("test must succeed"),
+                    None,
                     "Partial data at byte {} should return Ok(None)",
                     i
                 );
             } else {
                 // 最後のバイトで完全な命令が得られる
                 let instruction = result.expect("test must succeed");
-                prop_assert!(instruction.is_some(), "Complete data should return instruction");
-                if let Some(EncoderInstruction::InsertWithLiteralName { name: n, value: v }) = instruction {
-                    prop_assert_eq!(n, name.clone());
-                    prop_assert_eq!(v, value.clone());
+                assert!(
+                    instruction.is_some(),
+                    "Complete data should return instruction"
+                );
+                if let Some(EncoderInstruction::InsertWithLiteralName { name: n, value: v }) =
+                    instruction
+                {
+                    assert_eq!(n, name.clone());
+                    assert_eq!(v, value.clone());
                 }
             }
         }
-    }
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: デコーダーストリーム命令の分割受信 (RFC 9204 Section 4.2)
-    #[test]
-    fn prop_decoder_stream_partial_receive(stream_id in valid_stream_id()) {
+/// Property: デコーダーストリーム命令の分割受信 (RFC 9204 Section 4.2)
+#[test]
+fn prop_decoder_stream_partial_receive() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_QPACK_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let stream_id = valid_stream_id(ctx);
         let mut sender = DecoderStream::new();
         sender.encode_section_acknowledgment(stream_id);
         let encoded = sender.get_data().to_vec();
@@ -762,28 +949,34 @@ proptest! {
             let result = receiver.process(u64::MAX);
 
             if i < encoded.len() - 1 {
-                prop_assert_eq!(
-                    result.expect("test must succeed"), None,
+                assert_eq!(
+                    result.expect("test must succeed"),
+                    None,
                     "Partial data at byte {} should return Ok(None)",
                     i
                 );
             } else {
                 let instruction = result.expect("test must succeed");
-                prop_assert_eq!(
+                assert_eq!(
                     instruction,
                     Some(DecoderInstruction::SectionAcknowledgment { stream_id }),
                 );
             }
         }
-    }
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: Insert with Name Reference (動的テーブル) のラウンドトリップ
-    #[test]
-    fn prop_insert_with_name_ref_dynamic_roundtrip(
-        name in valid_header_name(),
-        value1 in valid_header_value(),
-        value2 in valid_header_value(),
-    ) {
+/// Property: Insert with Name Reference (動的テーブル) のラウンドトリップ
+#[test]
+fn prop_insert_with_name_ref_dynamic_roundtrip() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_QPACK_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let name = valid_header_name(ctx);
+        let value1 = valid_header_value(ctx);
+        let value2 = valid_header_value(ctx);
         // まず動的テーブルにエントリを追加
         let mut table = DynamicTable::with_capacity(4096);
         table.insert(name.clone(), value1);
@@ -791,7 +984,9 @@ proptest! {
         let mut sender = EncoderStream::new();
         sender.set_max_table_capacity(4096);
         // 動的テーブルの relative_index 0 を参照
-        sender.encode_insert_with_name_ref(false, 0, &value2).expect("test must succeed");
+        sender
+            .encode_insert_with_name_ref(false, 0, &value2)
+            .expect("test must succeed");
         let encoded = sender.get_data().to_vec();
 
         let mut receiver = EncoderStreamReceiver::new();
@@ -806,50 +1001,59 @@ proptest! {
             value: v,
         }) = instruction
         {
-            prop_assert!(!is_static);
-            prop_assert_eq!(name_index, 0);
-            prop_assert_eq!(&v, &value2);
+            assert!(!is_static);
+            assert_eq!(name_index, 0);
+            assert_eq!(&v, &value2);
         } else {
-            prop_assert!(false, "Expected InsertWithNameReference instruction");
+            panic!("Expected InsertWithNameReference instruction");
         }
 
         // テーブルに新しいエントリが追加されている
-        prop_assert_eq!(table.len(), 2);
+        assert_eq!(table.len(), 2);
         let new_entry = table.get_by_absolute_index(1).expect("test must succeed");
-        prop_assert_eq!(&new_entry.name, &name);
-        prop_assert_eq!(&new_entry.value, &value2);
-    }
+        assert_eq!(&new_entry.name, &name);
+        assert_eq!(&new_entry.value, &value2);
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // DynamicEncoder / DynamicDecoder Roundtrip (RFC 9204 Section 4)
 // =============================================================================
 
-prop_compose! {
-    /// 動的テーブルエンコード用のヘッダーを生成
-    fn dynamic_header()(
-        name in valid_header_name(),
-        value in valid_header_value(),
-    ) -> Header {
-        wire_header(&name, &value)
-    }
+/// 動的テーブルエンコード用のヘッダーを生成
+fn dynamic_header(ctx: &mut noprop::TestCaseContext) -> Header {
+    let name = valid_header_name(ctx);
+    let value = valid_header_value(ctx);
+    wire_header(&name, &value)
 }
 
-proptest! {
-    /// Property: エンコーダーとデコーダーのテーブルを同期させると、
-    /// DynamicEncoder でエンコードしたヘッダーは DynamicDecoder で復元できる
-    #[test]
-    fn prop_dynamic_encoder_decoder_roundtrip(
-        entries in prop::collection::vec(
-            (valid_header_name(), valid_header_value()),
-            0..5,
-        ),
-        headers in prop::collection::vec(dynamic_header(), 1..5),
-        use_huffman in any::<bool>(),
-    ) {
+/// Property: エンコーダーとデコーダーのテーブルを同期させると、
+/// DynamicEncoder でエンコードしたヘッダーは DynamicDecoder で復元できる
+#[test]
+fn prop_dynamic_encoder_decoder_roundtrip() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_QPACK_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let entry_count = noprop::sample_usize_in(ctx, 0..5);
+        let header_count = noprop::sample_usize_in(ctx, 1..5);
+        let mut entries = Vec::new();
+        for _ in 0..entry_count {
+            let name = valid_header_name(ctx);
+            let value = valid_header_value(ctx);
+            entries.push((name, value));
+        }
+        let mut headers = Vec::new();
+        for _ in 0..header_count {
+            headers.push(dynamic_header(ctx));
+        }
+        let use_huffman = noprop::sample_bool(ctx);
+
         let mut encoder = DynamicEncoder::new().use_huffman(use_huffman);
         encoder.set_max_table_capacity(DYNAMIC_TABLE_CAPACITY);
-        encoder.set_table_capacity(DYNAMIC_TABLE_CAPACITY)
+        encoder
+            .set_table_capacity(DYNAMIC_TABLE_CAPACITY)
             .expect("PBT: capacity matches max_table_capacity");
 
         let mut decoder = DynamicDecoder::new();
@@ -869,28 +1073,34 @@ proptest! {
 
         match decoder.decode(&buf[..len]) {
             Ok(DecodeOutput::Decoded(decoded)) => {
-                prop_assert_eq!(headers.len(), decoded.len());
+                assert_eq!(headers.len(), decoded.len());
                 for (orig, dec) in headers.iter().zip(decoded.iter()) {
-                    prop_assert_eq!(orig.name().to_vec(), dec.name().to_vec());
-                    prop_assert_eq!(orig.value().to_vec(), dec.value().to_vec());
+                    assert_eq!(orig.name().to_vec(), dec.name().to_vec());
+                    assert_eq!(orig.value().to_vec(), dec.value().to_vec());
                 }
             }
             // テーブル状態の不一致によるブロックやエラーは許容
             Ok(DecodeOutput::Blocked) | Err(_) => {}
         }
-    }
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: 動的テーブル参照でブロックされたデコードは、
-    /// エンコーダーストリームでテーブル更新後に成功する (RFC 9204 Section 2.1.2)
-    #[test]
-    fn prop_blocked_then_unblocked(
-        entry_name in valid_header_name(),
-        entry_value in valid_header_value(),
-    ) {
+/// Property: 動的テーブル参照でブロックされたデコードは、
+/// エンコーダーストリームでテーブル更新後に成功する (RFC 9204 Section 2.1.2)
+#[test]
+fn prop_blocked_then_unblocked() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_QPACK_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let entry_name = valid_header_name(ctx);
+        let entry_value = valid_header_value(ctx);
         // エンコーダー側: 動的テーブルにエントリを挿入してエンコード
         let mut encoder = DynamicEncoder::new().use_huffman(false);
         encoder.set_max_table_capacity(DYNAMIC_TABLE_CAPACITY);
-        encoder.set_table_capacity(DYNAMIC_TABLE_CAPACITY)
+        encoder
+            .set_table_capacity(DYNAMIC_TABLE_CAPACITY)
             .expect("PBT: capacity matches max_table_capacity");
         encoder.insert(entry_name.clone(), entry_value.clone());
 
@@ -929,68 +1139,84 @@ proptest! {
         if let (Ok(DecodeOutput::Blocked), Ok(DecodeOutput::Decoded(decoded))) =
             (first_result, second_result)
         {
-            prop_assert_eq!(decoded.len(), 1);
-            prop_assert_eq!(decoded[0].name().to_vec(), entry_name);
-            prop_assert_eq!(decoded[0].value().to_vec(), entry_value);
+            assert_eq!(decoded.len(), 1);
+            assert_eq!(decoded[0].name().to_vec(), entry_name);
+            assert_eq!(decoded[0].value().to_vec(), entry_value);
         }
-    }
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // Construct-Time Validation Consistency (Header)
 // =============================================================================
 
-proptest! {
-    // `Header::from_static` は `&'static [u8]` を要求するため `Box::leak` で
-    // 擬似的に静的化する。proptest の shrink でケースが追加発火するたびに
-    // リークが累積するためケース数を絞る (cases: 16)。
-    #![proptest_config(ProptestConfig { cases: 16, ..ProptestConfig::default() })]
-
-    /// Property: `Header::from_static` と `Header::new` が同じ値を返す
-    /// (`const fn` 検査とランタイム検査のロジック一致)
-    #[test]
-    fn prop_header_from_static_matches_new(
-        name in valid_header_name(),
-        value in valid_header_value(),
-    ) {
+/// Property: `Header::from_static` と `Header::new` が同じ値を返す
+/// (`const fn` 検査とランタイム検査のロジック一致)
+///
+/// `Header::from_static` は `&'static [u8]` を要求するため `Box::leak` で
+/// 擬似的に静的化する。noprop では shrink は発生しないが、ケースごとに
+/// リークが累積するためケース数を絞る (cases: 16)。
+#[test]
+fn prop_header_from_static_matches_new() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_QPACK_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(16, |ctx| {
+        let name = valid_header_name(ctx);
+        let value = valid_header_value(ctx);
         let via_new = Header::new(&name, &value).expect("test must succeed");
         let static_name: &'static [u8] = Box::leak(name.clone().into_boxed_slice());
         let static_value: &'static [u8] = Box::leak(value.clone().into_boxed_slice());
         let via_static = Header::from_static(static_name, static_value);
-        prop_assert_eq!(via_new, via_static);
-    }
+        assert_eq!(via_new, via_static);
+        Ok(())
+    })?;
+    Ok(())
 }
 
-proptest! {
-    /// Property: `wire_header` と `Header::new` が同じ値を返す
-    /// (wire 模擬経路と公開 API のロジック一致)
-    #[test]
-    fn prop_wire_header_matches_new(
-        name in valid_header_name(),
-        value in valid_header_value(),
-    ) {
+/// Property: `wire_header` と `Header::new` が同じ値を返す
+/// (wire 模擬経路と公開 API のロジック一致)
+#[test]
+fn prop_wire_header_matches_new() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_QPACK_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let name = valid_header_name(ctx);
+        let value = valid_header_value(ctx);
         let via_new = Header::new(&name, &value).expect("test must succeed");
         let via_wire = wire_header(&name, &value);
-        prop_assert_eq!(via_new, via_wire);
-    }
+        assert_eq!(via_new, via_wire);
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property (完全性): `Header::new` が受理する任意 (name, value) は、
-    /// QPACK encode → decode の往復で同じ Header が再構築される。
-    /// (構築時検査と decoder の受理集合一致の片方向確認)
-    #[test]
-    fn prop_header_new_accepts_imply_qpack_roundtrip(
-        name in valid_header_name(),
-        value in valid_header_value(),
-    ) {
+/// Property (完全性): `Header::new` が受理する任意 (name, value) は、
+/// QPACK encode → decode の往復で同じ Header が再構築される。
+/// (構築時検査と decoder の受理集合一致の片方向確認)
+#[test]
+fn prop_header_new_accepts_imply_qpack_roundtrip() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_QPACK_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let name = valid_header_name(ctx);
+        let value = valid_header_value(ctx);
         let original = Header::new(&name, &value).expect("test must succeed");
         let mut encoder = Encoder::new();
         let decoder = Decoder::new();
         let headers = vec![original.clone()];
         let mut buf = vec![0u8; 8192];
-        let encoded_len = encoder.encode(&mut buf, &headers, 0).expect("test must succeed");
-        let decoded = decoder.decode(&buf[..encoded_len]).expect("test must succeed");
-        prop_assert_eq!(decoded.len(), 1);
-        prop_assert_eq!(decoded[0].name(), original.name());
-        prop_assert_eq!(decoded[0].value(), original.value());
-    }
+        let encoded_len = encoder
+            .encode(&mut buf, &headers, 0)
+            .expect("test must succeed");
+        let decoded = decoder
+            .decode(&buf[..encoded_len])
+            .expect("test must succeed");
+        assert_eq!(decoded.len(), 1);
+        assert_eq!(decoded[0].name(), original.name());
+        assert_eq!(decoded[0].value(), original.value());
+        Ok(())
+    })?;
+    Ok(())
 }

--- a/pbt/tests/prop_settings.rs
+++ b/pbt/tests/prop_settings.rs
@@ -2,10 +2,9 @@
 //!
 //! 値域や bool 値検査は `Setting::from_wire` 側で構築時に検査されるため、
 //! 不正値の単体テストは `src/settings.rs` の `#[cfg(test)]` に移してある。
-//! 本ファイルは Strategy で構築した正常値が SettingsPayload とのラウンドトリップ /
+//! 本ファイルは noprop で構築した正常値が SettingsPayload とのラウンドトリップ /
 //! `Setting::from_wire` ↔ `Setting::as_wire` の対称性を満たすことを検査する。
 
-use proptest::prelude::*;
 use shiguredo_http3::frame::SettingsPayload;
 use shiguredo_http3::{Setting, SettingError, Settings, VarInt, webtransport};
 
@@ -14,107 +13,125 @@ fn vi(value: u64) -> VarInt {
 }
 
 // `arbitrary_settings` / `arbitrary_wt_settings` で生成する範囲は中規模 (`1 << 30`)
-// に絞り、Strategy ノイズを抑える。`prop_setting_wire_roundtrip` 等で VarInt
-// 全域を叩く場合は別 Strategy (`arbitrary_varint_full`) を用いる。
+// に絞り、サンプルノイズを抑える。`prop_setting_wire_roundtrip` 等で VarInt
+// 全域を叩く場合は別関数 (`arbitrary_varint_full`) を用いる。
 const VARINT_TEST_MAX: u64 = 1 << 30;
 
-prop_compose! {
-    fn arbitrary_varint()(value in 0u64..VARINT_TEST_MAX) -> VarInt {
-        vi(value)
-    }
+/// `0..VARINT_TEST_MAX` から VarInt を生成する
+fn arbitrary_varint(ctx: &mut noprop::TestCaseContext) -> VarInt {
+    vi(noprop::sample_u64_in(ctx, 0..VARINT_TEST_MAX))
 }
 
-prop_compose! {
-    /// VarInt 全域 (`0..=VarInt::MAX`) を生成する Strategy
-    fn arbitrary_varint_full()(value in 0u64..=VarInt::MAX.get()) -> VarInt {
-        vi(value)
-    }
+/// VarInt 全域 (`0..=VarInt::MAX`) を生成する
+fn arbitrary_varint_full(ctx: &mut noprop::TestCaseContext) -> VarInt {
+    vi(noprop::sample_u64_in(ctx, 0..=VarInt::MAX.get()))
 }
 
-/// `Setting::from_wire` で受理される ID のみを生成する Strategy
+/// `Setting::from_wire` で受理される ID のみを生成する
 ///
-/// HTTP/2 専用 ID (0x02..=0x05) と予約 ID (0x00) を Strategy 段階で除外し、
-/// `prop_assume!` の reject カウンタ消費を回避する。
-fn settable_id() -> impl Strategy<Value = VarInt> {
-    arbitrary_varint_full().prop_filter(
-        "HTTP/2 専用 ID と予約 ID は構築時拒否されるため除外",
-        |v| {
-            let raw = v.get();
-            raw != 0 && !matches!(raw, 0x02..=0x05)
-        },
-    )
+/// HTTP/2 専用 ID (0x02..=0x05) と予約 ID (0x00) を生成段階で除外する。
+/// 受理率はほぼ 1 のため rejection の試行回数は少なくて済む。
+fn settable_id(ctx: &mut noprop::TestCaseContext) -> VarInt {
+    noprop::sample_with_rejection(ctx, 64, |ctx| {
+        let v = arbitrary_varint_full(ctx);
+        let raw = v.get();
+        (raw != 0 && !matches!(raw, 0x02..=0x05)).then_some(v)
+    })
 }
 
-prop_compose! {
-    /// 任意の webtransport::Settings を生成
-    fn arbitrary_wt_settings()(
-        wt_enabled in arbitrary_varint(),
-        wt_initial_max_streams_uni in arbitrary_varint(),
-        wt_initial_max_streams_bidi in arbitrary_varint(),
-        wt_initial_max_data in arbitrary_varint(),
-        enable_webtransport_draft02 in proptest::option::of(any::<bool>()),
-        webtransport_max_sessions_draft07 in proptest::option::of(arbitrary_varint()),
-    ) -> webtransport::Settings {
-        let mut wt = webtransport::Settings::new()
-            .wt_enabled(wt_enabled)
-            .wt_initial_max_streams_uni(wt_initial_max_streams_uni)
-            .wt_initial_max_streams_bidi(wt_initial_max_streams_bidi)
-            .wt_initial_max_data(wt_initial_max_data);
-        if let Some(v) = enable_webtransport_draft02 {
-            wt = wt.enable_webtransport_draft02(v);
-        }
-        if let Some(v) = webtransport_max_sessions_draft07 {
-            wt = wt.webtransport_max_sessions_draft07(v);
-        }
-        wt
+/// Option を 50% の確率で生成するヘルパー
+fn sample_option<T>(
+    ctx: &mut noprop::TestCaseContext,
+    sample: impl Fn(&mut noprop::TestCaseContext) -> T,
+) -> Option<T> {
+    if noprop::sample_bool(ctx) {
+        Some(sample(ctx))
+    } else {
+        None
     }
 }
 
-prop_compose! {
-    /// 任意の Settings を生成 (各フィールドが Some または None)
-    fn arbitrary_settings()(
-        qpack_max_table_capacity in proptest::option::of(arbitrary_varint()),
-        max_field_section_size in proptest::option::of(arbitrary_varint()),
-        qpack_blocked_streams in proptest::option::of(arbitrary_varint()),
-        enable_connect_protocol in proptest::option::of(any::<bool>()),
-        h3_datagram in proptest::option::of(any::<bool>()),
-        wt_settings in proptest::option::of(arbitrary_wt_settings()),
-    ) -> Settings {
-        let mut s = Settings::new();
-        if let Some(v) = qpack_max_table_capacity {
-            s = s.qpack_max_table_capacity(v);
-        }
-        if let Some(v) = max_field_section_size {
-            s = s.max_field_section_size(v);
-        }
-        if let Some(v) = qpack_blocked_streams {
-            s = s.qpack_blocked_streams(v);
-        }
-        if let Some(v) = enable_connect_protocol {
-            s = s.enable_connect_protocol(v);
-        }
-        if let Some(v) = h3_datagram {
-            s = s.h3_datagram(v);
-        }
-        if let Some(wt) = wt_settings {
-            s = s.enable_webtransport_server(wt);
-        }
-        s
+/// 任意の webtransport::Settings を生成
+fn arbitrary_wt_settings(ctx: &mut noprop::TestCaseContext) -> webtransport::Settings {
+    let wt_enabled = arbitrary_varint(ctx);
+    let wt_initial_max_streams_uni = arbitrary_varint(ctx);
+    let wt_initial_max_streams_bidi = arbitrary_varint(ctx);
+    let wt_initial_max_data = arbitrary_varint(ctx);
+    let enable_webtransport_draft02 = sample_option(ctx, noprop::sample_bool);
+    let webtransport_max_sessions_draft07 = sample_option(ctx, arbitrary_varint);
+
+    let mut wt = webtransport::Settings::new()
+        .wt_enabled(wt_enabled)
+        .wt_initial_max_streams_uni(wt_initial_max_streams_uni)
+        .wt_initial_max_streams_bidi(wt_initial_max_streams_bidi)
+        .wt_initial_max_data(wt_initial_max_data);
+    if let Some(v) = enable_webtransport_draft02 {
+        wt = wt.enable_webtransport_draft02(v);
     }
+    if let Some(v) = webtransport_max_sessions_draft07 {
+        wt = wt.webtransport_max_sessions_draft07(v);
+    }
+    wt
 }
 
-proptest! {
-    /// Property: Settings を SettingsPayload に変換して from_payload で復元すると元と一致する
-    #[test]
-    fn prop_settings_roundtrip(settings in arbitrary_settings()) {
+/// 任意の Settings を生成 (各フィールドが Some または None)
+fn arbitrary_settings(ctx: &mut noprop::TestCaseContext) -> Settings {
+    let qpack_max_table_capacity = sample_option(ctx, arbitrary_varint);
+    let max_field_section_size = sample_option(ctx, arbitrary_varint);
+    let qpack_blocked_streams = sample_option(ctx, arbitrary_varint);
+    let enable_connect_protocol = sample_option(ctx, noprop::sample_bool);
+    let h3_datagram = sample_option(ctx, noprop::sample_bool);
+    let wt_settings = sample_option(ctx, arbitrary_wt_settings);
+
+    let mut s = Settings::new();
+    if let Some(v) = qpack_max_table_capacity {
+        s = s.qpack_max_table_capacity(v);
+    }
+    if let Some(v) = max_field_section_size {
+        s = s.max_field_section_size(v);
+    }
+    if let Some(v) = qpack_blocked_streams {
+        s = s.qpack_blocked_streams(v);
+    }
+    if let Some(v) = enable_connect_protocol {
+        s = s.enable_connect_protocol(v);
+    }
+    if let Some(v) = h3_datagram {
+        s = s.h3_datagram(v);
+    }
+    if let Some(wt) = wt_settings {
+        s = s.enable_webtransport_server(wt);
+    }
+    s
+}
+
+/// Property: Settings を SettingsPayload に変換して from_payload で復元すると元と一致する
+#[test]
+fn prop_settings_roundtrip() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_SETTINGS_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let settings = arbitrary_settings(ctx);
         let payload = SettingsPayload::from_settings(&settings);
         let restored = Settings::from_payload(&payload);
 
-        prop_assert_eq!(settings.qpack_max_table_capacity, restored.qpack_max_table_capacity);
-        prop_assert_eq!(settings.max_field_section_size, restored.max_field_section_size);
-        prop_assert_eq!(settings.qpack_blocked_streams, restored.qpack_blocked_streams);
-        prop_assert_eq!(settings.enable_connect_protocol, restored.enable_connect_protocol);
-        prop_assert_eq!(settings.h3_datagram, restored.h3_datagram);
+        assert_eq!(
+            settings.qpack_max_table_capacity,
+            restored.qpack_max_table_capacity
+        );
+        assert_eq!(
+            settings.max_field_section_size,
+            restored.max_field_section_size
+        );
+        assert_eq!(
+            settings.qpack_blocked_streams,
+            restored.qpack_blocked_streams
+        );
+        assert_eq!(
+            settings.enable_connect_protocol,
+            restored.enable_connect_protocol
+        );
+        assert_eq!(settings.h3_datagram, restored.h3_datagram);
 
         // enable_webtransport_server() で wt_settings を設定した場合、
         // enable_connect_protocol と h3_datagram も自動設定されるため、
@@ -123,134 +140,171 @@ proptest! {
         // from_payload で None になる。
         match (&settings.wt_settings, &restored.wt_settings) {
             (Some(orig), Some(rest)) => {
-                prop_assert_eq!(orig, rest, "wt_settings が不一致");
+                assert_eq!(orig, rest, "wt_settings が不一致");
             }
             (Some(orig), None) => {
-                prop_assert!(
+                assert!(
                     orig.iter().count() == 0,
                     "元の wt_settings にエントリがあるのに復元が None"
                 );
             }
             (None, None) => {}
             (None, Some(_)) => {
-                prop_assert!(false, "元が None なのに復元に wt_settings がある");
+                panic!("元が None なのに復元に wt_settings がある");
             }
         }
-    }
+        Ok(())
+    })?;
+    Ok(())
 }
 
-proptest! {
-    /// Property: Settings::len() は H3 + WT のエントリ合計数と一致する
-    #[test]
-    fn prop_iter_count_equals_len(settings in arbitrary_settings()) {
+/// Property: Settings::len() は H3 + WT のエントリ合計数と一致する
+#[test]
+fn prop_iter_count_equals_len() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_SETTINGS_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let settings = arbitrary_settings(ctx);
         let h3_count = settings.iter().count();
-        let wt_count = settings.wt_settings
+        let wt_count = settings
+            .wt_settings
             .as_ref()
             .map(|wt| wt.iter().count())
             .unwrap_or(0);
         let total = h3_count + wt_count;
-        prop_assert_eq!(total, settings.len());
-    }
+        assert_eq!(total, settings.len());
+        Ok(())
+    })?;
+    Ok(())
 }
 
-proptest! {
-    /// Property: enable_webtransport_server(wt) 後は is_webtransport_enabled() == true かつ
-    ///           enable_connect_protocol と h3_datagram が Some(true)
-    #[test]
-    fn prop_enable_webtransport_sets_required_fields(
-        wt_settings in arbitrary_wt_settings().prop_filter(
-            "wt_enabled が 0 だと is_enabled() が false になるためスキップ",
-            |wt| wt.is_enabled()
-        )
-    ) {
+/// Property: enable_webtransport_server(wt) 後は is_webtransport_enabled() == true かつ
+///           enable_connect_protocol と h3_datagram が Some(true)
+#[test]
+fn prop_enable_webtransport_sets_required_fields() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_SETTINGS_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        // wt_enabled が 0 だと is_enabled() が false になるためスキップ
+        let wt_settings = noprop::sample_with_rejection(ctx, 64, |ctx| {
+            let wt = arbitrary_wt_settings(ctx);
+            wt.is_enabled().then_some(wt)
+        });
         let settings = Settings::new().enable_webtransport_server(wt_settings);
-        prop_assert!(settings.is_webtransport_enabled());
-        prop_assert_eq!(settings.enable_connect_protocol, Some(true));
-        prop_assert_eq!(settings.h3_datagram, Some(true));
-    }
+        assert!(settings.is_webtransport_enabled());
+        assert_eq!(settings.enable_connect_protocol, Some(true));
+        assert_eq!(settings.h3_datagram, Some(true));
+        Ok(())
+    })?;
+    Ok(())
 }
 
-proptest! {
-    /// Property: Settings::webtransport_draft_pattern() は
-    /// wt_settings.as_ref().and_then(|wt| wt.detect_draft_pattern()) と一致する
-    #[test]
-    fn prop_webtransport_draft_pattern_consistent(settings in arbitrary_settings()) {
-        let expected = settings.wt_settings
+/// Property: Settings::webtransport_draft_pattern() は
+/// wt_settings.as_ref().and_then(|wt| wt.detect_draft_pattern()) と一致する
+#[test]
+fn prop_webtransport_draft_pattern_consistent() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_SETTINGS_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let settings = arbitrary_settings(ctx);
+        let expected = settings
+            .wt_settings
             .as_ref()
             .and_then(|wt| wt.detect_draft_pattern());
         let actual = settings.webtransport_draft_pattern();
-        prop_assert_eq!(actual, expected);
-    }
+        assert_eq!(actual, expected);
+        Ok(())
+    })?;
+    Ok(())
 }
 
-proptest! {
-    /// Property: `Setting::from_wire` → `as_wire` → `from_wire` のラウンドトリップ
-    ///
-    /// VarInt 全域 (`encoded_settings_payload_len` の合算境界含む) を叩く。
-    /// HTTP/2 専用 / 予約 ID は Strategy 段で除外して shrink ノイズを抑える。
-    #[test]
-    fn prop_setting_wire_roundtrip(
-        id in settable_id(),
-        value in arbitrary_varint_full(),
-    ) {
+/// Property: `Setting::from_wire` → `as_wire` → `from_wire` のラウンドトリップ
+///
+/// VarInt 全域 (`encoded_settings_payload_len` の合算境界含む) を叩く。
+/// HTTP/2 専用 / 予約 ID は生成段階で除外する。
+#[test]
+fn prop_setting_wire_roundtrip() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_SETTINGS_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let id = settable_id(ctx);
+        let mut value = arbitrary_varint_full(ctx);
+
         // bool 値 ID の場合は値域を 0/1 に正規化する
         let id_raw = id.get();
         let bool_ids = [0x08u64, 0x33, 0x2b603742];
-        let value = if bool_ids.contains(&id_raw) {
-            vi(value.get() & 1)
-        } else {
-            value
-        };
+        if bool_ids.contains(&id_raw) {
+            value = vi(value.get() & 1);
+        }
         let setting = Setting::from_wire(id, value).expect("test must succeed");
         let (id2, value2) = setting.as_wire();
-        prop_assert_eq!(id, id2);
-        prop_assert_eq!(value, value2);
+        assert_eq!(id, id2);
+        assert_eq!(value, value2);
         let restored = Setting::from_wire(id2, value2).expect("test must succeed");
-        prop_assert_eq!(setting, restored);
-    }
+        assert_eq!(setting, restored);
+        Ok(())
+    })?;
+    Ok(())
 }
 
-/// 任意の `Setting` variant を 1 つ生成する Strategy
+/// 任意の `Setting` variant を 1 つ生成する
 ///
 /// HTTP/2 専用 / 予約 ID は `Setting::from_wire` で構築不可のため除外。
 /// 重複検出 PBT で variant 全体に検査が及ぶことを保証するために定義する。
-fn arbitrary_setting() -> impl Strategy<Value = Setting> {
-    prop_oneof![
-        arbitrary_varint().prop_map(Setting::QpackMaxTableCapacity),
-        arbitrary_varint().prop_map(Setting::MaxFieldSectionSize),
-        arbitrary_varint().prop_map(Setting::QpackBlockedStreams),
-        any::<bool>().prop_map(Setting::EnableConnectProtocol),
-        any::<bool>().prop_map(Setting::H3Datagram),
-        arbitrary_varint().prop_map(Setting::WtEnabled),
-        arbitrary_varint().prop_map(Setting::WtMaxSessionsDraft14),
-        any::<bool>().prop_map(Setting::EnableWebTransportDraft02),
-        arbitrary_varint().prop_map(Setting::WebTransportMaxSessionsDraft07),
-        arbitrary_varint().prop_map(Setting::WtInitialMaxData),
-        arbitrary_varint().prop_map(Setting::WtInitialMaxStreamsUni),
-        arbitrary_varint().prop_map(Setting::WtInitialMaxStreamsBidi),
-    ]
+fn arbitrary_setting(ctx: &mut noprop::TestCaseContext) -> Setting {
+    match noprop::sample_weighted_index(ctx, &[1u32; 12]) {
+        0 => Setting::QpackMaxTableCapacity(arbitrary_varint(ctx)),
+        1 => Setting::MaxFieldSectionSize(arbitrary_varint(ctx)),
+        2 => Setting::QpackBlockedStreams(arbitrary_varint(ctx)),
+        3 => Setting::EnableConnectProtocol(noprop::sample_bool(ctx)),
+        4 => Setting::H3Datagram(noprop::sample_bool(ctx)),
+        5 => Setting::WtEnabled(arbitrary_varint(ctx)),
+        6 => Setting::WtMaxSessionsDraft14(arbitrary_varint(ctx)),
+        7 => Setting::EnableWebTransportDraft02(noprop::sample_bool(ctx)),
+        8 => Setting::WebTransportMaxSessionsDraft07(arbitrary_varint(ctx)),
+        9 => Setting::WtInitialMaxData(arbitrary_varint(ctx)),
+        10 => Setting::WtInitialMaxStreamsUni(arbitrary_varint(ctx)),
+        _ => Setting::WtInitialMaxStreamsBidi(arbitrary_varint(ctx)),
+    }
 }
 
-proptest! {
-    /// Property: 任意の `Setting` variant を 2 回 `add` すると `DuplicateId { id }`
-    /// エラーが返る (variant 横断で `Setting::id()` ベースの重複検出が機能することを検証)
-    #[test]
-    fn prop_settings_payload_add_duplicate_rejected(setting in arbitrary_setting()) {
+/// Property: 任意の `Setting` variant を 2 回 `add` すると `DuplicateId { id }`
+/// エラーが返る (variant 横断で `Setting::id()` ベースの重複検出が機能することを検証)
+#[test]
+fn prop_settings_payload_add_duplicate_rejected() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_SETTINGS_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
         use shiguredo_http3::frame::SettingsPayload;
+        let setting = arbitrary_setting(ctx);
         let mut payload = SettingsPayload::new();
         payload.add(setting).expect("test must succeed");
         let err = payload.add(setting).unwrap_err();
-        prop_assert_eq!(err, SettingError::DuplicateId { id: setting.id() });
-    }
+        assert_eq!(err, SettingError::DuplicateId { id: setting.id() });
+        Ok(())
+    })?;
+    Ok(())
 }
 
-proptest! {
-    /// Property: `SettingsPayload::from_settings()` が GREASE 設定 (RFC 9114 §7.2.4.1)
-    /// を最低 1 つ含む
-    #[test]
-    fn prop_settings_payload_includes_grease(settings in arbitrary_settings()) {
+/// Property: `SettingsPayload::from_settings()` が GREASE 設定 (RFC 9114 §7.2.4.1)
+/// を最低 1 つ含む
+#[test]
+fn prop_settings_payload_includes_grease() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_SETTINGS_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let settings = arbitrary_settings(ctx);
         let payload = SettingsPayload::from_settings(&settings);
-        let grease_count = payload.settings().iter().filter(|s| s.id().get() == 0x21).count();
-        prop_assert_eq!(grease_count, 1, "GREASE 設定 (0x21) がちょうど 1 つ含まれていること");
-    }
+        let grease_count = payload
+            .settings()
+            .iter()
+            .filter(|s| s.id().get() == 0x21)
+            .count();
+        assert_eq!(
+            grease_count, 1,
+            "GREASE 設定 (0x21) がちょうど 1 つ含まれていること"
+        );
+        Ok(())
+    })?;
+    Ok(())
 }

--- a/pbt/tests/prop_stream.rs
+++ b/pbt/tests/prop_stream.rs
@@ -1,50 +1,53 @@
 //! Property-Based Testing for HTTP/3 ストリーム (RFC 9114 Section 6)
 
-use proptest::prelude::*;
 use shiguredo_http3::stream::{StreamKind, StreamState, UniStreamType};
 
 // =============================================================================
 // (a) StreamState 状態遷移の対称性
 // =============================================================================
 
-proptest! {
-    /// Property: close_local → close_remote と close_remote → close_local は共に Closed に到達する
-    #[test]
-    fn prop_stream_state_close_symmetry(_dummy in Just(())) {
-        // Open → LocalClosed → Closed
-        let mut state_lr = StreamState::Open;
-        state_lr.close_local();
-        prop_assert_eq!(state_lr, StreamState::LocalClosed);
-        state_lr.close_remote();
-        prop_assert_eq!(state_lr, StreamState::Closed, "close_local → close_remote で Closed にならない");
+/// Property: close_local → close_remote と close_remote → close_local は共に Closed に到達する
+#[test]
+fn prop_stream_state_close_symmetry() {
+    // Open → LocalClosed → Closed
+    let mut state_lr = StreamState::Open;
+    state_lr.close_local();
+    assert_eq!(state_lr, StreamState::LocalClosed);
+    state_lr.close_remote();
+    assert_eq!(
+        state_lr,
+        StreamState::Closed,
+        "close_local → close_remote で Closed にならない"
+    );
 
-        // Open → RemoteClosed → Closed
-        let mut state_rl = StreamState::Open;
-        state_rl.close_remote();
-        prop_assert_eq!(state_rl, StreamState::RemoteClosed);
-        state_rl.close_local();
-        prop_assert_eq!(state_rl, StreamState::Closed, "close_remote → close_local で Closed にならない");
-    }
+    // Open → RemoteClosed → Closed
+    let mut state_rl = StreamState::Open;
+    state_rl.close_remote();
+    assert_eq!(state_rl, StreamState::RemoteClosed);
+    state_rl.close_local();
+    assert_eq!(
+        state_rl,
+        StreamState::Closed,
+        "close_remote → close_local で Closed にならない"
+    );
 }
 
 // =============================================================================
 // (b) Reset は全ての状態から遷移可能で、Reset 後は send/receive 不可
 // =============================================================================
 
-proptest! {
-    /// Property: 任意の状態遷移列の後に reset() を呼ぶと、can_send()==false かつ can_receive()==false
-    #[test]
-    fn prop_reset_disables_send_and_receive(
-        ops in prop::collection::vec(
-            prop::sample::select(vec![0u8, 1, 2]),
-            0..=10,
-        )
-    ) {
+/// Property: 任意の状態遷移列の後に reset() を呼ぶと、can_send()==false かつ can_receive()==false
+#[test]
+fn prop_reset_disables_send_and_receive() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_STREAM_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let op_count = noprop::sample_usize_in(ctx, 0..=10);
         let mut state = StreamState::Open;
 
         // 任意の操作列を適用
-        for op in &ops {
-            match op {
+        for _ in 0..op_count {
+            match noprop::sample_choice(ctx, &[0u8, 1, 2]) {
                 0 => state.close_local(),
                 1 => state.close_remote(),
                 _ => state.reset(),
@@ -54,153 +57,196 @@ proptest! {
         // reset() を適用
         state.reset();
 
-        prop_assert_eq!(state, StreamState::Reset);
-        prop_assert!(!state.can_send(), "Reset 後に can_send() が true");
-        prop_assert!(!state.can_receive(), "Reset 後に can_receive() が true");
-        prop_assert!(state.is_reset(), "Reset 後に is_reset() が false");
-    }
+        assert_eq!(state, StreamState::Reset);
+        assert!(!state.can_send(), "Reset 後に can_send() が true");
+        assert!(!state.can_receive(), "Reset 後に can_receive() が true");
+        assert!(state.is_reset(), "Reset 後に is_reset() が false");
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // (c) StreamKind のストリーム ID 分類が QUIC 仕様に準拠
 // =============================================================================
 
-proptest! {
-    /// Property: 任意の stream_id に対して下位 2 ビットに基づく StreamKind 分類が正しい
-    #[test]
-    fn prop_stream_kind_classification(stream_id in 0u64..1_000_000) {
+/// Property: 任意の stream_id に対して下位 2 ビットに基づく StreamKind 分類が正しい
+#[test]
+fn prop_stream_kind_classification() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_STREAM_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let stream_id = noprop::sample_u64_in(ctx, 0..1_000_000);
         let kind = StreamKind::from_stream_id(stream_id);
         let low_bits = stream_id & 0x03;
 
         // 下位 2 ビットに基づく分類 (RFC 9000 Table 1)
         match low_bits {
             0x00 => {
-                prop_assert_eq!(kind, StreamKind::ClientBidi);
-                prop_assert!(kind.is_bidirectional());
-                prop_assert!(kind.is_client_initiated());
-                prop_assert!(!kind.is_unidirectional());
-                prop_assert!(!kind.is_server_initiated());
+                assert_eq!(kind, StreamKind::ClientBidi);
+                assert!(kind.is_bidirectional());
+                assert!(kind.is_client_initiated());
+                assert!(!kind.is_unidirectional());
+                assert!(!kind.is_server_initiated());
             }
             0x01 => {
-                prop_assert_eq!(kind, StreamKind::ServerBidi);
-                prop_assert!(kind.is_bidirectional());
-                prop_assert!(kind.is_server_initiated());
+                assert_eq!(kind, StreamKind::ServerBidi);
+                assert!(kind.is_bidirectional());
+                assert!(kind.is_server_initiated());
             }
             0x02 => {
-                prop_assert_eq!(kind, StreamKind::ClientUni);
-                prop_assert!(kind.is_unidirectional());
-                prop_assert!(kind.is_client_initiated());
+                assert_eq!(kind, StreamKind::ClientUni);
+                assert!(kind.is_unidirectional());
+                assert!(kind.is_client_initiated());
             }
             0x03 => {
-                prop_assert_eq!(kind, StreamKind::ServerUni);
-                prop_assert!(kind.is_unidirectional());
-                prop_assert!(kind.is_server_initiated());
+                assert_eq!(kind, StreamKind::ServerUni);
+                assert!(kind.is_unidirectional());
+                assert!(kind.is_server_initiated());
             }
             _ => unreachable!(),
         }
-    }
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: bidirectional と unidirectional は排他的
-    #[test]
-    fn prop_stream_kind_bidi_uni_exclusive(stream_id in 0u64..1_000_000) {
+/// Property: bidirectional と unidirectional は排他的
+#[test]
+fn prop_stream_kind_bidi_uni_exclusive() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_STREAM_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let stream_id = noprop::sample_u64_in(ctx, 0..1_000_000);
         let kind = StreamKind::from_stream_id(stream_id);
-        prop_assert_ne!(
+        assert_ne!(
             kind.is_bidirectional(),
             kind.is_unidirectional(),
             "bidirectional と unidirectional が同じ値"
         );
-    }
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: client_initiated と server_initiated は排他的
-    #[test]
-    fn prop_stream_kind_initiator_exclusive(stream_id in 0u64..1_000_000) {
+/// Property: client_initiated と server_initiated は排他的
+#[test]
+fn prop_stream_kind_initiator_exclusive() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_STREAM_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let stream_id = noprop::sample_u64_in(ctx, 0..1_000_000);
         let kind = StreamKind::from_stream_id(stream_id);
-        prop_assert_ne!(
+        assert_ne!(
             kind.is_client_initiated(),
             kind.is_server_initiated(),
             "client_initiated と server_initiated が同じ値"
         );
-    }
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // (d) UniStreamType::is_reserved の GREASE パターン
 // =============================================================================
 
-proptest! {
-    /// Property: 0x1f * N + 0x21 形式の値は is_reserved() == true
-    #[test]
-    fn prop_reserved_stream_type_formula(n in 0u64..10000) {
+/// Property: 0x1f * N + 0x21 形式の値は is_reserved() == true
+#[test]
+fn prop_reserved_stream_type_formula() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_STREAM_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let n = noprop::sample_u64_in(ctx, 0..10000);
         let t = 0x1f * n + 0x21;
-        prop_assert!(
+        assert!(
             UniStreamType::is_reserved(t),
-            "0x1f * {} + 0x21 = {:#x} が is_reserved() == false", n, t
+            "0x1f * {} + 0x21 = {:#x} が is_reserved() == false",
+            n,
+            t
         );
-    }
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: 0x1f * N + 0x21 形式でない値は is_reserved() == false (0x21 未満 + その他)
-    #[test]
-    fn prop_non_reserved_stream_type(t in 0u64..0x21) {
-        prop_assert!(
+/// Property: 0x1f * N + 0x21 形式でない値は is_reserved() == false (0x21 未満 + その他)
+#[test]
+fn prop_non_reserved_stream_type() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_STREAM_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let t = noprop::sample_u64_in(ctx, 0..0x21);
+        assert!(
             !UniStreamType::is_reserved(t),
-            "{:#x} が is_reserved() == true (0x21 未満なのに予約済み)", t
+            "{:#x} が is_reserved() == true (0x21 未満なのに予約済み)",
+            t
         );
-    }
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: 0x21 以上で 0x1f * N + 0x21 形式でない値は is_reserved() == false
-    #[test]
-    fn prop_non_grease_above_threshold(n in 0u64..10000, offset in 1u64..0x1f) {
+/// Property: 0x21 以上で 0x1f * N + 0x21 形式でない値は is_reserved() == false
+#[test]
+fn prop_non_grease_above_threshold() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_STREAM_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let n = noprop::sample_u64_in(ctx, 0..10000);
+        let offset = noprop::sample_u64_in(ctx, 1..0x1f);
         let t = 0x1f * n + 0x21 + offset;
         // offset が 0x1f の倍数でない限り is_reserved() == false のはず
         // ただし offset + 0x21 が次の GREASE 値に一致する場合がある。
         // 正確には (t - 0x21) % 0x1f != 0 なら false
         if (t - 0x21) % 0x1f != 0 {
-            prop_assert!(
+            assert!(
                 !UniStreamType::is_reserved(t),
-                "{:#x} が is_reserved() == true (GREASE パターンに合致しないのに)", t
+                "{:#x} が is_reserved() == true (GREASE パターンに合致しないのに)",
+                t
             );
         }
-    }
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // (e) StreamState の can_send / can_receive の不変条件
 // =============================================================================
 
-proptest! {
-    /// Property: Open 状態では can_send==true, can_receive==true
-    #[test]
-    fn prop_open_state_can_send_receive(_dummy in Just(())) {
-        let state = StreamState::Open;
-        prop_assert!(state.can_send());
-        prop_assert!(state.can_receive());
-    }
+/// Property: Open 状態では can_send==true, can_receive==true
+#[test]
+fn prop_open_state_can_send_receive() {
+    let state = StreamState::Open;
+    assert!(state.can_send());
+    assert!(state.can_receive());
+}
 
-    /// Property: LocalClosed では can_send==false, can_receive==true
-    #[test]
-    fn prop_local_closed_no_send(_dummy in Just(())) {
-        let mut state = StreamState::Open;
-        state.close_local();
-        prop_assert!(!state.can_send());
-        prop_assert!(state.can_receive());
-    }
+/// Property: LocalClosed では can_send==false, can_receive==true
+#[test]
+fn prop_local_closed_no_send() {
+    let mut state = StreamState::Open;
+    state.close_local();
+    assert!(!state.can_send());
+    assert!(state.can_receive());
+}
 
-    /// Property: RemoteClosed では can_send==true, can_receive==false
-    #[test]
-    fn prop_remote_closed_no_receive(_dummy in Just(())) {
-        let mut state = StreamState::Open;
-        state.close_remote();
-        prop_assert!(state.can_send());
-        prop_assert!(!state.can_receive());
-    }
+/// Property: RemoteClosed では can_send==true, can_receive==false
+#[test]
+fn prop_remote_closed_no_receive() {
+    let mut state = StreamState::Open;
+    state.close_remote();
+    assert!(state.can_send());
+    assert!(!state.can_receive());
+}
 
-    /// Property: Closed では can_send==false, can_receive==false
-    #[test]
-    fn prop_closed_no_send_no_receive(_dummy in Just(())) {
-        let mut state = StreamState::Open;
-        state.close_local();
-        state.close_remote();
-        prop_assert!(!state.can_send());
-        prop_assert!(!state.can_receive());
-    }
+/// Property: Closed では can_send==false, can_receive==false
+#[test]
+fn prop_closed_no_send_no_receive() {
+    let mut state = StreamState::Open;
+    state.close_local();
+    state.close_remote();
+    assert!(!state.can_send());
+    assert!(!state.can_receive());
 }

--- a/pbt/tests/prop_validation.rs
+++ b/pbt/tests/prop_validation.rs
@@ -1,7 +1,6 @@
 //! Property-Based Testing for HTTP/3 メッセージ検証 (RFC 9114 Section 4.1.2)
 
 use pbt::wire_header;
-use proptest::prelude::*;
 use shiguredo_http3::Header;
 use shiguredo_http3::validation::{
     calculate_field_section_size, check_field_section_size, validate_content_length,
@@ -9,23 +8,23 @@ use shiguredo_http3::validation::{
 };
 
 // =============================================================================
-// Strategy ヘルパー
+// 生成ヘルパー
 // =============================================================================
 
 /// 有効なフィールド名を生成 (小文字 ASCII + tchar, 擬似ヘッダープレフィックス ':' を含まない)
-fn valid_field_name() -> impl Strategy<Value = Vec<u8>> {
+fn valid_field_name(ctx: &mut noprop::TestCaseContext) -> Vec<u8> {
     // RFC 9110 Section 5.6.2 の tchar のうち小文字のみ (RFC 9114 Section 4.2)
     // 接続固有フィールドと "te" は除外する
-    prop::collection::vec(
-        prop::sample::select(vec![
-            b'a', b'b', b'c', b'd', b'e', b'f', b'g', b'h', b'i', b'j', b'k', b'l', b'm', b'n',
-            b'o', b'p', b'q', b'r', b's', b't', b'u', b'v', b'w', b'x', b'y', b'z', b'0', b'1',
-            b'2', b'3', b'4', b'5', b'6', b'7', b'8', b'9', b'!', b'#', b'$', b'%', b'&', b'*',
-            b'+', b'-', b'.', b'^', b'_', b'`', b'|', b'~',
-        ]),
-        1..=20,
-    )
-    .prop_filter("接続固有フィールドと te を除外", |name| {
+    noprop::sample_with_rejection(ctx, 64, |ctx| {
+        let len = noprop::sample_usize_in(ctx, 1..=20);
+        let mut name = Vec::new();
+        for _ in 0..len {
+            name.push(noprop::sample_choice(
+                ctx,
+                b"abcdefghijklmnopqrstuvwxyz0123456789!#$%&*+-.^_`|~",
+            ));
+        }
+        // 接続固有フィールドと te を除外
         let forbidden: &[&[u8]] = &[
             b"connection",
             b"keep-alive",
@@ -34,109 +33,118 @@ fn valid_field_name() -> impl Strategy<Value = Vec<u8>> {
             b"upgrade",
             b"te",
         ];
-        !forbidden.contains(&name.as_slice())
+        (!forbidden.contains(&name.as_slice())).then_some(name)
     })
 }
 
 /// 有効なフィールド値を生成 (field-vchar: 0x21-0x7e, 空も許可)
-fn valid_field_value() -> impl Strategy<Value = Vec<u8>> {
-    prop::collection::vec(0x21u8..=0x7e, 0..=100)
+fn valid_field_value(ctx: &mut noprop::TestCaseContext) -> Vec<u8> {
+    let len = noprop::sample_usize_in(ctx, 0..=100);
+    let mut value = Vec::new();
+    for _ in 0..len {
+        value.push(0x21 + noprop::sample_usize_in(ctx, 0..=0x5d) as u8);
+    }
+    value
 }
 
 /// 有効な HTTP メソッドを生成
-fn valid_method() -> impl Strategy<Value = Vec<u8>> {
-    prop::sample::select(vec![
-        b"GET".to_vec(),
-        b"POST".to_vec(),
-        b"PUT".to_vec(),
-        b"DELETE".to_vec(),
-        b"HEAD".to_vec(),
-        b"OPTIONS".to_vec(),
-        b"PATCH".to_vec(),
-    ])
+fn valid_method(ctx: &mut noprop::TestCaseContext) -> Vec<u8> {
+    noprop::sample_choice(
+        ctx,
+        &[
+            b"GET".to_vec(),
+            b"POST".to_vec(),
+            b"PUT".to_vec(),
+            b"DELETE".to_vec(),
+            b"HEAD".to_vec(),
+            b"OPTIONS".to_vec(),
+            b"PATCH".to_vec(),
+        ],
+    )
 }
 
 /// 有効な :status 値を生成 (100-599 の 3 桁 ASCII 文字列、ただし 101 は除外)
-fn valid_status() -> impl Strategy<Value = Vec<u8>> {
-    (100u32..600)
-        .prop_filter("HTTP/3 は 101 をサポートしない", |s| *s != 101)
-        .prop_map(|s| format!("{s:03}").into_bytes())
-}
-
-/// 有効な URI scheme を生成
-fn valid_scheme() -> impl Strategy<Value = Vec<u8>> {
-    prop::sample::select(vec![b"http".to_vec(), b"https".to_vec()])
-}
-
-/// 有効な :path を生成 ("/" + 0-20 文字の英数字)
-fn valid_path() -> impl Strategy<Value = Vec<u8>> {
-    prop::collection::vec(
-        prop::sample::select(vec![
-            b'a', b'b', b'c', b'd', b'e', b'f', b'g', b'h', b'i', b'j', b'k', b'l', b'm', b'n',
-            b'o', b'p', b'q', b'r', b's', b't', b'u', b'v', b'w', b'x', b'y', b'z', b'0', b'1',
-            b'2', b'3', b'4', b'5', b'6', b'7', b'8', b'9',
-        ]),
-        0..=20,
-    )
-    .prop_map(|mut v| {
-        v.insert(0, b'/');
-        v
+fn valid_status(ctx: &mut noprop::TestCaseContext) -> Vec<u8> {
+    noprop::sample_with_rejection(ctx, 64, |ctx| {
+        let s = noprop::sample_u64_in(ctx, 100..600);
+        // HTTP/3 は 101 をサポートしない
+        (s != 101).then_some(format!("{s:03}").into_bytes())
     })
 }
 
+/// 有効な URI scheme を生成
+fn valid_scheme(ctx: &mut noprop::TestCaseContext) -> Vec<u8> {
+    noprop::sample_choice(ctx, &[b"http".to_vec(), b"https".to_vec()])
+}
+
+/// 有効な :path を生成 ("/" + 0-20 文字の英数字)
+fn valid_path(ctx: &mut noprop::TestCaseContext) -> Vec<u8> {
+    let len = noprop::sample_usize_in(ctx, 0..=20);
+    let mut path = vec![b'/'];
+    for _ in 0..len {
+        path.push(noprop::sample_choice(
+            ctx,
+            b"abcdefghijklmnopqrstuvwxyz0123456789",
+        ));
+    }
+    path
+}
+
 /// 有効な通常ヘッダーのリストを生成
-fn valid_regular_headers() -> impl Strategy<Value = Vec<Header>> {
-    prop::collection::vec(
-        (valid_field_name(), valid_field_value())
-            .prop_map(|(name, value)| Header::new(name, value).expect("test must succeed")),
-        0..=5,
-    )
+fn valid_regular_headers(ctx: &mut noprop::TestCaseContext) -> Vec<Header> {
+    let len = noprop::sample_usize_in(ctx, 0..=5);
+    let mut headers = Vec::new();
+    for _ in 0..len {
+        let name = valid_field_name(ctx);
+        let value = valid_field_value(ctx);
+        headers.push(Header::new(name, value).expect("test must succeed"));
+    }
+    headers
 }
 
 // =============================================================================
 // (a) field_section_size の計算式が RFC 準拠
 // =============================================================================
 
-proptest! {
-    /// Property: calculate_field_section_size は各ヘッダーの (name_len + value_len + 32) の合計と一致する
-    #[test]
-    fn prop_field_section_size_matches_rfc_formula(
-        headers in prop::collection::vec(
-            (valid_field_name(), valid_field_value()),
-            0..=10,
-        )
-    ) {
-        let header_list: Vec<Header> = headers
-            .iter()
-            .map(|(n, v)| Header::new(n.as_slice(), v.as_slice()).expect("test must succeed"))
-            .collect();
+/// Property: calculate_field_section_size は各ヘッダーの (name_len + value_len + 32) の合計と一致する
+#[test]
+fn prop_field_section_size_matches_rfc_formula() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_VALIDATION_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let count = noprop::sample_usize_in(ctx, 0..=10);
+        let mut headers = Vec::new();
+        let mut expected = 0u64;
+        for _ in 0..count {
+            let name = valid_field_name(ctx);
+            let value = valid_field_value(ctx);
+            // RFC 9114 Section 4.2.2: 各フィールドの name_len + value_len + 32 の合計
+            expected += name.len() as u64 + value.len() as u64 + 32;
+            headers.push(Header::new(name, value).expect("test must succeed"));
+        }
 
-        // RFC 9114 Section 4.2.2: 各フィールドの name_len + value_len + 32 の合計
-        let expected: u64 = headers
-            .iter()
-            .map(|(n, v)| n.len() as u64 + v.len() as u64 + 32)
-            .sum();
-
-        let actual = calculate_field_section_size(&header_list);
-        prop_assert_eq!(actual, expected, "RFC 準拠の計算式と不一致");
-    }
+        let actual = calculate_field_section_size(&headers);
+        assert_eq!(actual, expected, "RFC 準拠の計算式と不一致");
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // (b) 有効なリクエストヘッダーは常に受理される
 // =============================================================================
 
-proptest! {
-    /// Property: 正しい擬似ヘッダーと有効な通常ヘッダーを持つリクエストは受理される
-    #[test]
-    fn prop_valid_request_headers_accepted(
-        method in valid_method(),
-        scheme in valid_scheme(),
-        path in valid_path(),
-        regular_headers in valid_regular_headers(),
-    ) {
-        // CONNECT は :scheme, :path を持たないため除外
-        prop_assume!(method != b"CONNECT");
+/// Property: 正しい擬似ヘッダーと有効な通常ヘッダーを持つリクエストは受理される
+#[test]
+fn prop_valid_request_headers_accepted() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_VALIDATION_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let method = valid_method(ctx);
+        let scheme = valid_scheme(ctx);
+        let path = valid_path(ctx);
+        let regular_headers = valid_regular_headers(ctx);
+        // 生成されるメソッドに CONNECT は含まれないため、CONNECT 除外は不要
 
         let mut headers = vec![
             Header::new(b":method", method.as_slice()).expect("test must succeed"),
@@ -147,26 +155,26 @@ proptest! {
         headers.extend(regular_headers);
 
         let result = validate_request_headers(&headers);
-        prop_assert!(
-            result.is_ok(),
-            "有効なリクエストが拒否された: {:?}",
-            result,
-        );
-    }
+        assert!(result.is_ok(), "有効なリクエストが拒否された: {:?}", result,);
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // (c) 有効なレスポンスヘッダーは常に受理される
 // =============================================================================
 
-proptest! {
-    /// Property: 正しい :status と有効な通常ヘッダーを持つレスポンスは受理される
-    #[test]
-    fn prop_valid_response_headers_accepted(
-        status in valid_status(),
-        regular_headers in valid_regular_headers(),
-    ) {
-        let mut headers = vec![Header::new(b":status", status.as_slice()).expect("test must succeed")];
+/// Property: 正しい :status と有効な通常ヘッダーを持つレスポンスは受理される
+#[test]
+fn prop_valid_response_headers_accepted() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_VALIDATION_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let status = valid_status(ctx);
+        let regular_headers = valid_regular_headers(ctx);
+        let mut headers =
+            vec![Header::new(b":status", status.as_slice()).expect("test must succeed")];
         // レスポンスでは "te" ヘッダーは禁止なのでフィルタする
         let filtered: Vec<_> = regular_headers
             .into_iter()
@@ -175,27 +183,26 @@ proptest! {
         headers.extend(filtered);
 
         let result = validate_response_headers(&headers);
-        prop_assert!(
-            result.is_ok(),
-            "有効なレスポンスが拒否された: {:?}",
-            result,
-        );
-    }
+        assert!(result.is_ok(), "有効なレスポンスが拒否された: {:?}", result,);
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // (d) 擬似ヘッダーが通常ヘッダーの後に出現すると拒否
 // =============================================================================
 
-proptest! {
-    /// Property: 擬似ヘッダーの後に通常ヘッダーが来てから再び擬似ヘッダーが出現すると MessageError
-    #[test]
-    fn prop_pseudo_header_after_regular_rejected(
-        method in valid_method(),
-        scheme in valid_scheme(),
-        path in valid_path(),
-    ) {
-        prop_assume!(method != b"CONNECT");
+/// Property: 擬似ヘッダーの後に通常ヘッダーが来てから再び擬似ヘッダーが出現すると MessageError
+#[test]
+fn prop_pseudo_header_after_regular_rejected() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_VALIDATION_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let method = valid_method(ctx);
+        let scheme = valid_scheme(ctx);
+        let path = valid_path(ctx);
+        // 生成されるメソッドに CONNECT は含まれないため、CONNECT 除外は不要
 
         // 擬似ヘッダー → 通常ヘッダー → 擬似ヘッダー の順序にする
         let headers = vec![
@@ -207,29 +214,35 @@ proptest! {
         ];
 
         let result = validate_request_headers(&headers);
-        prop_assert!(
+        assert!(
             result.is_err(),
             "擬似ヘッダーが通常ヘッダーの後に来ても受理された"
         );
-    }
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // (e) 接続固有ヘッダーは必ず拒否
 // =============================================================================
 
-proptest! {
-    /// Property: connection, keep-alive, proxy-connection, transfer-encoding, upgrade を含むリクエストは拒否
-    #[test]
-    fn prop_connection_specific_headers_rejected_in_request(
-        conn_header in prop::sample::select(vec![
-            b"connection".to_vec(),
-            b"keep-alive".to_vec(),
-            b"proxy-connection".to_vec(),
-            b"transfer-encoding".to_vec(),
-            b"upgrade".to_vec(),
-        ]),
-    ) {
+/// Property: connection, keep-alive, proxy-connection, transfer-encoding, upgrade を含むリクエストは拒否
+#[test]
+fn prop_connection_specific_headers_rejected_in_request() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_VALIDATION_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let conn_header = noprop::sample_choice(
+            ctx,
+            &[
+                b"connection".to_vec(),
+                b"keep-alive".to_vec(),
+                b"proxy-connection".to_vec(),
+                b"transfer-encoding".to_vec(),
+                b"upgrade".to_vec(),
+            ],
+        );
         let headers = vec![
             Header::new(b":method", b"GET").expect("test must succeed"),
             Header::new(b":scheme", b"https").expect("test must succeed"),
@@ -239,46 +252,59 @@ proptest! {
         ];
 
         let result = validate_request_headers(&headers);
-        prop_assert!(
+        assert!(
             result.is_err(),
             "接続固有ヘッダー {:?} がリクエストで受理された",
             String::from_utf8_lossy(&conn_header),
         );
-    }
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: 接続固有ヘッダーを含むレスポンスは拒否
-    #[test]
-    fn prop_connection_specific_headers_rejected_in_response(
-        conn_header in prop::sample::select(vec![
-            b"connection".to_vec(),
-            b"keep-alive".to_vec(),
-            b"proxy-connection".to_vec(),
-            b"transfer-encoding".to_vec(),
-            b"upgrade".to_vec(),
-        ]),
-    ) {
+/// Property: 接続固有ヘッダーを含むレスポンスは拒否
+#[test]
+fn prop_connection_specific_headers_rejected_in_response() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_VALIDATION_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let conn_header = noprop::sample_choice(
+            ctx,
+            &[
+                b"connection".to_vec(),
+                b"keep-alive".to_vec(),
+                b"proxy-connection".to_vec(),
+                b"transfer-encoding".to_vec(),
+                b"upgrade".to_vec(),
+            ],
+        );
         let headers = vec![
             Header::new(b":status", b"200").expect("test must succeed"),
             Header::new(conn_header.as_slice(), b"some-value").expect("test must succeed"),
         ];
 
         let result = validate_response_headers(&headers);
-        prop_assert!(
+        assert!(
             result.is_err(),
             "接続固有ヘッダー {:?} がレスポンスで受理された",
             String::from_utf8_lossy(&conn_header),
         );
-    }
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // (f) content-length の一致/不一致
 // =============================================================================
 
-proptest! {
-    /// Property: content-length と body_size が一致すれば Ok
-    #[test]
-    fn prop_content_length_match_ok(body_size in 0u64..10000) {
+/// Property: content-length と body_size が一致すれば Ok
+#[test]
+fn prop_content_length_match_ok() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_VALIDATION_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let body_size = noprop::sample_u64_in(ctx, 0..10000);
         let cl_str = body_size.to_string();
         let headers = vec![
             Header::new(b":method", b"GET").expect("test must succeed"),
@@ -286,16 +312,23 @@ proptest! {
         ];
 
         let result = validate_content_length(&headers, body_size, false);
-        prop_assert!(result.is_ok(), "一致する content-length が拒否された");
-    }
+        assert!(result.is_ok(), "一致する content-length が拒否された");
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: content-length と body_size が不一致なら Err
-    #[test]
-    fn prop_content_length_mismatch_err(
-        expected in 0u64..10000,
-        actual in 0u64..10000,
-    ) {
-        prop_assume!(expected != actual);
+/// Property: content-length と body_size が不一致なら Err
+#[test]
+fn prop_content_length_mismatch_err() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_VALIDATION_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let (expected, actual) = noprop::sample_with_rejection(ctx, 64, |ctx| {
+            let e = noprop::sample_u64_in(ctx, 0..10000);
+            let a = noprop::sample_u64_in(ctx, 0..10000);
+            (e != a).then_some((e, a))
+        });
 
         let cl_str = expected.to_string();
         let headers = vec![
@@ -304,75 +337,98 @@ proptest! {
         ];
 
         let result = validate_content_length(&headers, actual, false);
-        prop_assert!(result.is_err(), "不一致な content-length が受理された");
-    }
+        assert!(result.is_err(), "不一致な content-length が受理された");
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // (g) field_section_size の上限チェック
 // =============================================================================
 
-proptest! {
-    /// Property: field_section_size が peer_max 以下なら Ok、超過なら Err
-    #[test]
-    fn prop_field_section_size_limit(
-        headers in prop::collection::vec(
-            (valid_field_name(), valid_field_value()),
-            1..=5,
-        ),
-        peer_max in 0u64..5000,
-    ) {
-        let header_list: Vec<Header> = headers
-            .iter()
-            .map(|(n, v)| Header::new(n.as_slice(), v.as_slice()).expect("test must succeed"))
-            .collect();
+/// Property: field_section_size が peer_max 以下なら Ok、超過なら Err
+#[test]
+fn prop_field_section_size_limit() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_VALIDATION_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let count = noprop::sample_usize_in(ctx, 1..=5);
+        let mut header_list = Vec::new();
+        for _ in 0..count {
+            let name = valid_field_name(ctx);
+            let value = valid_field_value(ctx);
+            header_list.push(Header::new(name, value).expect("test must succeed"));
+        }
+        let peer_max = noprop::sample_u64_in(ctx, 0..5000);
 
         let size = calculate_field_section_size(&header_list);
         let result = check_field_section_size(&header_list, Some(peer_max));
 
         if size <= peer_max {
-            prop_assert!(result.is_ok(), "上限以下なのに拒否された: size={}, max={}", size, peer_max);
+            assert!(
+                result.is_ok(),
+                "上限以下なのに拒否された: size={}, max={}",
+                size,
+                peer_max
+            );
         } else {
-            prop_assert!(result.is_err(), "上限超過なのに受理された: size={}, max={}", size, peer_max);
+            assert!(
+                result.is_err(),
+                "上限超過なのに受理された: size={}, max={}",
+                size,
+                peer_max
+            );
         }
-    }
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: peer_max が None の場合は常に Ok
-    #[test]
-    fn prop_field_section_size_no_limit(
-        headers in prop::collection::vec(
-            (valid_field_name(), valid_field_value()),
-            0..=5,
-        ),
-    ) {
-        let header_list: Vec<Header> = headers
-            .iter()
-            .map(|(n, v)| Header::new(n.as_slice(), v.as_slice()).expect("test must succeed"))
-            .collect();
+/// Property: peer_max が None の場合は常に Ok
+#[test]
+fn prop_field_section_size_no_limit() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_VALIDATION_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let count = noprop::sample_usize_in(ctx, 0..=5);
+        let mut header_list = Vec::new();
+        for _ in 0..count {
+            let name = valid_field_name(ctx);
+            let value = valid_field_value(ctx);
+            header_list.push(Header::new(name, value).expect("test must succeed"));
+        }
 
         let result = check_field_section_size(&header_list, None);
-        prop_assert!(result.is_ok(), "peer_max=None なのに拒否された");
-    }
+        assert!(result.is_ok(), "peer_max=None なのに拒否された");
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // (h) トレーラーに擬似ヘッダーが含まれると拒否
 // =============================================================================
 
-proptest! {
-    /// Property: 擬似ヘッダーを含むトレーラーは拒否される
-    #[test]
-    fn prop_trailer_with_pseudo_header_rejected(
-        pseudo in prop::sample::select(vec![
-            b":method".to_vec(),
-            b":scheme".to_vec(),
-            b":path".to_vec(),
-            b":authority".to_vec(),
-            b":status".to_vec(),
-            b":protocol".to_vec(),
-        ]),
-        regular_headers in valid_regular_headers(),
-    ) {
+/// Property: 擬似ヘッダーを含むトレーラーは拒否される
+#[test]
+fn prop_trailer_with_pseudo_header_rejected() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_VALIDATION_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let pseudo = noprop::sample_choice(
+            ctx,
+            &[
+                b":method".to_vec(),
+                b":scheme".to_vec(),
+                b":path".to_vec(),
+                b":authority".to_vec(),
+                b":status".to_vec(),
+                b":protocol".to_vec(),
+            ],
+        );
+        let regular_headers = valid_regular_headers(ctx);
+
         // 有効な通常ヘッダーのみのトレーラーは受理される
         let filtered: Vec<_> = regular_headers
             .iter()
@@ -381,7 +437,7 @@ proptest! {
             .collect();
         if !filtered.is_empty() {
             let result = validate_trailer_headers(&filtered);
-            prop_assert!(result.is_ok(), "有効なトレーラーが拒否された: {:?}", result);
+            assert!(result.is_ok(), "有効なトレーラーが拒否された: {:?}", result);
         }
 
         // 擬似ヘッダーを混入
@@ -393,12 +449,14 @@ proptest! {
         bad_trailer.push(wire_header(&pseudo, b"value"));
 
         let result = validate_trailer_headers(&bad_trailer);
-        prop_assert!(
+        assert!(
             result.is_err(),
             "擬似ヘッダー {:?} を含むトレーラーが受理された",
             String::from_utf8_lossy(&pseudo),
         );
-    }
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
@@ -409,13 +467,15 @@ proptest! {
 // 挙動が乖離していないことを保証する。
 // =============================================================================
 
-proptest! {
-    /// Property: `Header::new(b":protocol", v).is_ok()` ⇔ Extended CONNECT で
-    /// 同じ `v` を渡したリクエストが `validate_request_headers` を通る
-    #[test]
-    fn prop_protocol_check_consistency(
-        value in prop::collection::vec(any::<u8>(), 0..=32),
-    ) {
+/// Property: `Header::new(b":protocol", v).is_ok()` ⇔ Extended CONNECT で
+/// 同じ `v` を渡したリクエストが `validate_request_headers` を通る
+#[test]
+fn prop_protocol_check_consistency() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_VALIDATION_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let len = noprop::sample_usize_in(ctx, 0..=32);
+        let value = noprop::sample_bytes_vec(ctx, len);
         let build_ok = Header::new(b":protocol", &value).is_ok();
 
         // wire 模擬で Header を組み立て、validation 側の判定だけを取り出す
@@ -428,12 +488,14 @@ proptest! {
         ];
         let validate_ok = validate_request_headers(&headers).is_ok();
 
-        prop_assert_eq!(
+        assert_eq!(
             build_ok, validate_ok,
             "Header::new と validation::is_valid_protocol の判定が乖離: value={:?}",
             value,
         );
-    }
+        Ok(())
+    })?;
+    Ok(())
 }
 
 /// authority 候補を生成する (host[:port] 構文の有効・無効を混在させる)。
@@ -441,19 +503,28 @@ proptest! {
 /// 文字集合はすべて有効な field-value 文字に限定するため、Host 経路の
 /// field-value 検査では落ちず、authority 構文検査 (is_valid_authority) の
 /// 結果だけが Ok/Err を分ける。
-fn authority_candidate() -> impl Strategy<Value = Vec<u8>> {
-    proptest::collection::vec(prop::sample::select(b"ab01.:-[]".to_vec()), 1..16)
+fn authority_candidate(ctx: &mut noprop::TestCaseContext) -> Vec<u8> {
+    let chars = b"ab01.:-[]";
+    let len = noprop::sample_usize_in(ctx, 1..16);
+    let mut value = Vec::new();
+    for _ in 0..len {
+        value.push(noprop::sample_choice(ctx, chars));
+    }
+    value
 }
 
-proptest! {
-    /// :authority 経路と Host 単独経路で authority 構文検証の結果が一致すること。
-    ///
-    /// Host は :authority の代替として同じ uri-host[:port] 構文で検証される (RFC 9110
-    /// Section 7.2)。charset は field-value として有効かつ userinfo (@) や空値を含まないため、
-    /// 両経路で挙動が分かれる差分 (userinfo 拒否 / 空値 / CONNECT) を踏まず、
-    /// is_valid_authority の結果だけが Ok/Err を分ける。それらの差分は単体テストで固定する。
-    #[test]
-    fn prop_host_only_matches_authority_validation(value in authority_candidate()) {
+/// :authority 経路と Host 単独経路で authority 構文検証の結果が一致すること。
+///
+/// Host は :authority の代替として同じ uri-host[:port] 構文で検証される (RFC 9110
+/// Section 7.2)。charset は field-value として有効かつ userinfo (@) や空値を含まないため、
+/// 両経路で挙動が分かれる差分 (userinfo 拒否 / 空値 / CONNECT) を踏まず、
+/// is_valid_authority の結果だけが Ok/Err を分ける。それらの差分は単体テストで固定する。
+#[test]
+fn prop_host_only_matches_authority_validation() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_VALIDATION_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let value = authority_candidate(ctx);
         let with_authority = vec![
             Header::new(b":method", b"GET").expect("test must succeed"),
             Header::new(b":scheme", b"https").expect("test must succeed"),
@@ -466,11 +537,13 @@ proptest! {
             Header::new(b":path", b"/").expect("test must succeed"),
             Header::new(b"host", &value).expect("test must succeed"),
         ];
-        prop_assert_eq!(
+        assert_eq!(
             validate_request_headers(&with_authority).is_ok(),
             validate_request_headers(&with_host).is_ok(),
             "value={:?}",
             value,
         );
-    }
+        Ok(())
+    })?;
+    Ok(())
 }

--- a/pbt/tests/prop_varint.rs
+++ b/pbt/tests/prop_varint.rs
@@ -1,144 +1,208 @@
 //! Property-Based Testing for QUIC Variable-Length Integer (RFC 9000 Section 16)
 
 use pbt::strategies::{invalid_varint_u64, valid_varint};
-use proptest::prelude::*;
 use shiguredo_http3::VarInt;
 use shiguredo_http3::varint;
 
-prop_compose! {
-    /// 1 バイトエンコード範囲の値を生成 (0-63)
-    fn one_byte_value()(value in 0u64..64) -> VarInt {
-        VarInt::new(value).expect("test must succeed")
-    }
+/// 1 バイトエンコード範囲の値を生成 (0-63)
+fn one_byte_value(ctx: &mut noprop::TestCaseContext) -> VarInt {
+    VarInt::new(noprop::sample_u64_in(ctx, 0..64)).expect("test must succeed")
 }
 
-prop_compose! {
-    /// 2 バイトエンコード範囲の値を生成 (64-16383)
-    fn two_byte_value()(value in 64u64..16384) -> VarInt {
-        VarInt::new(value).expect("test must succeed")
-    }
+/// 2 バイトエンコード範囲の値を生成 (64-16383)
+fn two_byte_value(ctx: &mut noprop::TestCaseContext) -> VarInt {
+    VarInt::new(noprop::sample_u64_in(ctx, 64..16384)).expect("test must succeed")
 }
 
-prop_compose! {
-    /// 4 バイトエンコード範囲の値を生成 (16384-1073741823)
-    fn four_byte_value()(value in 16384u64..1073741824) -> VarInt {
-        VarInt::new(value).expect("test must succeed")
-    }
+/// 4 バイトエンコード範囲の値を生成 (16384-1073741823)
+fn four_byte_value(ctx: &mut noprop::TestCaseContext) -> VarInt {
+    VarInt::new(noprop::sample_u64_in(ctx, 16384..1073741824)).expect("test must succeed")
 }
 
-prop_compose! {
-    /// 8 バイトエンコード範囲の値を生成 (1073741824-MAX)
-    fn eight_byte_value()(value in 1073741824u64..=VarInt::MAX.get()) -> VarInt {
-        VarInt::new(value).expect("test must succeed")
-    }
+/// 8 バイトエンコード範囲の値を生成 (1073741824-MAX)
+fn eight_byte_value(ctx: &mut noprop::TestCaseContext) -> VarInt {
+    VarInt::new(noprop::sample_u64_in(ctx, 1073741824..=VarInt::MAX.get()))
+        .expect("test must succeed")
 }
 
-proptest! {
-    /// Property: エンコード -> デコードのラウンドトリップで値が保存される
-    #[test]
-    fn prop_roundtrip_preserves_value(value in valid_varint()) {
+/// Property: エンコード -> デコードのラウンドトリップで値が保存される
+#[test]
+fn prop_roundtrip_preserves_value() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_VARINT_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let value = valid_varint(ctx);
         let mut buf = [0u8; 8];
         let encoded_len = varint::encode(&mut buf, value).expect("test must succeed");
         let (decoded, decoded_len) = varint::decode(&buf).expect("test must succeed");
 
-        prop_assert_eq!(value, decoded, "Roundtrip failed for value {}", value);
-        prop_assert_eq!(encoded_len, decoded_len, "Length mismatch for value {}", value);
-    }
+        assert_eq!(value, decoded, "Roundtrip failed for value {}", value);
+        assert_eq!(
+            encoded_len, decoded_len,
+            "Length mismatch for value {}",
+            value
+        );
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: VarInt::encoded_len() が実際のエンコード長と一致する
-    #[test]
-    fn prop_encoded_len_matches_actual(value in valid_varint()) {
+/// Property: VarInt::encoded_len() が実際のエンコード長と一致する
+#[test]
+fn prop_encoded_len_matches_actual() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_VARINT_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let value = valid_varint(ctx);
         let expected_len = value.encoded_len();
         let mut buf = [0u8; 8];
         let actual_len = varint::encode(&mut buf, value).expect("test must succeed");
 
-        prop_assert_eq!(expected_len, actual_len, "encoded_len mismatch for {}", value);
-    }
+        assert_eq!(
+            expected_len, actual_len,
+            "encoded_len mismatch for {}",
+            value
+        );
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: 任意 VarInt は `encoded_len()` 分のバッファで必ずエンコードできる
-    /// (`EncodeError::ValueTooLarge` を削除した正当性: 値域は型レベルで保証される)
-    #[test]
-    fn prop_encode_succeeds_for_any_varint(value in valid_varint()) {
+/// Property: 任意 VarInt は `encoded_len()` 分のバッファで必ずエンコードできる
+/// (`EncodeError::ValueTooLarge` を削除した正当性: 値域は型レベルで保証される)
+#[test]
+fn prop_encode_succeeds_for_any_varint() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_VARINT_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let value = valid_varint(ctx);
         let mut buf = vec![0u8; value.encoded_len()];
         let result = varint::encode(&mut buf, value);
-        prop_assert!(result.is_ok(), "encode should succeed for any VarInt");
-    }
+        assert!(result.is_ok(), "encode should succeed for any VarInt");
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: バッファ長が `encoded_len()` 未満なら必ず `BufferTooShort` を返す
-    #[test]
-    fn prop_short_buffer_returns_buffer_too_short(
-        value in valid_varint(),
-        shortfall in 1usize..=8,
-    ) {
+/// Property: バッファ長が `encoded_len()` 未満なら必ず `BufferTooShort` を返す
+#[test]
+fn prop_short_buffer_returns_buffer_too_short() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_VARINT_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let value = valid_varint(ctx);
+        let shortfall = noprop::sample_usize_in(ctx, 1..=8);
         let need = value.encoded_len();
         // shortfall 分だけ短いバッファ (need == 1 の場合は 0 バイトバッファ)
         let len = need.saturating_sub(shortfall);
         let mut buf = vec![0u8; len];
         let result = varint::encode(&mut buf, value);
-        prop_assert_eq!(result, Err(varint::EncodeError::BufferTooShort));
-    }
+        assert_eq!(result, Err(varint::EncodeError::BufferTooShort));
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: 1 バイト値は 1 バイトでエンコードされる
-    #[test]
-    fn prop_one_byte_encoding(value in one_byte_value()) {
+/// Property: 1 バイト値は 1 バイトでエンコードされる
+#[test]
+fn prop_one_byte_encoding() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_VARINT_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let value = one_byte_value(ctx);
         let len = value.encoded_len();
-        prop_assert_eq!(len, 1, "Value {} should encode to 1 byte", value);
+        assert_eq!(len, 1, "Value {} should encode to 1 byte", value);
 
         let mut buf = [0u8; 8];
         varint::encode(&mut buf, value).expect("test must succeed");
         // 上位 2 ビットは 00
-        prop_assert_eq!(buf[0] >> 6, 0, "1-byte prefix should be 00");
-    }
+        assert_eq!(buf[0] >> 6, 0, "1-byte prefix should be 00");
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: 2 バイト値は 2 バイトでエンコードされる
-    #[test]
-    fn prop_two_byte_encoding(value in two_byte_value()) {
+/// Property: 2 バイト値は 2 バイトでエンコードされる
+#[test]
+fn prop_two_byte_encoding() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_VARINT_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let value = two_byte_value(ctx);
         let len = value.encoded_len();
-        prop_assert_eq!(len, 2, "Value {} should encode to 2 bytes", value);
+        assert_eq!(len, 2, "Value {} should encode to 2 bytes", value);
 
         let mut buf = [0u8; 8];
         varint::encode(&mut buf, value).expect("test must succeed");
         // 上位 2 ビットは 01
-        prop_assert_eq!(buf[0] >> 6, 1, "2-byte prefix should be 01");
-    }
+        assert_eq!(buf[0] >> 6, 1, "2-byte prefix should be 01");
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: 4 バイト値は 4 バイトでエンコードされる
-    #[test]
-    fn prop_four_byte_encoding(value in four_byte_value()) {
+/// Property: 4 バイト値は 4 バイトでエンコードされる
+#[test]
+fn prop_four_byte_encoding() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_VARINT_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let value = four_byte_value(ctx);
         let len = value.encoded_len();
-        prop_assert_eq!(len, 4, "Value {} should encode to 4 bytes", value);
+        assert_eq!(len, 4, "Value {} should encode to 4 bytes", value);
 
         let mut buf = [0u8; 8];
         varint::encode(&mut buf, value).expect("test must succeed");
         // 上位 2 ビットは 10
-        prop_assert_eq!(buf[0] >> 6, 2, "4-byte prefix should be 10");
-    }
+        assert_eq!(buf[0] >> 6, 2, "4-byte prefix should be 10");
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: 8 バイト値は 8 バイトでエンコードされる
-    #[test]
-    fn prop_eight_byte_encoding(value in eight_byte_value()) {
+/// Property: 8 バイト値は 8 バイトでエンコードされる
+#[test]
+fn prop_eight_byte_encoding() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_VARINT_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let value = eight_byte_value(ctx);
         let len = value.encoded_len();
-        prop_assert_eq!(len, 8, "Value {} should encode to 8 bytes", value);
+        assert_eq!(len, 8, "Value {} should encode to 8 bytes", value);
 
         let mut buf = [0u8; 8];
         varint::encode(&mut buf, value).expect("test must succeed");
         // 上位 2 ビットは 11
-        prop_assert_eq!(buf[0] >> 6, 3, "8-byte prefix should be 11");
-    }
+        assert_eq!(buf[0] >> 6, 3, "8-byte prefix should be 11");
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: peek_len() がデコード前に正しい長さを返す
-    #[test]
-    fn prop_peek_len_matches_decode_len(value in valid_varint()) {
+/// Property: peek_len() がデコード前に正しい長さを返す
+#[test]
+fn prop_peek_len_matches_decode_len() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_VARINT_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let value = valid_varint(ctx);
         let mut buf = [0u8; 8];
         let encoded_len = varint::encode(&mut buf, value).expect("test must succeed");
         let peeked_len = varint::peek_len(&buf).expect("test must succeed");
 
-        prop_assert_eq!(encoded_len, peeked_len, "peek_len mismatch for {}", value);
-    }
+        assert_eq!(encoded_len, peeked_len, "peek_len mismatch for {}", value);
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: エンコード結果はビッグエンディアン順
-    #[test]
-    fn prop_encoding_is_big_endian(value in two_byte_value()) {
+/// Property: エンコード結果はビッグエンディアン順
+#[test]
+fn prop_encoding_is_big_endian() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_VARINT_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let value = two_byte_value(ctx);
         let mut buf = [0u8; 8];
         varint::encode(&mut buf, value).expect("test must succeed");
 
@@ -147,63 +211,114 @@ proptest! {
         let expected_high = (0x40 | ((raw >> 8) & 0x3f)) as u8;
         let expected_low = (raw & 0xff) as u8;
 
-        prop_assert_eq!(buf[0], expected_high, "High byte mismatch");
-        prop_assert_eq!(buf[1], expected_low, "Low byte mismatch");
-    }
+        assert_eq!(buf[0], expected_high, "High byte mismatch");
+        assert_eq!(buf[1], expected_low, "Low byte mismatch");
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: `From<u8>` は任意 u8 で値が一致する
-    #[test]
-    fn prop_from_u8_roundtrip(value in any::<u8>()) {
+/// Property: `From<u8>` は任意 u8 で値が一致する
+#[test]
+fn prop_from_u8_roundtrip() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_VARINT_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let value = noprop::sample_u8(ctx);
         let v = VarInt::from(value);
-        prop_assert_eq!(v.get(), u64::from(value));
-    }
+        assert_eq!(v.get(), u64::from(value));
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: `From<u16>` は任意 u16 で値が一致する
-    #[test]
-    fn prop_from_u16_roundtrip(value in any::<u16>()) {
+/// Property: `From<u16>` は任意 u16 で値が一致する
+#[test]
+fn prop_from_u16_roundtrip() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_VARINT_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let value = noprop::sample_u16(ctx);
         let v = VarInt::from(value);
-        prop_assert_eq!(v.get(), u64::from(value));
-    }
+        assert_eq!(v.get(), u64::from(value));
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: `From<u32>` は任意 u32 で値が一致する
-    #[test]
-    fn prop_from_u32_roundtrip(value in any::<u32>()) {
+/// Property: `From<u32>` は任意 u32 で値が一致する
+#[test]
+fn prop_from_u32_roundtrip() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_VARINT_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let value = noprop::sample_u32(ctx);
         let v = VarInt::from(value);
-        prop_assert_eq!(v.get(), u64::from(value));
-    }
+        assert_eq!(v.get(), u64::from(value));
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: `TryFrom<u64>` は値域内で必ず Ok、値域外で必ず Err
-    #[test]
-    fn prop_try_from_u64_value_domain(value in any::<u64>()) {
+/// Property: `TryFrom<u64>` は値域内で必ず Ok、値域外で必ず Err
+#[test]
+fn prop_try_from_u64_value_domain() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_VARINT_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let value = noprop::sample_u64(ctx);
         let result = VarInt::try_from(value);
         if value <= VarInt::MAX.get() {
-            prop_assert!(result.is_ok());
-            prop_assert_eq!(result.expect("test must succeed").get(), value);
+            assert!(result.is_ok());
+            assert_eq!(result.expect("test must succeed").get(), value);
         } else {
-            prop_assert!(result.is_err());
+            assert!(result.is_err());
         }
-    }
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: `VarInt::Display` 出力は内部値の 10 進表現と一致する
-    #[test]
-    fn prop_display_matches_u64(value in valid_varint()) {
-        prop_assert_eq!(format!("{value}"), format!("{}", value.get()));
-    }
+/// Property: `VarInt::Display` 出力は内部値の 10 進表現と一致する
+#[test]
+fn prop_display_matches_u64() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_VARINT_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let value = valid_varint(ctx);
+        assert_eq!(format!("{value}"), format!("{}", value.get()));
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: `from_static` と `new` が同じ値を返す (`const fn` 検査と
-    /// ランタイム検査のロジック一致)
-    #[test]
-    fn prop_from_static_matches_new(value in 0u64..=VarInt::MAX.get()) {
+/// Property: `from_static` と `new` が同じ値を返す (`const fn` 検査と
+/// ランタイム検査のロジック一致)
+#[test]
+fn prop_from_static_matches_new() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_VARINT_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let value = noprop::sample_u64_in(ctx, 0..=VarInt::MAX.get());
         let via_new = VarInt::new(value).expect("test must succeed");
         let via_static = VarInt::from_static(value);
-        prop_assert_eq!(via_new, via_static);
-    }
+        assert_eq!(via_new, via_static);
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: VarInt 範囲外の `u64` は `new` で必ず Err、`TryFrom<u64>` でも必ず Err
-    /// (構築 API の値域判定が一貫している)
-    #[test]
-    fn prop_invalid_varint_rejected(value in invalid_varint_u64()) {
-        prop_assert!(VarInt::new(value).is_err());
-        prop_assert!(VarInt::try_from(value).is_err());
-    }
+/// Property: VarInt 範囲外の `u64` は `new` で必ず Err、`TryFrom<u64>` でも必ず Err
+/// (構築 API の値域判定が一貫している)
+#[test]
+fn prop_invalid_varint_rejected() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_VARINT_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let value = invalid_varint_u64(ctx);
+        assert!(VarInt::new(value).is_err());
+        assert!(VarInt::try_from(value).is_err());
+        Ok(())
+    })?;
+    Ok(())
 }

--- a/pbt/tests/prop_webtransport/capsule.rs
+++ b/pbt/tests/prop_webtransport/capsule.rs
@@ -1,111 +1,122 @@
 //! Capsule の capsule_type 検証・Unknown ラウンドトリップ・不完全バッファの Sans I/O 挙動
 //! (既知バリアントのラウンドトリップは pbt/tests/prop_capsule.rs に集約)
 
-use proptest::prelude::*;
 use shiguredo_http3::webtransport::Capsule;
 
-prop_compose! {
-    /// 有効なエラーコード (32-bit)
-    fn valid_error_code()(code in any::<u32>()) -> u32 {
-        code
+/// 有効なエラーコード (32-bit)
+fn valid_error_code(ctx: &mut noprop::TestCaseContext) -> u32 {
+    noprop::sample_u32(ctx)
+}
+
+/// 有効なエラーメッセージ (最大 1024 バイト)
+fn valid_error_message(ctx: &mut noprop::TestCaseContext) -> String {
+    let len = noprop::sample_usize_in(ctx, 0..=1024);
+    let mut msg = Vec::new();
+    for _ in 0..len {
+        msg.push(0x20 + noprop::sample_usize_in(ctx, 0..=0x5f) as u8);
+    }
+    String::from_utf8(msg).expect("ASCII range bytes are always valid UTF-8")
+}
+
+/// 有効な最大値 (可変長整数範囲)
+fn valid_maximum(ctx: &mut noprop::TestCaseContext) -> u64 {
+    noprop::sample_u64_in(ctx, 0..=(1 << 62) - 1)
+}
+
+/// 有効な Unknown Capsule
+fn valid_unknown_capsule(ctx: &mut noprop::TestCaseContext) -> Capsule {
+    let capsule_type = noprop::sample_u64_in(ctx, 0x100000..0x200000);
+    let payload_len = noprop::sample_usize_in(ctx, 0..256);
+    let payload = noprop::sample_bytes_vec(ctx, payload_len);
+    Capsule::Unknown {
+        capsule_type,
+        payload,
     }
 }
 
-prop_compose! {
-    /// 有効なエラーメッセージ (最大 1024 バイト)
-    fn valid_error_message()(
-        len in 0usize..=1024,
-    )(
-        msg in prop::collection::vec(0x20u8..0x7f, len)
-    ) -> String {
-        String::from_utf8(msg).expect("ASCII range bytes are always valid UTF-8")
-    }
-}
-
-prop_compose! {
-    /// 有効な最大値 (可変長整数範囲)
-    fn valid_maximum()(max in 0u64..=(1 << 62) - 1) -> u64 {
-        max
-    }
-}
-
-prop_compose! {
-    /// 有効な Unknown Capsule
-    fn valid_unknown_capsule()(
-        capsule_type in 0x100000u64..0x200000,
-        payload_len in 0usize..256,
-    )(
-        capsule_type in Just(capsule_type),
-        payload in prop::collection::vec(any::<u8>(), payload_len)
-    ) -> Capsule {
-        Capsule::Unknown { capsule_type, payload }
-    }
-}
-
-proptest! {
-    /// Property: Unknown Capsule のラウンドトリップ
-    #[test]
-    fn prop_unknown_capsule_roundtrip(capsule in valid_unknown_capsule()) {
+/// Property: Unknown Capsule のラウンドトリップ
+#[test]
+fn prop_unknown_capsule_roundtrip() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_CAPSULE_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let capsule = valid_unknown_capsule(ctx);
         let mut buf = Vec::new();
         capsule.encode(&mut buf);
 
         let (decoded, consumed) = Capsule::decode(&buf)
             .expect("decode should not error")
             .expect("decode should not be incomplete");
-        prop_assert_eq!(consumed, buf.len());
-        prop_assert_eq!(decoded, capsule);
-    }
+        assert_eq!(consumed, buf.len());
+        assert_eq!(decoded, capsule);
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: Capsule の capsule_type() が正しい値を返す
-    #[test]
-    fn prop_capsule_type_consistent(
-        error_code in valid_error_code(),
-        maximum in 0u64..1000,
-        bidirectional in any::<bool>(),
-    ) {
+/// Property: Capsule の capsule_type() が正しい値を返す
+#[test]
+fn prop_capsule_type_consistent() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_CAPSULE_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let error_code = valid_error_code(ctx);
+        let maximum = noprop::sample_u64_in(ctx, 0..1000);
+        let bidirectional = noprop::sample_bool(ctx);
+
         let close = Capsule::CloseSession {
             error_code,
             message: String::new(),
         };
-        prop_assert_eq!(close.capsule_type(), 0x2843);
+        assert_eq!(close.capsule_type(), 0x2843);
 
         let drain = Capsule::DrainSession;
-        prop_assert_eq!(drain.capsule_type(), 0x78ae);
+        assert_eq!(drain.capsule_type(), 0x78ae);
 
         let max_data = Capsule::MaxData { maximum };
-        prop_assert_eq!(max_data.capsule_type(), 0x190B4D3D);
+        assert_eq!(max_data.capsule_type(), 0x190B4D3D);
 
-        let max_streams = Capsule::MaxStreams { bidirectional, maximum };
+        let max_streams = Capsule::MaxStreams {
+            bidirectional,
+            maximum,
+        };
         if bidirectional {
-            prop_assert_eq!(max_streams.capsule_type(), 0x190B4D3F);
+            assert_eq!(max_streams.capsule_type(), 0x190B4D3F);
         } else {
-            prop_assert_eq!(max_streams.capsule_type(), 0x190B4D40);
+            assert_eq!(max_streams.capsule_type(), 0x190B4D40);
         }
 
         let data_blocked = Capsule::DataBlocked { maximum };
-        prop_assert_eq!(data_blocked.capsule_type(), 0x190B4D41);
+        assert_eq!(data_blocked.capsule_type(), 0x190B4D41);
 
-        let streams_blocked = Capsule::StreamsBlocked { bidirectional, maximum };
+        let streams_blocked = Capsule::StreamsBlocked {
+            bidirectional,
+            maximum,
+        };
         if bidirectional {
-            prop_assert_eq!(streams_blocked.capsule_type(), 0x190B4D43);
+            assert_eq!(streams_blocked.capsule_type(), 0x190B4D43);
         } else {
-            prop_assert_eq!(streams_blocked.capsule_type(), 0x190B4D44);
+            assert_eq!(streams_blocked.capsule_type(), 0x190B4D44);
         }
-    }
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // 不完全バッファの Sans I/O 挙動
 // =============================================================================
 
-proptest! {
-    /// Property: 不完全なバッファでは None を返す (CloseSession)
-    #[test]
-    fn prop_capsule_incomplete_buffer_close_session(
-        error_code in any::<u32>(),
-        message in valid_error_message(),
-        cut_ratio in 0.1f64..0.9,
-    ) {
+/// Property: 不完全なバッファでは None を返す (CloseSession)
+#[test]
+fn prop_capsule_incomplete_buffer_close_session() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_CAPSULE_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let error_code = noprop::sample_u32(ctx);
+        let message = valid_error_message(ctx);
+        let cut_ratio = noprop::sample_f64_in(ctx, 0.1, 0.9);
+
         let capsule = Capsule::CloseSession {
             error_code,
             message,
@@ -118,15 +129,24 @@ proptest! {
         let incomplete = &buf[..cut_at.max(1)];
 
         let result = Capsule::decode(incomplete);
-        prop_assert!(matches!(result, Ok(None)), "Incomplete buffer should return None");
-    }
+        assert!(
+            matches!(result, Ok(None)),
+            "Incomplete buffer should return None"
+        );
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: 不完全なバッファでは None を返す (MaxData)
-    #[test]
-    fn prop_capsule_incomplete_buffer_max_data(
-        maximum in valid_maximum(),
-        cut_ratio in 0.1f64..0.9,
-    ) {
+/// Property: 不完全なバッファでは None を返す (MaxData)
+#[test]
+fn prop_capsule_incomplete_buffer_max_data() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_CAPSULE_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let maximum = valid_maximum(ctx);
+        let cut_ratio = noprop::sample_f64_in(ctx, 0.1, 0.9);
+
         let capsule = Capsule::MaxData { maximum };
 
         let mut buf = Vec::new();
@@ -137,14 +157,19 @@ proptest! {
             let incomplete = &buf[..cut_at.max(1)];
 
             let result = Capsule::decode(incomplete);
-            prop_assert!(matches!(result, Ok(None)), "Incomplete buffer should return None");
+            assert!(
+                matches!(result, Ok(None)),
+                "Incomplete buffer should return None"
+            );
         }
-    }
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: 空バッファでは None を返す
-    #[test]
-    fn prop_capsule_empty_buffer_returns_none(_dummy in Just(())) {
-        let result = Capsule::decode(&[]);
-        prop_assert!(matches!(result, Ok(None)));
-    }
+/// Property: 空バッファでは None を返す
+#[test]
+fn prop_capsule_empty_buffer_returns_none() {
+    let result = Capsule::decode(&[]);
+    assert!(matches!(result, Ok(None)));
 }

--- a/pbt/tests/prop_webtransport/connect.rs
+++ b/pbt/tests/prop_webtransport/connect.rs
@@ -1,62 +1,82 @@
 //! ConnectRequest / ConnectResponse のバリデーションとプロトコルネゴシエーション
 //! (draft-ietf-webtrans-http3-15 Section 3.2, 3.3)
 
-use proptest::prelude::*;
 use shiguredo_http3::webtransport::{ConnectRequest, ConnectResponse};
 
-prop_compose! {
-    /// 任意の非空文字列 (HTTP ヘッダー値として安全な文字のみ)
-    fn non_empty_string()(
-        len in 1usize..64,
-    )(
-        s in prop::collection::vec(0x20u8..0x7f, len)
-    ) -> String {
-        String::from_utf8(s).unwrap_or_else(|_| "x".to_string())
+/// 任意の非空文字列 (HTTP ヘッダー値として安全な文字のみ)
+fn non_empty_string(ctx: &mut noprop::TestCaseContext) -> String {
+    let len = noprop::sample_usize_in(ctx, 1..64);
+    let mut s = String::new();
+    for _ in 0..len {
+        s.push((0x20 + noprop::sample_usize_in(ctx, 0..=0x5f)) as u8 as char);
     }
+    s
 }
 
-/// プロトコル名として安全な文字列の Strategy
+/// プロトコル名として安全な文字列を生成
 ///
 /// Structured Fields List のカンマ区切りや
 /// クォート文字列のエスケープ対象文字 (',', '"', '\\') を除外する。
-fn safe_protocol_name() -> impl Strategy<Value = String> {
-    prop::string::string_regex("[a-zA-Z0-9_\\-\\.\\+/]{1,32}")
-        .expect("valid regex")
-        .prop_filter("non-empty", |s| !s.is_empty())
+fn safe_protocol_name(ctx: &mut noprop::TestCaseContext) -> String {
+    let chars = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-./+";
+    let len = noprop::sample_usize_in(ctx, 1..=32);
+    let mut s = String::new();
+    for _ in 0..len {
+        s.push(noprop::sample_choice(ctx, chars) as char);
+    }
+    s
 }
 
 // =============================================================================
 // ConnectRequest バリデーション (draft-ietf-webtrans-http3-15 Section 3.2)
 // =============================================================================
 
-proptest! {
-    /// Property: 有効なリクエストは validate() が Ok を返す
-    #[test]
-    fn prop_connect_request_valid(
-        authority in non_empty_string(),
-        path in non_empty_string(),
-    ) {
+/// Property: 有効なリクエストは validate() が Ok を返す
+#[test]
+fn prop_connect_request_valid() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_CONNECT_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let authority = non_empty_string(ctx);
+        let path = non_empty_string(ctx);
         let req = ConnectRequest::new("https", authority, path);
-        prop_assert!(req.validate().is_ok());
-    }
+        assert!(req.validate().is_ok());
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: scheme が "https" 以外なら InvalidScheme
-    #[test]
-    fn prop_connect_request_invalid_scheme(
-        scheme in non_empty_string(),
-        authority in non_empty_string(),
-        path in non_empty_string(),
-    ) {
-        prop_assume!(scheme != "https");
+/// Property: scheme が "https" 以外なら InvalidScheme
+#[test]
+fn prop_connect_request_invalid_scheme() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_CONNECT_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let scheme = noprop::sample_with_rejection(ctx, 64, |ctx| {
+            let s = non_empty_string(ctx);
+            (s != "https").then_some(s)
+        });
+        let authority = non_empty_string(ctx);
+        let path = non_empty_string(ctx);
         let req = ConnectRequest::new(scheme, authority, path);
-        prop_assert!(req.validate().is_err());
-    }
+        assert!(req.validate().is_err());
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: WT-Available-Protocols の文字列型のみを抽出
-    #[test]
-    fn prop_parse_available_protocols_strings_only(
-        protocols in prop::collection::vec(safe_protocol_name(), 1..5),
-    ) {
+/// Property: WT-Available-Protocols の文字列型のみを抽出
+#[test]
+fn prop_parse_available_protocols_strings_only() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_CONNECT_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let protocol_count = noprop::sample_usize_in(ctx, 1..5);
+        let mut protocols = Vec::new();
+        for _ in 0..protocol_count {
+            protocols.push(safe_protocol_name(ctx));
+        }
+
         let header_value = protocols
             .iter()
             .map(|p| format!("\"{}\"", p))
@@ -64,68 +84,96 @@ proptest! {
             .join(", ");
 
         let result = ConnectRequest::parse_available_protocols(&header_value);
-        prop_assert_eq!(result, protocols);
-    }
+        assert_eq!(result, protocols);
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: WT-Protocol 文字列型のラウンドトリップ
-    #[test]
-    fn prop_parse_protocol_string_roundtrip(proto in safe_protocol_name()) {
+/// Property: WT-Protocol 文字列型のラウンドトリップ
+#[test]
+fn prop_parse_protocol_string_roundtrip() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_CONNECT_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let proto = safe_protocol_name(ctx);
         let header_value = format!("\"{}\"", proto);
         let result = ConnectResponse::parse_protocol(&header_value);
-        prop_assert_eq!(result, Some(proto));
-    }
+        assert_eq!(result, Some(proto));
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: available_protocols が空なら selected_protocol なしで true
-    #[test]
-    fn prop_connect_response_no_protocol_no_negotiation_valid(
-        authority in non_empty_string(),
-        path in non_empty_string(),
-    ) {
+/// Property: available_protocols が空なら selected_protocol なしで true
+#[test]
+fn prop_connect_response_no_protocol_no_negotiation_valid() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_CONNECT_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let authority = non_empty_string(ctx);
+        let path = non_empty_string(ctx);
         let req = ConnectRequest::new("https", authority, path);
         let resp = ConnectResponse::new(200);
-        prop_assert!(resp.is_protocol_valid(&req));
-    }
+        assert!(resp.is_protocol_valid(&req));
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: available_protocols が非空なら selected_protocol なしで false (draft-15)
-    #[test]
-    fn prop_connect_response_no_protocol_with_negotiation_invalid(
-        authority in non_empty_string(),
-        path in non_empty_string(),
-        protocols in prop::collection::vec(non_empty_string(), 1..5),
-    ) {
-        let req = ConnectRequest::new("https", authority, path)
-            .available_protocols(protocols);
+/// Property: available_protocols が非空なら selected_protocol なしで false (draft-15)
+#[test]
+fn prop_connect_response_no_protocol_with_negotiation_invalid() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_CONNECT_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let authority = non_empty_string(ctx);
+        let path = non_empty_string(ctx);
+        let protocol_count = noprop::sample_usize_in(ctx, 1..5);
+        let mut protocols = Vec::new();
+        for _ in 0..protocol_count {
+            protocols.push(non_empty_string(ctx));
+        }
+        let req = ConnectRequest::new("https", authority, path).available_protocols(protocols);
         let resp = ConnectResponse::new(200);
-        prop_assert!(!resp.is_protocol_valid(&req));
-    }
+        assert!(!resp.is_protocol_valid(&req));
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // プロトコルネゴシエーション (draft-ietf-webtrans-http3-15 Section 3.3)
 // =============================================================================
 
-proptest! {
-    /// Property: selected_protocol が available_protocols に含まれる場合は valid、
-    /// 含まれない場合は invalid (draft-ietf-webtrans-http3-15 Section 3.3)
-    #[test]
-    fn prop_connect_response_protocol_selection(
-        protocols in prop::collection::vec(safe_protocol_name(), 1..5),
-        selected_idx in 0usize..10,
-        extra_protocol in safe_protocol_name(),
-    ) {
-        let req = ConnectRequest::new("https", "example.com", "/")
-            .available_protocols(protocols.clone());
+/// Property: selected_protocol が available_protocols に含まれる場合は valid、
+/// 含まれない場合は invalid (draft-ietf-webtrans-http3-15 Section 3.3)
+#[test]
+fn prop_connect_response_protocol_selection() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_CONNECT_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let protocol_count = noprop::sample_usize_in(ctx, 1..5);
+        let mut protocols = Vec::new();
+        for _ in 0..protocol_count {
+            protocols.push(safe_protocol_name(ctx));
+        }
+        let selected_idx = noprop::sample_usize_in(ctx, 0..10);
+        let extra_protocol = safe_protocol_name(ctx);
+
+        let req =
+            ConnectRequest::new("https", "example.com", "/").available_protocols(protocols.clone());
 
         if selected_idx < protocols.len() {
-            let resp = ConnectResponse::new(200)
-                .with_protocol(&protocols[selected_idx]);
-            prop_assert!(resp.is_protocol_valid(&req));
+            let resp = ConnectResponse::new(200).with_protocol(&protocols[selected_idx]);
+            assert!(resp.is_protocol_valid(&req));
         }
 
         if !protocols.contains(&extra_protocol) {
-            let resp = ConnectResponse::new(200)
-                .with_protocol(&extra_protocol);
-            prop_assert!(!resp.is_protocol_valid(&req));
+            let resp = ConnectResponse::new(200).with_protocol(&extra_protocol);
+            assert!(!resp.is_protocol_valid(&req));
         }
-    }
+        Ok(())
+    })?;
+    Ok(())
 }

--- a/pbt/tests/prop_webtransport/error.rs
+++ b/pbt/tests/prop_webtransport/error.rs
@@ -1,75 +1,96 @@
 //! ApplicationErrorCode / Error のプロパティと CloseSession メッセージ長制約
 //! (draft-ietf-webtrans-http3-15 Section 6, 9.5)
 
-use proptest::prelude::*;
 use shiguredo_http3::webtransport::{ApplicationErrorCode, Error, ErrorCode};
 
-prop_compose! {
-    /// 有効なエラーメッセージ (最大 1024 バイト)
-    fn valid_error_message()(
-        len in 0usize..=1024,
-    )(
-        msg in prop::collection::vec(0x20u8..0x7f, len)
-    ) -> String {
-        String::from_utf8(msg).expect("ASCII range bytes are always valid UTF-8")
+/// 有効なエラーメッセージ (最大 1024 バイト)
+fn valid_error_message(ctx: &mut noprop::TestCaseContext) -> String {
+    let len = noprop::sample_usize_in(ctx, 0..=1024);
+    let mut msg = Vec::new();
+    for _ in 0..len {
+        msg.push(0x20 + noprop::sample_usize_in(ctx, 0..=0x5f) as u8);
     }
+    String::from_utf8(msg).expect("ASCII range bytes are always valid UTF-8")
 }
 
-prop_compose! {
-    /// 1024 バイト超のメッセージ (ASCII)
-    fn long_message()(
-        len in 1025usize..2048,
-    )(
-        msg in prop::collection::vec(0x20u8..0x7f, len)
-    ) -> String {
-        String::from_utf8(msg).expect("ASCII range bytes are always valid UTF-8")
+/// 1024 バイト超のメッセージ (ASCII)
+fn long_message(ctx: &mut noprop::TestCaseContext) -> String {
+    let len = noprop::sample_usize_in(ctx, 1025..2048);
+    let mut msg = Vec::new();
+    for _ in 0..len {
+        msg.push(0x20 + noprop::sample_usize_in(ctx, 0..=0x5f) as u8);
     }
+    String::from_utf8(msg).expect("ASCII range bytes are always valid UTF-8")
 }
 
 // =============================================================================
 // ApplicationErrorCode (draft-ietf-webtrans-http3-15 Section 9.5)
 // =============================================================================
 
-proptest! {
-    /// Property: アプリケーションエラーコードのラウンドトリップ
-    #[test]
-    fn prop_application_error_code_roundtrip(app_code in any::<u32>()) {
+/// Property: アプリケーションエラーコードのラウンドトリップ
+#[test]
+fn prop_application_error_code_roundtrip() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_ERROR_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let app_code = noprop::sample_u32(ctx);
         let http3_code = ApplicationErrorCode::to_http3_code(app_code);
         let back = ApplicationErrorCode::from_http3_code(http3_code);
 
-        prop_assert_eq!(back, Some(app_code));
-    }
+        assert_eq!(back, Some(app_code));
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: HTTP/3 コードが範囲内
-    #[test]
-    fn prop_http3_code_in_range(app_code in any::<u32>()) {
+/// Property: HTTP/3 コードが範囲内
+#[test]
+fn prop_http3_code_in_range() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_ERROR_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let app_code = noprop::sample_u32(ctx);
         let http3_code = ApplicationErrorCode::to_http3_code(app_code);
 
-        prop_assert!(
+        assert!(
             http3_code >= ApplicationErrorCode::FIRST,
             "HTTP/3 code {} < FIRST {}",
-            http3_code, ApplicationErrorCode::FIRST
+            http3_code,
+            ApplicationErrorCode::FIRST
         );
-        prop_assert!(
+        assert!(
             http3_code <= ApplicationErrorCode::LAST,
             "HTTP/3 code {} > LAST {}",
-            http3_code, ApplicationErrorCode::LAST
+            http3_code,
+            ApplicationErrorCode::LAST
         );
-    }
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: is_application_error が正しく判定
-    #[test]
-    fn prop_is_application_error_consistent(app_code in any::<u32>()) {
+/// Property: is_application_error が正しく判定
+#[test]
+fn prop_is_application_error_consistent() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_ERROR_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let app_code = noprop::sample_u32(ctx);
         let http3_code = ApplicationErrorCode::to_http3_code(app_code);
-        prop_assert!(ApplicationErrorCode::is_application_error(http3_code));
-    }
+        assert!(ApplicationErrorCode::is_application_error(http3_code));
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: Error::application のラウンドトリップ
-    #[test]
-    fn prop_error_application_roundtrip(
-        code in any::<u32>(),
-        message in valid_error_message(),
-    ) {
+/// Property: Error::application のラウンドトリップ
+#[test]
+fn prop_error_application_roundtrip() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_ERROR_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let code = noprop::sample_u32(ctx);
+        let message = valid_error_message(ctx);
         let error = Error::application(code, message.clone());
 
         if let Error::Application {
@@ -77,107 +98,152 @@ proptest! {
             message: dec_msg,
         } = error
         {
-            prop_assert_eq!(dec_code, code);
-            prop_assert!(dec_msg.len() <= 1024);
+            assert_eq!(dec_code, code);
+            assert!(dec_msg.len() <= 1024);
             if message.len() <= 1024 {
-                prop_assert_eq!(dec_msg, message);
+                assert_eq!(dec_msg, message);
             }
         } else {
-            prop_assert!(false, "Expected Application error");
+            panic!("Expected Application error");
         }
-    }
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: Error の HTTP/3 コード変換
-    #[test]
-    fn prop_error_to_http3_code(code in any::<u32>()) {
+/// Property: Error の HTTP/3 コード変換
+#[test]
+fn prop_error_to_http3_code() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_ERROR_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let code = noprop::sample_u32(ctx);
         let error = Error::Application {
             code,
             message: String::new(),
         };
 
         let http3_code = error.to_http3_code();
-        prop_assert_eq!(http3_code, ApplicationErrorCode::to_http3_code(code));
-    }
+        assert_eq!(http3_code, ApplicationErrorCode::to_http3_code(code));
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: Error::from_http3_code で Protocol エラーを正しく復元
-    #[test]
-    fn prop_error_from_http3_code_protocol(
-        error_code in prop::sample::select(vec![
-            ErrorCode::BufferedStreamRejected,
-            ErrorCode::SessionGone,
-            ErrorCode::FlowControlError,
-        ])
-    ) {
+/// Property: Error::from_http3_code で Protocol エラーを正しく復元
+#[test]
+fn prop_error_from_http3_code_protocol() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_ERROR_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let error_code = noprop::sample_choice(
+            ctx,
+            &[
+                ErrorCode::BufferedStreamRejected,
+                ErrorCode::SessionGone,
+                ErrorCode::FlowControlError,
+            ],
+        );
         let http3_code = error_code as u64;
         let error = Error::from_http3_code(http3_code);
 
-        prop_assert_eq!(error, Error::Protocol(error_code));
-    }
+        assert_eq!(error, Error::Protocol(error_code));
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // CloseSession メッセージ長制約 (draft-ietf-webtrans-http3-15 Section 6)
 // =============================================================================
 
-proptest! {
-    /// Property: 1024 バイト以下のメッセージはそのまま保存
-    #[test]
-    fn prop_close_session_message_preserved(message in valid_error_message()) {
+/// Property: 1024 バイト以下のメッセージはそのまま保存
+#[test]
+fn prop_close_session_message_preserved() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_ERROR_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let message = valid_error_message(ctx);
         let error = Error::application(0, message.clone());
 
         if let Error::Application { message: msg, .. } = error {
-            prop_assert_eq!(msg, message);
+            assert_eq!(msg, message);
         } else {
-            prop_assert!(false, "Expected Application error");
+            panic!("Expected Application error");
         }
-    }
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: 1024 バイト超のメッセージは切り詰められる
-    #[test]
-    fn prop_close_session_message_truncated(message in long_message()) {
+/// Property: 1024 バイト超のメッセージは切り詰められる
+#[test]
+fn prop_close_session_message_truncated() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_ERROR_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let message = long_message(ctx);
         let error = Error::application(0, message.clone());
 
         if let Error::Application { message: msg, .. } = error {
-            prop_assert!(msg.len() <= 1024, "Message should be truncated to 1024 bytes");
-            prop_assert!(message.starts_with(&msg), "Truncated message should be a prefix");
+            assert!(
+                msg.len() <= 1024,
+                "Message should be truncated to 1024 bytes"
+            );
+            assert!(
+                message.starts_with(&msg),
+                "Truncated message should be a prefix"
+            );
         } else {
-            prop_assert!(false, "Expected Application error");
+            panic!("Expected Application error");
         }
-    }
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: UTF-8 マルチバイト文字の境界で正しく切り詰め
-    #[test]
-    fn prop_close_session_message_utf8_boundary(
-        prefix_len in 1020usize..1024,
-    ) {
+/// Property: UTF-8 マルチバイト文字の境界で正しく切り詰め
+#[test]
+fn prop_close_session_message_utf8_boundary() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_ERROR_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let prefix_len = noprop::sample_usize_in(ctx, 1020..1024);
         let prefix: String = (0..prefix_len).map(|_| 'a').collect();
         let message = format!("{}日本語テスト", prefix);
 
         let error = Error::application(0, message);
 
         if let Error::Application { message: msg, .. } = error {
-            prop_assert!(msg.len() <= 1024);
-            prop_assert!(msg.is_ascii() || msg.chars().count() > 0);
+            assert!(msg.len() <= 1024);
+            assert!(msg.is_ascii() || msg.chars().count() > 0);
         } else {
-            prop_assert!(false, "Expected Application error");
+            panic!("Expected Application error");
         }
-    }
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // 予約コードポイント衝突回避 (draft-ietf-webtrans-http3-15 Section 9.5)
 // =============================================================================
 
-proptest! {
-    /// Property: to_http3_code() の結果が予約コードポイント (x - 0x21) % 0x1f == 0 でない
-    #[test]
-    fn prop_application_error_code_no_reserved_collision(app_code in any::<u32>()) {
+/// Property: to_http3_code() の結果が予約コードポイント (x - 0x21) % 0x1f == 0 でない
+#[test]
+fn prop_application_error_code_no_reserved_collision() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_ERROR_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let app_code = noprop::sample_u32(ctx);
         let http3_code = ApplicationErrorCode::to_http3_code(app_code);
 
-        prop_assert!(
+        assert!(
             !(http3_code.wrapping_sub(0x21)).is_multiple_of(0x1f),
             "HTTP/3 code {} is a reserved codepoint",
             http3_code
         );
-    }
+        Ok(())
+    })?;
+    Ok(())
 }

--- a/pbt/tests/prop_webtransport/session.rs
+++ b/pbt/tests/prop_webtransport/session.rs
@@ -1,222 +1,245 @@
 //! Session の状態遷移・フロー制御・バッファリング・GOAWAY・終了処理プロパティ
 //! (draft-ietf-webtrans-http3-15 Section 3, 4.5, 4.6, 4.7, 5.6, 6)
 
-use proptest::prelude::*;
 use shiguredo_http3::webtransport::{
     Capsule, FlowControlLimits, MAX_STREAMS_LIMIT, Session, SessionState, Stream,
 };
 
-prop_compose! {
-    /// 有効なエラーコード (32-bit)
-    fn valid_error_code()(code in any::<u32>()) -> u32 {
-        code
-    }
+/// 有効なエラーコード (32-bit)
+fn valid_error_code(ctx: &mut noprop::TestCaseContext) -> u32 {
+    noprop::sample_u32(ctx)
 }
 
-prop_compose! {
-    /// 有効なエラーメッセージ (最大 1024 バイト)
-    fn valid_error_message()(
-        len in 0usize..=1024,
-    )(
-        msg in prop::collection::vec(0x20u8..0x7f, len)
-    ) -> String {
-        String::from_utf8(msg).expect("ASCII range bytes are always valid UTF-8")
+/// 有効なエラーメッセージ (最大 1024 バイト)
+fn valid_error_message(ctx: &mut noprop::TestCaseContext) -> String {
+    let len = noprop::sample_usize_in(ctx, 0..=1024);
+    let mut msg = Vec::new();
+    for _ in 0..len {
+        msg.push(0x20 + noprop::sample_usize_in(ctx, 0..=0x5f) as u8);
     }
+    String::from_utf8(msg).expect("ASCII range bytes are always valid UTF-8")
 }
 
 // =============================================================================
 // 状態遷移 (draft-ietf-webtrans-http3-15 Section 3, 6)
 // =============================================================================
 
-proptest! {
-    /// Property: 有効な状態遷移パス (Pending → Connecting → Established → Draining → Closed)
-    #[test]
-    fn prop_session_valid_transitions(_dummy in Just(())) {
-        let mut session = Session::new(0);
-        prop_assert_eq!(session.state(), SessionState::Pending);
+/// Property: 有効な状態遷移パス (Pending → Connecting → Established → Draining → Closed)
+#[test]
+fn prop_session_valid_transitions() {
+    let mut session = Session::new(0);
+    assert_eq!(session.state(), SessionState::Pending);
 
-        session.set_connecting();
-        prop_assert_eq!(session.state(), SessionState::Connecting);
+    session.set_connecting();
+    assert_eq!(session.state(), SessionState::Connecting);
 
-        session.set_established();
-        prop_assert_eq!(session.state(), SessionState::Established);
+    session.set_established();
+    assert_eq!(session.state(), SessionState::Established);
 
-        session.set_draining();
-        prop_assert_eq!(session.state(), SessionState::Draining);
+    session.set_draining();
+    assert_eq!(session.state(), SessionState::Draining);
 
-        session.close(None);
-        prop_assert_eq!(session.state(), SessionState::Closed);
-    }
+    session.close(None);
+    assert_eq!(session.state(), SessionState::Closed);
+}
 
-    /// Property: Pending → Established の直接遷移も有効
-    #[test]
-    fn prop_session_direct_establish(_dummy in Just(())) {
-        let mut session = Session::new(0);
-        prop_assert_eq!(session.state(), SessionState::Pending);
+/// Property: Pending → Established の直接遷移も有効
+#[test]
+fn prop_session_direct_establish() {
+    let mut session = Session::new(0);
+    assert_eq!(session.state(), SessionState::Pending);
 
-        session.set_established();
-        prop_assert_eq!(session.state(), SessionState::Established);
+    session.set_established();
+    assert_eq!(session.state(), SessionState::Established);
 
-        session.close(None);
-        prop_assert_eq!(session.state(), SessionState::Closed);
-    }
+    session.close(None);
+    assert_eq!(session.state(), SessionState::Closed);
+}
 
-    /// Property: 各状態でのストリーム作成可否
-    #[test]
-    fn prop_session_state_can_create_stream(_dummy in Just(())) {
-        prop_assert!(!SessionState::Pending.can_create_stream());
-        prop_assert!(!SessionState::Connecting.can_create_stream());
-        prop_assert!(SessionState::Established.can_create_stream());
-        prop_assert!(SessionState::Draining.can_create_stream());
-        prop_assert!(!SessionState::Closed.can_create_stream());
-    }
+/// Property: 各状態でのストリーム作成可否
+#[test]
+fn prop_session_state_can_create_stream() {
+    assert!(!SessionState::Pending.can_create_stream());
+    assert!(!SessionState::Connecting.can_create_stream());
+    assert!(SessionState::Established.can_create_stream());
+    assert!(SessionState::Draining.can_create_stream());
+    assert!(!SessionState::Closed.can_create_stream());
+}
 
-    /// Property: 各状態での送信可否
-    #[test]
-    fn prop_session_state_can_send(_dummy in Just(())) {
-        prop_assert!(!SessionState::Pending.can_send());
-        prop_assert!(!SessionState::Connecting.can_send());
-        prop_assert!(SessionState::Established.can_send());
-        prop_assert!(SessionState::Draining.can_send());
-        prop_assert!(!SessionState::Closed.can_send());
-    }
+/// Property: 各状態での送信可否
+#[test]
+fn prop_session_state_can_send() {
+    assert!(!SessionState::Pending.can_send());
+    assert!(!SessionState::Connecting.can_send());
+    assert!(SessionState::Established.can_send());
+    assert!(SessionState::Draining.can_send());
+    assert!(!SessionState::Closed.can_send());
 }
 
 // =============================================================================
 // フロー制御の単調増加制約 (draft-ietf-webtrans-http3-16 Section 5.6.2, 5.6.4)
 // =============================================================================
 
-proptest! {
-    /// Property: MaxData が減少した場合にエラー
-    #[test]
-    fn prop_session_max_data_non_monotonic_error(
-        initial in 100u64..10000,
-        decrease in 1u64..100,
-    ) {
+/// Property: MaxData が減少した場合にエラー
+#[test]
+fn prop_session_max_data_non_monotonic_error() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_SESSION_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let initial = noprop::sample_u64_in(ctx, 100..10000);
+        let decrease = noprop::sample_u64_in(ctx, 1..100);
         let mut session = Session::new(0);
 
         let result = session.process_capsule(&Capsule::MaxData { maximum: initial });
-        prop_assert!(result.is_ok());
-        prop_assert_eq!(session.remote_limits().max_data, initial);
+        assert!(result.is_ok());
+        assert_eq!(session.remote_limits().max_data, initial);
 
         let smaller = initial.saturating_sub(decrease);
         let result = session.process_capsule(&Capsule::MaxData { maximum: smaller });
-        prop_assert!(result.is_err());
+        assert!(result.is_err());
 
-        prop_assert_eq!(session.remote_limits().max_data, initial);
-    }
+        assert_eq!(session.remote_limits().max_data, initial);
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: MaxData が厳密に増加すれば成功
-    ///
-    /// draft-16 Section 5.6.4: "does not increase" は WT_FLOW_CONTROL_ERROR。
-    /// セッション初期値は 0 のため、最初の値も 1 以上が必要。
-    #[test]
-    fn prop_session_max_data_monotonic_ok(
-        initial in 1u64..10000,
-        increase in 1u64..10000,
-    ) {
+/// Property: MaxData が厳密に増加すれば成功
+///
+/// draft-16 Section 5.6.4: "does not increase" は WT_FLOW_CONTROL_ERROR。
+/// セッション初期値は 0 のため、最初の値も 1 以上が必要。
+#[test]
+fn prop_session_max_data_monotonic_ok() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_SESSION_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let initial = noprop::sample_u64_in(ctx, 1..10000);
+        let increase = noprop::sample_u64_in(ctx, 1..10000);
         let mut session = Session::new(0);
 
         let result = session.process_capsule(&Capsule::MaxData { maximum: initial });
-        prop_assert!(result.is_ok());
+        assert!(result.is_ok());
 
         let larger = initial.saturating_add(increase);
         let result = session.process_capsule(&Capsule::MaxData { maximum: larger });
-        prop_assert!(result.is_ok());
-        prop_assert_eq!(session.remote_limits().max_data, larger);
-    }
+        assert!(result.is_ok());
+        assert_eq!(session.remote_limits().max_data, larger);
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: MaxStreams (双方向) が減少した場合にエラー
-    #[test]
-    fn prop_session_max_streams_bidi_non_monotonic_error(
-        initial in 100u64..10000,
-        decrease in 1u64..100,
-    ) {
+/// Property: MaxStreams (双方向) が減少した場合にエラー
+#[test]
+fn prop_session_max_streams_bidi_non_monotonic_error() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_SESSION_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let initial = noprop::sample_u64_in(ctx, 100..10000);
+        let decrease = noprop::sample_u64_in(ctx, 1..100);
         let mut session = Session::new(0);
 
         let result = session.process_capsule(&Capsule::MaxStreams {
             bidirectional: true,
             maximum: initial,
         });
-        prop_assert!(result.is_ok());
+        assert!(result.is_ok());
 
         let smaller = initial.saturating_sub(decrease);
         let result = session.process_capsule(&Capsule::MaxStreams {
             bidirectional: true,
             maximum: smaller,
         });
-        prop_assert!(result.is_err());
-    }
+        assert!(result.is_err());
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: MaxStreams (単方向) が減少した場合にエラー
-    #[test]
-    fn prop_session_max_streams_uni_non_monotonic_error(
-        initial in 100u64..10000,
-        decrease in 1u64..100,
-    ) {
+/// Property: MaxStreams (単方向) が減少した場合にエラー
+#[test]
+fn prop_session_max_streams_uni_non_monotonic_error() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_SESSION_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let initial = noprop::sample_u64_in(ctx, 100..10000);
+        let decrease = noprop::sample_u64_in(ctx, 1..100);
         let mut session = Session::new(0);
 
         let result = session.process_capsule(&Capsule::MaxStreams {
             bidirectional: false,
             maximum: initial,
         });
-        prop_assert!(result.is_ok());
+        assert!(result.is_ok());
 
         let smaller = initial.saturating_sub(decrease);
         let result = session.process_capsule(&Capsule::MaxStreams {
             bidirectional: false,
             maximum: smaller,
         });
-        prop_assert!(result.is_err());
-    }
+        assert!(result.is_err());
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // フロー制御リミット境界テスト
 // =============================================================================
 
-proptest! {
-    /// Property: ストリーム作成可否の境界テスト (単方向)
-    #[test]
-    fn prop_session_can_create_stream_boundary_uni(
-        limit in 1u64..100,
-    ) {
+/// Property: ストリーム作成可否の境界テスト (単方向)
+#[test]
+fn prop_session_can_create_stream_boundary_uni() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_SESSION_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let limit = noprop::sample_u64_in(ctx, 1..100);
         let mut session = Session::new(0);
         session.set_established();
         session.remote_limits_mut().max_streams_uni = limit;
 
         session.flow_state_mut().streams_uni_opened = limit - 1;
-        prop_assert!(session.can_create_unidirectional_stream());
+        assert!(session.can_create_unidirectional_stream());
 
         session.flow_state_mut().streams_uni_opened = limit;
-        prop_assert!(!session.can_create_unidirectional_stream());
+        assert!(!session.can_create_unidirectional_stream());
 
         session.flow_state_mut().streams_uni_opened = limit + 1;
-        prop_assert!(!session.can_create_unidirectional_stream());
-    }
+        assert!(!session.can_create_unidirectional_stream());
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: ストリーム作成可否の境界テスト (双方向)
-    #[test]
-    fn prop_session_can_create_stream_boundary_bidi(
-        limit in 1u64..100,
-    ) {
+/// Property: ストリーム作成可否の境界テスト (双方向)
+#[test]
+fn prop_session_can_create_stream_boundary_bidi() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_SESSION_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let limit = noprop::sample_u64_in(ctx, 1..100);
         let mut session = Session::new(0);
         session.set_established();
         session.remote_limits_mut().max_streams_bidi = limit;
 
         session.flow_state_mut().streams_bidi_opened = limit - 1;
-        prop_assert!(session.can_create_bidirectional_stream());
+        assert!(session.can_create_bidirectional_stream());
 
         session.flow_state_mut().streams_bidi_opened = limit;
-        prop_assert!(!session.can_create_bidirectional_stream());
-    }
+        assert!(!session.can_create_bidirectional_stream());
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: データ送信可否の境界テスト
-    #[test]
-    fn prop_session_can_send_data_boundary(
-        limit in 100u64..10000,
-        sent in 0u64..100,
-    ) {
+/// Property: データ送信可否の境界テスト
+#[test]
+fn prop_session_can_send_data_boundary() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_SESSION_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let limit = noprop::sample_u64_in(ctx, 100..10000);
+        let sent = noprop::sample_u64_in(ctx, 0..100);
         let mut session = Session::new(0);
         session.set_established();
         session.remote_limits_mut().max_data = limit;
@@ -224,108 +247,131 @@ proptest! {
 
         let remaining = limit - sent;
 
-        prop_assert!(session.can_send_data(remaining));
-        prop_assert!(!session.can_send_data(remaining + 1));
-    }
+        assert!(session.can_send_data(remaining));
+        assert!(!session.can_send_data(remaining + 1));
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: Established/Draining 以外ではストリーム作成不可
-    #[test]
-    fn prop_session_cannot_create_stream_in_wrong_state(
-        limit in 1u64..100,
-    ) {
+/// Property: Established/Draining 以外ではストリーム作成不可
+#[test]
+fn prop_session_cannot_create_stream_in_wrong_state() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_SESSION_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let limit = noprop::sample_u64_in(ctx, 1..100);
         let mut session = Session::new(0);
         session.remote_limits_mut().max_streams_uni = limit;
         session.remote_limits_mut().max_streams_bidi = limit;
 
         // Pending 状態
-        prop_assert!(!session.can_create_unidirectional_stream());
-        prop_assert!(!session.can_create_bidirectional_stream());
+        assert!(!session.can_create_unidirectional_stream());
+        assert!(!session.can_create_bidirectional_stream());
 
         // Connecting 状態
         session.set_connecting();
-        prop_assert!(!session.can_create_unidirectional_stream());
-        prop_assert!(!session.can_create_bidirectional_stream());
+        assert!(!session.can_create_unidirectional_stream());
+        assert!(!session.can_create_bidirectional_stream());
 
         // Closed 状態
         session.close(None);
-        prop_assert!(!session.can_create_unidirectional_stream());
-        prop_assert!(!session.can_create_bidirectional_stream());
-    }
+        assert!(!session.can_create_unidirectional_stream());
+        assert!(!session.can_create_bidirectional_stream());
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: Established/Draining 以外ではデータ送信不可
-    #[test]
-    fn prop_session_cannot_send_in_wrong_state(
-        limit in 100u64..10000,
-    ) {
+/// Property: Established/Draining 以外ではデータ送信不可
+#[test]
+fn prop_session_cannot_send_in_wrong_state() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_SESSION_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let limit = noprop::sample_u64_in(ctx, 100..10000);
         let mut session = Session::new(0);
         session.remote_limits_mut().max_data = limit;
 
         // Pending 状態
-        prop_assert!(!session.can_send_data(1));
+        assert!(!session.can_send_data(1));
 
         // Connecting 状態
         session.set_connecting();
-        prop_assert!(!session.can_send_data(1));
+        assert!(!session.can_send_data(1));
 
         // Closed 状態
         session.close(None);
-        prop_assert!(!session.can_send_data(1));
-    }
+        assert!(!session.can_send_data(1));
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // バッファリング (draft-ietf-webtrans-http3-15 Section 4.6)
 // =============================================================================
 
-proptest! {
-    /// Property: MAX_BUFFERED_STREAMS (100) までバッファリング成功
-    #[test]
-    fn prop_session_buffer_streams_up_to_limit(
-        count in 1usize..=100,
-    ) {
+/// Property: MAX_BUFFERED_STREAMS (100) までバッファリング成功
+#[test]
+fn prop_session_buffer_streams_up_to_limit() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_SESSION_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let count = noprop::sample_usize_in(ctx, 1..=100);
         let mut session = Session::new(0);
 
         for i in 0..count {
-            prop_assert!(session.buffer_incoming_stream(i as u64 * 4, false));
+            assert!(session.buffer_incoming_stream(i as u64 * 4, false));
         }
 
         let buffered = session.take_buffered_streams();
-        prop_assert_eq!(buffered.len(), count);
+        assert_eq!(buffered.len(), count);
+        Ok(())
+    })?;
+    Ok(())
+}
+
+/// Property: 101 個目のバッファリングは失敗
+#[test]
+fn prop_session_buffer_streams_over_limit() {
+    let mut session = Session::new(0);
+
+    for i in 0..100 {
+        assert!(session.buffer_incoming_stream(i as u64 * 4, false));
     }
 
-    /// Property: 101 個目のバッファリングは失敗
-    #[test]
-    fn prop_session_buffer_streams_over_limit(_dummy in proptest::strategy::Just(())) {
-        let mut session = Session::new(0);
+    assert!(!session.buffer_incoming_stream(99999, false));
+}
 
-        for i in 0..100 {
-            prop_assert!(session.buffer_incoming_stream(i as u64 * 4, false));
-        }
-
-        prop_assert!(!session.buffer_incoming_stream(99999, false));
-    }
-
-    /// Property: MAX_BUFFERED_DATAGRAMS (100) までバッファリング成功
-    #[test]
-    fn prop_session_buffer_datagrams_up_to_limit(
-        count in 1usize..=100,
-    ) {
+/// Property: MAX_BUFFERED_DATAGRAMS (100) までバッファリング成功
+#[test]
+fn prop_session_buffer_datagrams_up_to_limit() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_SESSION_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let count = noprop::sample_usize_in(ctx, 1..=100);
         let mut session = Session::new(0);
 
         for i in 0..count {
-            prop_assert!(session.buffer_datagram(vec![i as u8]));
+            assert!(session.buffer_datagram(vec![i as u8]));
         }
 
         let buffered = session.take_buffered_datagrams();
-        prop_assert_eq!(buffered.len(), count);
-    }
+        assert_eq!(buffered.len(), count);
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: take 後のバッファは空になる
-    #[test]
-    fn prop_session_take_buffered_empties_buffer(
-        stream_count in 1usize..=10,
-        datagram_count in 1usize..=10,
-    ) {
+/// Property: take 後のバッファは空になる
+#[test]
+fn prop_session_take_buffered_empties_buffer() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_SESSION_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let stream_count = noprop::sample_usize_in(ctx, 1..=10);
+        let datagram_count = noprop::sample_usize_in(ctx, 1..=10);
         let mut session = Session::new(0);
 
         for i in 0..stream_count {
@@ -338,36 +384,39 @@ proptest! {
         let _streams = session.take_buffered_streams();
         let _datagrams = session.take_buffered_datagrams();
 
-        prop_assert!(session.take_buffered_streams().is_empty());
-        prop_assert!(session.take_buffered_datagrams().is_empty());
-    }
+        assert!(session.take_buffered_streams().is_empty());
+        assert!(session.take_buffered_datagrams().is_empty());
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // GOAWAY (draft-ietf-webtrans-http3-15 Section 4.7)
 // =============================================================================
 
-proptest! {
-    /// Property: handle_goaway 後は goaway_received が true でドレイン状態
-    #[test]
-    fn prop_session_goaway_sets_draining(_dummy in proptest::strategy::Just(())) {
-        let mut session = Session::new(0);
-        session.set_established();
+/// Property: handle_goaway 後は goaway_received が true でドレイン状態
+#[test]
+fn prop_session_goaway_sets_draining() {
+    let mut session = Session::new(0);
+    session.set_established();
 
-        prop_assert!(!session.is_goaway_received());
-        prop_assert_eq!(session.state(), SessionState::Established);
+    assert!(!session.is_goaway_received());
+    assert_eq!(session.state(), SessionState::Established);
 
-        session.handle_goaway();
+    session.handle_goaway();
 
-        prop_assert!(session.is_goaway_received());
-        prop_assert_eq!(session.state(), SessionState::Draining);
-    }
+    assert!(session.is_goaway_received());
+    assert_eq!(session.state(), SessionState::Draining);
+}
 
-    /// Property: handle_goaway 後も既存ストリームは保持され can_send() == true
-    #[test]
-    fn prop_session_handle_goaway_preserves_streams(
-        stream_count in 1usize..10,
-    ) {
+/// Property: handle_goaway 後も既存ストリームは保持され can_send() == true
+#[test]
+fn prop_session_handle_goaway_preserves_streams() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_SESSION_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let stream_count = noprop::sample_usize_in(ctx, 1..10);
         let mut session = Session::new(0);
         session.set_established();
         session.remote_limits_mut().max_data = 100000;
@@ -378,25 +427,28 @@ proptest! {
 
         session.handle_goaway();
 
-        prop_assert_eq!(session.stream_count(), stream_count);
+        assert_eq!(session.stream_count(), stream_count);
         for i in 0..stream_count {
-            prop_assert!(session.get_stream(i as u64 * 4).is_some());
+            assert!(session.get_stream(i as u64 * 4).is_some());
         }
-        prop_assert!(session.state().can_send());
-    }
+        assert!(session.state().can_send());
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // セッション終了処理 (draft-ietf-webtrans-http3-15 Section 6)
 // =============================================================================
 
-proptest! {
-    /// Property: 任意の初期状態 (Established/Draining) で on_connect_stream_closed() →
-    /// is_close_session_received() == true かつ is_closed() == true
-    #[test]
-    fn prop_session_on_connect_stream_closed_sets_flags(
-        start_draining in any::<bool>(),
-    ) {
+/// Property: 任意の初期状態 (Established/Draining) で on_connect_stream_closed() →
+/// is_close_session_received() == true かつ is_closed() == true
+#[test]
+fn prop_session_on_connect_stream_closed_sets_flags() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_SESSION_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let start_draining = noprop::sample_bool(ctx);
         let mut session = Session::new(0);
         session.set_established();
 
@@ -406,40 +458,57 @@ proptest! {
 
         session.on_connect_stream_closed();
 
-        prop_assert!(session.is_close_session_received());
-        prop_assert!(session.is_closed());
-    }
+        assert!(session.is_close_session_received());
+        assert!(session.is_closed());
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: CloseSession Capsule 受信後に on_connect_stream_closed() →
-    /// 最初のエラー情報が保持される
-    #[test]
-    fn prop_session_on_connect_stream_closed_preserves_first_error(
-        error_code in valid_error_code(),
-        message in valid_error_message(),
-    ) {
+/// Property: CloseSession Capsule 受信後に on_connect_stream_closed() →
+/// 最初のエラー情報が保持される
+#[test]
+fn prop_session_on_connect_stream_closed_preserves_first_error() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_SESSION_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let error_code = valid_error_code(ctx);
+        let message = valid_error_message(ctx);
         let mut session = Session::new(0);
         session.set_established();
 
-        session.process_capsule(&Capsule::CloseSession {
-            error_code,
-            message: message.clone(),
-        }).expect("CloseSession capsule should be accepted");
+        session
+            .process_capsule(&Capsule::CloseSession {
+                error_code,
+                message: message.clone(),
+            })
+            .expect("CloseSession capsule should be accepted");
 
         let first_error = session.close_error().cloned();
 
         session.on_connect_stream_closed();
 
-        prop_assert_eq!(session.close_error(), first_error.as_ref());
-        prop_assert!(session.is_close_session_received());
-    }
+        assert_eq!(session.close_error(), first_error.as_ref());
+        assert!(session.is_close_session_received());
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: 任意のストリーム追加/削除後、stream_ids_to_reset() が
-    /// 残存ストリーム ID と一致
-    #[test]
-    fn prop_session_stream_ids_to_reset_matches_streams(
-        add_count in 1usize..20,
-        remove_indices in prop::collection::vec(0usize..20, 0..10),
-    ) {
+/// Property: 任意のストリーム追加/削除後、stream_ids_to_reset() が
+/// 残存ストリーム ID と一致
+#[test]
+fn prop_session_stream_ids_to_reset_matches_streams() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_SESSION_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let add_count = noprop::sample_usize_in(ctx, 1..20);
+        let remove_count = noprop::sample_usize_in(ctx, 0..10);
+        let mut remove_indices = Vec::new();
+        for _ in 0..remove_count {
+            remove_indices.push(noprop::sample_usize_in(ctx, 0..20));
+        }
+
         let mut session = Session::new(0);
         session.set_established();
 
@@ -461,25 +530,41 @@ proptest! {
         expected.sort();
 
         let reset_count = reset_ids.len();
-        prop_assert_eq!(reset_ids, expected);
-        prop_assert_eq!(reset_count, session.stream_count());
-    }
+        assert_eq!(reset_ids, expected);
+        assert_eq!(reset_count, session.stream_count());
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // カプセルインターリーブ処理 (draft-ietf-webtrans-http3-15 Section 5.6, 6)
 // =============================================================================
 
-proptest! {
-    /// Property: MaxData/MaxStreams/DataBlocked/StreamsBlocked をランダム順で処理しても
-    /// 最終リミットが整合的
-    /// (draft-16: 単調増加制約のため値は 1 以上から生成)
-    #[test]
-    fn prop_session_interleaved_capsule_processing(
-        max_data_values in prop::collection::vec(1u64..10000, 1..5),
-        max_streams_bidi_values in prop::collection::vec(1u64..1000, 1..5),
-        max_streams_uni_values in prop::collection::vec(1u64..1000, 1..5),
-    ) {
+/// Property: MaxData/MaxStreams/DataBlocked/StreamsBlocked をランダム順で処理しても
+/// 最終リミットが整合的
+/// (draft-16: 単調増加制約のため値は 1 以上から生成)
+#[test]
+fn prop_session_interleaved_capsule_processing() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_SESSION_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let data_count = noprop::sample_usize_in(ctx, 1..5);
+        let mut max_data_values = Vec::new();
+        for _ in 0..data_count {
+            max_data_values.push(noprop::sample_u64_in(ctx, 1..10000));
+        }
+        let bidi_count = noprop::sample_usize_in(ctx, 1..5);
+        let mut max_streams_bidi_values = Vec::new();
+        for _ in 0..bidi_count {
+            max_streams_bidi_values.push(noprop::sample_u64_in(ctx, 1..1000));
+        }
+        let uni_count = noprop::sample_usize_in(ctx, 1..5);
+        let mut max_streams_uni_values = Vec::new();
+        for _ in 0..uni_count {
+            max_streams_uni_values.push(noprop::sample_u64_in(ctx, 1..1000));
+        }
+
         let mut session = Session::new(0);
 
         let mut sorted_data = max_data_values.clone();
@@ -494,21 +579,21 @@ proptest! {
 
         for &v in &sorted_data {
             let result = session.process_capsule(&Capsule::MaxData { maximum: v });
-            prop_assert!(result.is_ok());
+            assert!(result.is_ok());
         }
         for &v in &sorted_bidi {
             let result = session.process_capsule(&Capsule::MaxStreams {
                 bidirectional: true,
                 maximum: v,
             });
-            prop_assert!(result.is_ok());
+            assert!(result.is_ok());
         }
         for &v in &sorted_uni {
             let result = session.process_capsule(&Capsule::MaxStreams {
                 bidirectional: false,
                 maximum: v,
             });
-            prop_assert!(result.is_ok());
+            assert!(result.is_ok());
         }
 
         let _ = session.process_capsule(&Capsule::DataBlocked { maximum: 999 });
@@ -518,48 +603,69 @@ proptest! {
         });
 
         if let Some(&max) = sorted_data.last() {
-            prop_assert_eq!(session.remote_limits().max_data, max);
+            assert_eq!(session.remote_limits().max_data, max);
         }
         if let Some(&max) = sorted_bidi.last() {
-            prop_assert_eq!(session.remote_limits().max_streams_bidi, max);
+            assert_eq!(session.remote_limits().max_streams_bidi, max);
         }
         if let Some(&max) = sorted_uni.last() {
-            prop_assert_eq!(session.remote_limits().max_streams_uni, max);
+            assert_eq!(session.remote_limits().max_streams_uni, max);
         }
-    }
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: 単調増加列の後に減少値を送ると FlowControlError
-    #[test]
-    fn prop_session_flow_control_violation_after_increase(
-        first in 100u64..10000,
-        increase in 1u64..10000,
-        decrease in 1u64..100,
-    ) {
+/// Property: 単調増加列の後に減少値を送ると FlowControlError
+#[test]
+fn prop_session_flow_control_violation_after_increase() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_SESSION_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let first = noprop::sample_u64_in(ctx, 100..10000);
+        let increase = noprop::sample_u64_in(ctx, 1..10000);
+        let decrease = noprop::sample_u64_in(ctx, 1..100);
         let mut session = Session::new(0);
         let second = first.saturating_add(increase);
 
-        session.process_capsule(&Capsule::MaxData { maximum: first }).expect("monotonic increase");
-        session.process_capsule(&Capsule::MaxData { maximum: second }).expect("monotonic increase");
+        session
+            .process_capsule(&Capsule::MaxData { maximum: first })
+            .expect("monotonic increase");
+        session
+            .process_capsule(&Capsule::MaxData { maximum: second })
+            .expect("monotonic increase");
 
         let smaller = second.saturating_sub(decrease);
         if smaller < second {
             let result = session.process_capsule(&Capsule::MaxData { maximum: smaller });
-            prop_assert!(result.is_err());
+            assert!(result.is_err());
         }
-    }
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // ストリーム追加/削除の整合性
 // =============================================================================
 
-proptest! {
-    /// Property: 追加/削除を交互に実行後、stream_count() と get_stream() が整合的
-    #[test]
-    fn prop_session_add_remove_stream_consistency(
-        add_ids in prop::collection::vec(0u64..100, 1..20),
-        remove_ids in prop::collection::vec(0u64..100, 0..10),
-    ) {
+/// Property: 追加/削除を交互に実行後、stream_count() と get_stream() が整合的
+#[test]
+fn prop_session_add_remove_stream_consistency() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_SESSION_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let add_count = noprop::sample_usize_in(ctx, 1..20);
+        let mut add_ids = Vec::new();
+        for _ in 0..add_count {
+            add_ids.push(noprop::sample_u64_in(ctx, 0..100));
+        }
+        let remove_count = noprop::sample_usize_in(ctx, 0..10);
+        let mut remove_ids = Vec::new();
+        for _ in 0..remove_count {
+            remove_ids.push(noprop::sample_u64_in(ctx, 0..100));
+        }
+
         let mut session = Session::new(0);
 
         let mut added_set = std::collections::HashSet::new();
@@ -576,37 +682,46 @@ proptest! {
             added_set.remove(&sid);
         }
 
-        prop_assert_eq!(session.stream_count(), added_set.len());
+        assert_eq!(session.stream_count(), added_set.len());
 
         for &sid in &added_set {
-            prop_assert!(session.get_stream(sid).is_some(),
-                "Stream {} should exist", sid);
+            assert!(
+                session.get_stream(sid).is_some(),
+                "Stream {} should exist",
+                sid
+            );
         }
 
         for &raw_id in &remove_ids {
             let sid = raw_id * 4;
             if !added_set.contains(&sid) {
-                prop_assert!(session.get_stream(sid).is_none(),
-                    "Stream {} should not exist", sid);
+                assert!(
+                    session.get_stream(sid).is_none(),
+                    "Stream {} should not exist",
+                    sid
+                );
             }
         }
-    }
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // 動的ウィンドウ更新
 // =============================================================================
 
-proptest! {
-    /// advertised_max は単調増加する (ストリーム)
-    ///
-    /// 任意の open/close シーケンスに対して、生成される WT_MAX_STREAMS の
-    /// maximum は常に前回以上の値である。
-    #[test]
-    fn prop_advertised_max_monotonically_increases(
-        concurrent_limit in 1u64..200,
-        num_streams in 1usize..500,
-    ) {
+/// Property: advertised_max は単調増加する (ストリーム)
+///
+/// 任意の open/close シーケンスに対して、生成される WT_MAX_STREAMS の
+/// maximum は常に前回以上の値である。
+#[test]
+fn prop_advertised_max_monotonically_increases() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_SESSION_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let concurrent_limit = noprop::sample_u64_in(ctx, 1..200);
+        let num_streams = noprop::sample_usize_in(ctx, 1..500);
         let mut session = Session::new(0);
         session.set_established();
         session.initialize_local_limits(FlowControlLimits {
@@ -624,23 +739,34 @@ proptest! {
             session.on_remote_stream_closed(false);
 
             for capsule in session.take_pending_capsules() {
-                if let Capsule::MaxStreams { bidirectional: false, maximum } = capsule {
-                    prop_assert!(
+                if let Capsule::MaxStreams {
+                    bidirectional: false,
+                    maximum,
+                } = capsule
+                {
+                    assert!(
                         maximum >= last_max,
-                        "advertised_max decreased: {} -> {}", last_max, maximum
+                        "advertised_max decreased: {} -> {}",
+                        last_max,
+                        maximum
                     );
                     last_max = maximum;
                 }
             }
         }
-    }
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// advertised_max は MAX_STREAMS_LIMIT を超えない (ストリーム)
-    #[test]
-    fn prop_advertised_max_within_limit(
-        concurrent_limit in 1u64..=MAX_STREAMS_LIMIT,
-        num_cycles in 1usize..100,
-    ) {
+/// Property: advertised_max は MAX_STREAMS_LIMIT を超えない (ストリーム)
+#[test]
+fn prop_advertised_max_within_limit() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_SESSION_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let concurrent_limit = noprop::sample_u64_in(ctx, 1..=MAX_STREAMS_LIMIT);
+        let num_cycles = noprop::sample_usize_in(ctx, 1..100);
         let mut session = Session::new(0);
         session.set_established();
         session.initialize_local_limits(FlowControlLimits {
@@ -654,53 +780,73 @@ proptest! {
 
             for capsule in session.take_pending_capsules() {
                 if let Capsule::MaxStreams { maximum, .. } = capsule {
-                    prop_assert!(
+                    assert!(
                         maximum <= MAX_STREAMS_LIMIT,
-                        "advertised_max exceeds limit: {}", maximum
+                        "advertised_max exceeds limit: {}",
+                        maximum
                     );
                 }
             }
         }
-    }
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// WT_STREAMS_BLOCKED は同じ maximum に対して 1 回だけ送信される
-    #[test]
-    fn prop_streams_blocked_dedup(
-        limit in 0u64..50,
-        attempts in 2usize..20,
-    ) {
+/// Property: WT_STREAMS_BLOCKED は同じ maximum に対して 1 回だけ送信される
+#[test]
+fn prop_streams_blocked_dedup() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_SESSION_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let limit = noprop::sample_u64_in(ctx, 0..50);
+        let attempts = noprop::sample_usize_in(ctx, 2..20);
         let mut session = Session::new(0);
         session.set_established();
         session.remote_limits_mut().max_streams_uni = limit;
 
         for _ in 0..limit {
-            prop_assert!(session.try_open_stream(false));
+            assert!(session.try_open_stream(false));
         }
 
         for _ in 0..attempts {
-            prop_assert!(!session.try_open_stream(false));
+            assert!(!session.try_open_stream(false));
         }
 
         let capsules = session.take_pending_capsules();
         let blocked_count = capsules
             .iter()
-            .filter(|c| matches!(c, Capsule::StreamsBlocked { bidirectional: false, .. }))
+            .filter(|c| {
+                matches!(
+                    c,
+                    Capsule::StreamsBlocked {
+                        bidirectional: false,
+                        ..
+                    }
+                )
+            })
             .count();
-        prop_assert_eq!(
+        assert_eq!(
             blocked_count, 1,
-            "STREAMS_BLOCKED should be sent exactly once per maximum, got {}", blocked_count
+            "STREAMS_BLOCKED should be sent exactly once per maximum, got {}",
+            blocked_count
         );
-    }
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// セッション A → セッション B の動的ウィンドウ更新往復プロパティ
-    ///
-    /// セッション A で on_remote_stream_closed により生成された WT_MAX_STREAMS カプセルを
-    /// セッション B の process_capsule に渡すと remote_limits が正しく更新される。
-    #[test]
-    fn prop_dynamic_max_streams_roundtrip(
-        concurrent_limit in 1u64..200,
-        num_streams in 1usize..200,
-    ) {
+/// Property: セッション A → セッション B の動的ウィンドウ更新往復プロパティ
+///
+/// セッション A で on_remote_stream_closed により生成された WT_MAX_STREAMS カプセルを
+/// セッション B の process_capsule に渡すと remote_limits が正しく更新される。
+#[test]
+fn prop_dynamic_max_streams_roundtrip() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_SESSION_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let concurrent_limit = noprop::sample_u64_in(ctx, 1..200);
+        let num_streams = noprop::sample_usize_in(ctx, 1..200);
         let mut session_a = Session::new(0);
         session_a.set_established();
         session_a.initialize_local_limits(FlowControlLimits {
@@ -722,26 +868,31 @@ proptest! {
             for capsule in session_a.take_pending_capsules() {
                 if capsule.capsule_type() == 0x190B4D40 {
                     let result = session_b.process_capsule(&capsule);
-                    prop_assert!(result.is_ok(), "process_capsule failed: {:?}", result);
+                    assert!(result.is_ok(), "process_capsule failed: {:?}", result);
                 }
             }
         }
 
-        prop_assert!(
+        assert!(
             session_b.remote_limits().max_streams_uni >= concurrent_limit,
             "remote_limits should be >= initial: {} < {}",
             session_b.remote_limits().max_streams_uni,
             concurrent_limit
         );
-    }
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// advertised_max は単調増加する (データ)
-    #[test]
-    fn prop_data_advertised_max_monotonically_increases(
-        initial_window in 1u64..10000,
-        num_chunks in 1usize..100,
-        chunk_size in 1u64..200,
-    ) {
+/// Property: advertised_max は単調増加する (データ)
+#[test]
+fn prop_data_advertised_max_monotonically_increases() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_SESSION_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let initial_window = noprop::sample_u64_in(ctx, 1..10000);
+        let num_chunks = noprop::sample_usize_in(ctx, 1..100);
+        let chunk_size = noprop::sample_u64_in(ctx, 1..200);
         let mut session = Session::new(0);
         session.set_established();
         session.initialize_local_limits(FlowControlLimits {
@@ -759,33 +910,40 @@ proptest! {
 
                 for capsule in session.take_pending_capsules() {
                     if let Capsule::MaxData { maximum } = capsule {
-                        prop_assert!(
+                        assert!(
                             maximum >= last_max,
-                            "data advertised_max decreased: {} -> {}", last_max, maximum
+                            "data advertised_max decreased: {} -> {}",
+                            last_max,
+                            maximum
                         );
                         last_max = maximum;
                     }
                 }
             }
         }
-    }
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// WT_DATA_BLOCKED は同じ maximum に対して 1 回だけ送信される
-    #[test]
-    fn prop_data_blocked_dedup(
-        limit in 0u64..100,
-        attempts in 2usize..20,
-    ) {
+/// Property: WT_DATA_BLOCKED は同じ maximum に対して 1 回だけ送信される
+#[test]
+fn prop_data_blocked_dedup() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_SESSION_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let limit = noprop::sample_u64_in(ctx, 0..100);
+        let attempts = noprop::sample_usize_in(ctx, 2..20);
         let mut session = Session::new(0);
         session.set_established();
         session.remote_limits_mut().max_data = limit;
 
         if limit > 0 {
-            prop_assert!(session.try_send_data(limit));
+            assert!(session.try_send_data(limit));
         }
 
         for _ in 0..attempts {
-            prop_assert!(!session.try_send_data(1));
+            assert!(!session.try_send_data(1));
         }
 
         let capsules = session.take_pending_capsules();
@@ -793,9 +951,12 @@ proptest! {
             .iter()
             .filter(|c| matches!(c, Capsule::DataBlocked { .. }))
             .count();
-        prop_assert_eq!(
+        assert_eq!(
             blocked_count, 1,
-            "DATA_BLOCKED should be sent exactly once per maximum, got {}", blocked_count
+            "DATA_BLOCKED should be sent exactly once per maximum, got {}",
+            blocked_count
         );
-    }
+        Ok(())
+    })?;
+    Ok(())
 }

--- a/pbt/tests/prop_webtransport/settings.rs
+++ b/pbt/tests/prop_webtransport/settings.rs
@@ -1,7 +1,6 @@
 //! WebTransport Settings のプロパティ
 //! (draft-ietf-webtrans-http3-15 Section 5.1, 9.2)
 
-use proptest::prelude::*;
 use shiguredo_http3::webtransport::Settings;
 use shiguredo_http3::{Setting, VarInt};
 
@@ -9,60 +8,72 @@ use shiguredo_http3::{Setting, VarInt};
 // フロー制御有効化判定 (draft-ietf-webtrans-http3-15 Section 5.1)
 // =============================================================================
 
-proptest! {
-    /// Property: wt_enabled のみではフロー制御無効 (draft-15)
-    #[test]
-    fn prop_settings_flow_control_wt_enabled_only(wt_enabled in 1u64..100) {
-        let settings = Settings::new().wt_enabled(VarInt::new(wt_enabled).expect("value in VarInt range"));
-        prop_assert!(!settings.declares_flow_control());
-    }
+/// Property: wt_enabled のみではフロー制御無効 (draft-15)
+#[test]
+fn prop_settings_flow_control_wt_enabled_only() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_SETTINGS_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let wt_enabled = noprop::sample_u64_in(ctx, 1..100);
+        let settings =
+            Settings::new().wt_enabled(VarInt::new(wt_enabled).expect("value in VarInt range"));
+        assert!(!settings.declares_flow_control());
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: INITIAL_MAX_* が 0 以外ならフロー制御有効 (draft-15)
-    #[test]
-    fn prop_settings_flow_control_enabled_by_initial_values(
-        max_streams_uni in 1u64..100,
-        max_streams_bidi in 1u64..100,
-        max_data in 1u64..100000,
-    ) {
+/// Property: INITIAL_MAX_* が 0 以外ならフロー制御有効 (draft-15)
+#[test]
+fn prop_settings_flow_control_enabled_by_initial_values() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_SETTINGS_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let max_streams_uni = noprop::sample_u64_in(ctx, 1..100);
+        let max_streams_bidi = noprop::sample_u64_in(ctx, 1..100);
+        let max_data = noprop::sample_u64_in(ctx, 1..100000);
         let v = |x: u64| VarInt::new(x).expect("value in VarInt range");
         let settings = Settings::new()
             .wt_enabled(VarInt::from_static(1))
             .wt_initial_max_streams_uni(v(max_streams_uni));
-        prop_assert!(settings.declares_flow_control());
+        assert!(settings.declares_flow_control());
 
         let settings = Settings::new()
             .wt_enabled(VarInt::from_static(1))
             .wt_initial_max_streams_bidi(v(max_streams_bidi));
-        prop_assert!(settings.declares_flow_control());
+        assert!(settings.declares_flow_control());
 
         let settings = Settings::new()
             .wt_enabled(VarInt::from_static(1))
             .wt_initial_max_data(v(max_data));
-        prop_assert!(settings.declares_flow_control());
-    }
+        assert!(settings.declares_flow_control());
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: 全て 0 または wt_enabled = 0 なら無効
-    #[test]
-    fn prop_settings_disabled_when_zero(_dummy in Just(())) {
-        let settings = Settings::new();
-        prop_assert!(!settings.is_enabled());
-        prop_assert!(!settings.declares_flow_control());
-    }
+/// Property: 全て 0 または wt_enabled = 0 なら無効
+#[test]
+fn prop_settings_disabled_when_zero() {
+    let settings = Settings::new();
+    assert!(!settings.is_enabled());
+    assert!(!settings.declares_flow_control());
 }
 
 // =============================================================================
 // Settings iter (draft-ietf-webtrans-http3-15 Section 9.2)
 // =============================================================================
 
-proptest! {
-    /// Property: builder で設定した値と iter() 出力が一致。0 の値は含まれない
-    #[test]
-    fn prop_settings_iter_matches_builder(
-        max_sessions in 0u64..100,
-        max_streams_uni in 0u64..1000,
-        max_streams_bidi in 0u64..1000,
-        max_data in 0u64..100000,
-    ) {
+/// Property: builder で設定した値と iter() 出力が一致。0 の値は含まれない
+#[test]
+fn prop_settings_iter_matches_builder() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_SETTINGS_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let max_sessions = noprop::sample_u64_in(ctx, 0..100);
+        let max_streams_uni = noprop::sample_u64_in(ctx, 0..1000);
+        let max_streams_bidi = noprop::sample_u64_in(ctx, 0..1000);
+        let max_data = noprop::sample_u64_in(ctx, 0..100000);
         let v = |x: u64| VarInt::new(x).expect("value in VarInt range");
         let settings = Settings::new()
             .wt_enabled(v(max_sessions))
@@ -74,26 +85,28 @@ proptest! {
 
         for e in &entries {
             let (_, val) = e.as_wire();
-            prop_assert!(val.get() > 0);
+            assert!(val.get() > 0);
         }
 
         if max_sessions > 0 {
-            prop_assert!(entries.contains(&Setting::WtEnabled(v(max_sessions))));
+            assert!(entries.contains(&Setting::WtEnabled(v(max_sessions))));
         }
         if max_streams_uni > 0 {
-            prop_assert!(entries.contains(&Setting::WtInitialMaxStreamsUni(v(max_streams_uni))));
+            assert!(entries.contains(&Setting::WtInitialMaxStreamsUni(v(max_streams_uni))));
         }
         if max_streams_bidi > 0 {
-            prop_assert!(entries.contains(&Setting::WtInitialMaxStreamsBidi(v(max_streams_bidi))));
+            assert!(entries.contains(&Setting::WtInitialMaxStreamsBidi(v(max_streams_bidi))));
         }
         if max_data > 0 {
-            prop_assert!(entries.contains(&Setting::WtInitialMaxData(v(max_data))));
+            assert!(entries.contains(&Setting::WtInitialMaxData(v(max_data))));
         }
 
         let expected_count = [max_sessions, max_streams_uni, max_streams_bidi, max_data]
             .iter()
             .filter(|&&v| v > 0)
             .count();
-        prop_assert_eq!(entries.len(), expected_count);
-    }
+        assert_eq!(entries.len(), expected_count);
+        Ok(())
+    })?;
+    Ok(())
 }

--- a/pbt/tests/prop_webtransport/stream.rs
+++ b/pbt/tests/prop_webtransport/stream.rs
@@ -1,31 +1,28 @@
 //! StreamHeader / Stream ID のプロパティ
 //! (draft-ietf-webtrans-http3-15 Section 4)
 
-use proptest::prelude::*;
 use shiguredo_http3::webtransport::{StreamHeader, stream_type};
 
-prop_compose! {
-    /// 有効なセッション ID (client-initiated bidirectional stream ID: id % 4 == 0)
-    fn valid_session_id()(id in 0u64..250_000) -> u64 {
-        id * 4
+/// 有効なセッション ID (client-initiated bidirectional stream ID: id % 4 == 0)
+fn valid_session_id(ctx: &mut noprop::TestCaseContext) -> u64 {
+    noprop::sample_u64_in(ctx, 0..250_000) * 4
+}
+
+/// 不正な単方向ストリームタイプ (0x54 以外)
+fn invalid_unidirectional_type(ctx: &mut noprop::TestCaseContext) -> u64 {
+    if noprop::sample_bool(ctx) {
+        noprop::sample_u64_in(ctx, 0..0x54)
+    } else {
+        noprop::sample_u64_in(ctx, 0x55..0x1000)
     }
 }
 
-prop_compose! {
-    /// 不正な単方向ストリームタイプ (0x54 以外)
-    fn invalid_unidirectional_type()(
-        value in (0u64..0x54).prop_union(0x55u64..0x1000)
-    ) -> u64 {
-        value
-    }
-}
-
-prop_compose! {
-    /// 不正な双方向シグナル値 (0x41 以外)
-    fn invalid_bidirectional_signal()(
-        value in (0u64..0x41).prop_union(0x42u64..0x1000)
-    ) -> u64 {
-        value
+/// 不正な双方向シグナル値 (0x41 以外)
+fn invalid_bidirectional_signal(ctx: &mut noprop::TestCaseContext) -> u64 {
+    if noprop::sample_bool(ctx) {
+        noprop::sample_u64_in(ctx, 0..0x41)
+    } else {
+        noprop::sample_u64_in(ctx, 0x42..0x1000)
     }
 }
 
@@ -41,36 +38,55 @@ fn encode_varint_for_test(buf: &mut Vec<u8>, value: u64) {
 // StreamHeader ラウンドトリップ (draft-ietf-webtrans-http3-15 Section 4)
 // =============================================================================
 
-proptest! {
-    /// Property: 単方向ストリームヘッダーのラウンドトリップ
-    #[test]
-    fn prop_unidirectional_header_roundtrip(session_id in valid_session_id()) {
+/// Property: 単方向ストリームヘッダーのラウンドトリップ
+#[test]
+fn prop_unidirectional_header_roundtrip() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_STREAM_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let session_id = valid_session_id(ctx);
         let header = StreamHeader::new(session_id).expect("valid session_id");
 
         let mut buf = Vec::new();
         header.encode_unidirectional(&mut buf);
 
-        let (decoded, consumed) = StreamHeader::decode_unidirectional(&buf).expect("valid encoded header");
-        prop_assert_eq!(consumed, buf.len());
-        prop_assert_eq!(decoded.session_id, session_id);
-    }
+        let (decoded, consumed) =
+            StreamHeader::decode_unidirectional(&buf).expect("valid encoded header");
+        assert_eq!(consumed, buf.len());
+        assert_eq!(decoded.session_id, session_id);
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: 双方向ストリームヘッダーのラウンドトリップ
-    #[test]
-    fn prop_bidirectional_header_roundtrip(session_id in valid_session_id()) {
+/// Property: 双方向ストリームヘッダーのラウンドトリップ
+#[test]
+fn prop_bidirectional_header_roundtrip() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_STREAM_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let session_id = valid_session_id(ctx);
         let header = StreamHeader::new(session_id).expect("valid session_id");
 
         let mut buf = Vec::new();
         header.encode_bidirectional(&mut buf);
 
-        let (decoded, consumed) = StreamHeader::decode_bidirectional(&buf).expect("valid encoded header");
-        prop_assert_eq!(consumed, buf.len());
-        prop_assert_eq!(decoded.session_id, session_id);
-    }
+        let (decoded, consumed) =
+            StreamHeader::decode_bidirectional(&buf).expect("valid encoded header");
+        assert_eq!(consumed, buf.len());
+        assert_eq!(decoded.session_id, session_id);
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: 単方向ストリームヘッダーのフォーマット検証
-    #[test]
-    fn prop_unidirectional_header_format(session_id in valid_session_id()) {
+/// Property: 単方向ストリームヘッダーのフォーマット検証
+#[test]
+fn prop_unidirectional_header_format() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_STREAM_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let session_id = valid_session_id(ctx);
         let header = StreamHeader::new(session_id).expect("valid session_id");
 
         let mut buf = Vec::new();
@@ -78,13 +94,20 @@ proptest! {
 
         // 先頭は Stream Type (0x54) の varint エンコード
         // 0x54 = 84 は 2 バイト varint: 0x40 | (84 >> 8), 84 & 0xff = 0x40, 0x54
-        prop_assert_eq!(buf[0], 0x40, "First byte should be 0x40 for 2-byte varint");
-        prop_assert_eq!(buf[1], 0x54, "Second byte should be 0x54 (stream type)");
-    }
+        assert_eq!(buf[0], 0x40, "First byte should be 0x40 for 2-byte varint");
+        assert_eq!(buf[1], 0x54, "Second byte should be 0x54 (stream type)");
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: 双方向ストリームヘッダーのフォーマット検証
-    #[test]
-    fn prop_bidirectional_header_format(session_id in valid_session_id()) {
+/// Property: 双方向ストリームヘッダーのフォーマット検証
+#[test]
+fn prop_bidirectional_header_format() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_STREAM_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let session_id = valid_session_id(ctx);
         let header = StreamHeader::new(session_id).expect("valid session_id");
 
         let mut buf = Vec::new();
@@ -92,13 +115,20 @@ proptest! {
 
         // 先頭は Signal Value (0x41) の varint エンコード
         // 0x41 = 65 は 2 バイト varint: 0x40 | (65 >> 8), 65 & 0xff = 0x40, 0x41
-        prop_assert_eq!(buf[0], 0x40, "First byte should be 0x40 for 2-byte varint");
-        prop_assert_eq!(buf[1], 0x41, "Second byte should be 0x41 (signal value)");
-    }
+        assert_eq!(buf[0], 0x40, "First byte should be 0x40 for 2-byte varint");
+        assert_eq!(buf[1], 0x41, "Second byte should be 0x41 (signal value)");
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: encoded_size が実際のエンコード長と一致
-    #[test]
-    fn prop_encoded_size_matches_actual(session_id in valid_session_id()) {
+/// Property: encoded_size が実際のエンコード長と一致
+#[test]
+fn prop_encoded_size_matches_actual() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_STREAM_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let session_id = valid_session_id(ctx);
         let header = StreamHeader::new(session_id).expect("valid session_id");
 
         let predicted_size = header.encoded_size();
@@ -110,96 +140,131 @@ proptest! {
         header.encode_bidirectional(&mut buf_bidi);
 
         // 単方向と双方向は Signal/Type 部分が同じサイズなので同じ長さになる
-        prop_assert_eq!(buf_uni.len(), buf_bidi.len());
-        prop_assert_eq!(predicted_size, buf_uni.len());
-    }
+        assert_eq!(buf_uni.len(), buf_bidi.len());
+        assert_eq!(predicted_size, buf_uni.len());
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // Stream ID 分類 (draft-ietf-webtrans-http3-15 Section 4)
 // =============================================================================
 
-proptest! {
-    /// Property: クライアント開始/サーバー開始の判定は相互排他的
-    #[test]
-    fn prop_stream_id_client_server_initiated(stream_id in any::<u64>()) {
+/// Property: クライアント開始/サーバー開始の判定は相互排他的
+#[test]
+fn prop_stream_id_client_server_initiated() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_STREAM_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let stream_id = noprop::sample_u64(ctx);
         let is_client = stream_type::is_client_initiated(stream_id);
         let is_server = stream_type::is_server_initiated(stream_id);
 
-        prop_assert!(is_client != is_server, "Stream ID must be either client or server initiated");
-    }
+        assert!(
+            is_client != is_server,
+            "Stream ID must be either client or server initiated"
+        );
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: 双方向/単方向の判定は相互排他的
-    #[test]
-    fn prop_stream_id_bidirectional_unidirectional(stream_id in any::<u64>()) {
+/// Property: 双方向/単方向の判定は相互排他的
+#[test]
+fn prop_stream_id_bidirectional_unidirectional() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_STREAM_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let stream_id = noprop::sample_u64(ctx);
         let is_bidi = stream_type::is_bidirectional(stream_id);
         let is_uni = stream_type::is_unidirectional(stream_id);
 
-        prop_assert!(is_bidi != is_uni, "Stream ID must be either bidirectional or unidirectional");
-    }
+        assert!(
+            is_bidi != is_uni,
+            "Stream ID must be either bidirectional or unidirectional"
+        );
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: 全ストリームタイプの組み合わせ (4 パターン)
-    #[test]
-    fn prop_stream_id_all_combinations(base_id in 0u64..1_000_000) {
+/// Property: 全ストリームタイプの組み合わせ (4 パターン)
+#[test]
+fn prop_stream_id_all_combinations() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_STREAM_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let base_id = noprop::sample_u64_in(ctx, 0..1_000_000);
         // クライアント開始双方向 (0b00)
         let id_00 = base_id * 4;
-        prop_assert!(stream_type::is_client_initiated(id_00));
-        prop_assert!(stream_type::is_bidirectional(id_00));
+        assert!(stream_type::is_client_initiated(id_00));
+        assert!(stream_type::is_bidirectional(id_00));
 
         // サーバー開始双方向 (0b01)
         let id_01 = base_id * 4 + 1;
-        prop_assert!(stream_type::is_server_initiated(id_01));
-        prop_assert!(stream_type::is_bidirectional(id_01));
+        assert!(stream_type::is_server_initiated(id_01));
+        assert!(stream_type::is_bidirectional(id_01));
 
         // クライアント開始単方向 (0b10)
         let id_10 = base_id * 4 + 2;
-        prop_assert!(stream_type::is_client_initiated(id_10));
-        prop_assert!(stream_type::is_unidirectional(id_10));
+        assert!(stream_type::is_client_initiated(id_10));
+        assert!(stream_type::is_unidirectional(id_10));
 
         // サーバー開始単方向 (0b11)
         let id_11 = base_id * 4 + 3;
-        prop_assert!(stream_type::is_server_initiated(id_11));
-        prop_assert!(stream_type::is_unidirectional(id_11));
-    }
+        assert!(stream_type::is_server_initiated(id_11));
+        assert!(stream_type::is_unidirectional(id_11));
+        Ok(())
+    })?;
+    Ok(())
 }
 
 // =============================================================================
 // 不正な StreamHeader のデコード
 // =============================================================================
 
-proptest! {
-    /// Property: 不正な stream type では単方向デコード失敗
-    #[test]
-    fn prop_unidirectional_header_invalid_type_fails(
-        invalid_type in invalid_unidirectional_type(),
-        session_id in valid_session_id(),
-    ) {
+/// Property: 不正な stream type では単方向デコード失敗
+#[test]
+fn prop_unidirectional_header_invalid_type_fails() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_STREAM_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let invalid_type = invalid_unidirectional_type(ctx);
+        let session_id = valid_session_id(ctx);
         let mut buf = Vec::new();
         encode_varint_for_test(&mut buf, invalid_type);
         encode_varint_for_test(&mut buf, session_id);
 
         let result = StreamHeader::decode_unidirectional(&buf);
-        prop_assert!(result.is_none(), "Invalid stream type should fail decode");
-    }
+        assert!(result.is_none(), "Invalid stream type should fail decode");
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: 不正な signal value では双方向デコード失敗
-    #[test]
-    fn prop_bidirectional_header_invalid_type_fails(
-        invalid_signal in invalid_bidirectional_signal(),
-        session_id in valid_session_id(),
-    ) {
+/// Property: 不正な signal value では双方向デコード失敗
+#[test]
+fn prop_bidirectional_header_invalid_type_fails() -> noprop::TestResult {
+    let seed = noprop::seed_from_env_or_time("PROP_WEBTRANSPORT_STREAM_SEED")?;
+    let mut runner = noprop::Runner::new(seed);
+    runner.run(256, |ctx| {
+        let invalid_signal = invalid_bidirectional_signal(ctx);
+        let session_id = valid_session_id(ctx);
         let mut buf = Vec::new();
         encode_varint_for_test(&mut buf, invalid_signal);
         encode_varint_for_test(&mut buf, session_id);
 
         let result = StreamHeader::decode_bidirectional(&buf);
-        prop_assert!(result.is_none(), "Invalid signal value should fail decode");
-    }
+        assert!(result.is_none(), "Invalid signal value should fail decode");
+        Ok(())
+    })?;
+    Ok(())
+}
 
-    /// Property: 空バッファでは StreamHeader デコード失敗
-    #[test]
-    fn prop_stream_header_empty_buffer_fails(_dummy in Just(())) {
-        prop_assert!(StreamHeader::decode_unidirectional(&[]).is_none());
-        prop_assert!(StreamHeader::decode_bidirectional(&[]).is_none());
-    }
+/// Property: 空バッファでは StreamHeader デコード失敗
+#[test]
+fn prop_stream_header_empty_buffer_fails() {
+    assert!(StreamHeader::decode_unidirectional(&[]).is_none());
+    assert!(StreamHeader::decode_bidirectional(&[]).is_none());
 }


### PR DESCRIPTION
## 概要

PBT (Property-Based Testing) を proptest から noprop に置き換える。

- `pbt/Cargo.toml` の `proptest` 依存を `noprop` に置き換える
- `pbt` クレージの全プロパティテストを noprop の命令形クロージャ形式に書き換える
  - 範囲生成は `sample_u64_in` / `sample_usize_in` を使用する
  - 分岐選択は `sample_choice` / `sample_weighted_index` を使用する
  - フィルタ相当は `sample_with_rejection` または valid-by-construction に置き換える
  - 決定的なテスト (`Just(())`) は素の `#[test]` に移行する
- 各テストは `seed_from_env_or_time` により再現可能な seed を利用する
- noprop は panic で失敗を検出するため `[profile.dev]` に `panic = "unwind"` を明示する

## 検証

- `cargo test --workspace --tests` 全パス (pbt は 184 テスト)
- `cargo clippy --workspace --all-targets -- -D warnings` 警告 0
- `cargo fmt --all` 適用済み
- pbt テストを異なる seed で 3 回実行し安定性を確認